### PR TITLE
docs(spec): adversarial multi-agent review of protocol references

### DIFF
--- a/spec/HAP-Categories.md
+++ b/spec/HAP-Categories.md
@@ -42,13 +42,25 @@ From `const.py:23-50` and `Categories.md`:
 | 31  | `CATEGORY_TELEVISION`          | Television          |
 | 32  | `CATEGORY_TARGET_CONTROLLER`   | Remote Controller   |
 
-Note: IDs 24, 25, 27 are not defined in the public specification.
+Note: IDs 24, 25 and 27 are marked Reserved in the public specification and are
+absent from HAP-python; HAP-NodeJS defines them as the Apple-only device types
+`APPLE_TV` (24), `HOMEPOD` (25) and `AIRPORT` (27). Later protocol revisions add
+four more categories, defined in HAP-NodeJS:
+
+| ID  | Constant (HAP-NodeJS) | Name               |
+| --- | --------------------- | ------------------ |
+| 33  | `ROUTER`              | Wi-Fi Router       |
+| 34  | `AUDIO_RECEIVER`      | Audio Receiver     |
+| 35  | `TV_SET_TOP_BOX`      | TV Set Top Box     |
+| 36  | `TV_STREAMING_STICK`  | TV Streaming Stick |
 
 ---
 
 ## 2. Category Name List (HomeSpan)
 
-From `Categories.md`, the complete list of category names:
+From `Categories.md`, the category names HomeSpan supports (not a complete list
+— HomeSpan omits Range Extender (16), Speaker (26) and Remote Controller (32),
+which appear in the identifier table above):
 
 - AirConditioners
 - AirPurifiers
@@ -121,10 +133,17 @@ This indicates a Lightbulb accessory.
 
 2. **Bridges**: A bridge (category 2) aggregates multiple accessories. The
    bridge's category should always be 2, regardless of what types of accessories
-   it bridges.
+   it bridges. Bridged accessories have no advertised category of their own:
+   HomeKitADK assigns them category 0 (`kHAPAccessoryCategory_BridgedAccessory`,
+   "accessory that is accessed through a bridge"); only the bridge's category
+   appears in the `ci` TXT record.
 
 3. **Unknown categories**: If the Home app encounters an unknown category ID, it
    falls back to the "Other" icon.
 
 4. **Persistence**: The category should not change after initial pairing, as
    this may confuse users.
+
+5. **Obsolete categories**: Range Extender (16) is obsolete since HAP
+   specification R10 — HomeKitADK marks it "Obsolete since R10" and HomeSpan
+   omits it entirely. Do not use it for new accessories.

--- a/spec/HAP-Characteristics.md
+++ b/spec/HAP-Characteristics.md
@@ -36,7 +36,7 @@ Each characteristic has the following properties:
 | `uint8`  | Unsigned 8-bit integer (0–255)    | number    |
 | `uint16` | Unsigned 16-bit integer (0–65535) | number    |
 | `uint32` | Unsigned 32-bit integer           | number    |
-| `uint64` | Unsigned 64-bit integer           | string    |
+| `uint64` | Unsigned 64-bit integer           | number    |
 | `int`    | Signed 32-bit integer             | number    |
 | `float`  | IEEE 754 floating point           | number    |
 | `string` | UTF-8 string                      | string    |
@@ -55,7 +55,7 @@ Each characteristic has the following properties:
 | `aa`       | Additional Authorization required             |
 | `tw`       | Timed Write required                          |
 | `hd`       | Hidden — not shown in Home app                |
-| `wr`       | Write Response — returns response after write |
+| `wr`       | Write Response — value returned in reply body |
 
 ---
 
@@ -75,17 +75,18 @@ Each characteristic has the following properties:
 
 ### Identification
 
-| Characteristic       | UUID | Format | Permissions | Range/Values                     |
-| -------------------- | ---- | ------ | ----------- | -------------------------------- |
-| **Identify**         | 0x14 | bool   | pw          | -                                |
-| **Manufacturer**     | 0x20 | string | pr          | -                                |
-| **Model**            | 0x21 | string | pr          | -                                |
-| **Name**             | 0x23 | string | pr          | -                                |
-| **SerialNumber**     | 0x30 | string | pr          | max 64 chars                     |
-| **FirmwareRevision** | 0x52 | string | pr          | x.y.z format                     |
-| **HardwareRevision** | 0x53 | string | pr          | x.y.z format                     |
-| **AccessoryFlags**   | 0xA6 | uint32 | pr, ev      | bit 0: requires additional setup |
-| **ConfiguredName**   | 0xE3 | string | pr, pw, ev  | -                                |
+| Characteristic       | UUID  | Format | Permissions | Range/Values                     |
+| -------------------- | ----- | ------ | ----------- | -------------------------------- |
+| **Identify**         | 0x14  | bool   | pw          | -                                |
+| **Manufacturer**     | 0x20  | string | pr          | -                                |
+| **Model**            | 0x21  | string | pr          | -                                |
+| **Name**             | 0x23  | string | pr          | -                                |
+| **SerialNumber**     | 0x30  | string | pr          | max 64 chars                     |
+| **FirmwareRevision** | 0x52  | string | pr          | x.y.z format                     |
+| **HardwareRevision** | 0x53  | string | pr          | x.y.z format                     |
+| **AccessoryFlags**   | 0xA6  | uint32 | pr, ev      | bit 0: requires additional setup |
+| **ConfiguredName**   | 0xE3  | string | pr, pw, ev  | -                                |
+| **ProductData**      | 0x220 | data   | pr          | -                                |
 
 ### On/Off and Active
 
@@ -104,7 +105,11 @@ Each characteristic has the following properties:
 | **Brightness**       | 0x08 | int    | pr, pw, ev  | 0–100   | percentage |
 | **Hue**              | 0x13 | float  | pr, pw, ev  | 0–360   | arcdegrees |
 | **Saturation**       | 0x2F | float  | pr, pw, ev  | 0–100   | percentage |
-| **ColorTemperature** | 0xCE | uint32 | pr, pw, ev  | 140–500 | mired      |
+| **ColorTemperature** | 0xCE | uint32 | pr, pw, ev  | 140–500 | -          |
+
+ColorTemperature values are expressed in mireds (reciprocal megakelvins), but
+`mired` is not a defined HAP unit (see section 4); the `unit` field is omitted
+for this characteristic.
 
 ### Temperature
 
@@ -158,6 +163,8 @@ Each characteristic has the following properties:
 | **PM2.5Density**           | 0xC6 | float  | pr, ev      | 0–1000 μg/m³                                               |
 | **PM10Density**            | 0xC7 | float  | pr, ev      | 0–1000 μg/m³                                               |
 | **VOCDensity**             | 0xC8 | float  | pr, ev      | 0–1000 μg/m³                                               |
+| **AirParticulateDensity**  | 0x64 | float  | pr, ev      | 0–1000 μg/m³                                               |
+| **AirParticulateSize**     | 0x65 | uint8  | pr, ev      | 0=2.5μm, 1=10μm                                            |
 
 ### Air Purifier
 
@@ -187,14 +194,14 @@ Each characteristic has the following properties:
 
 ### Sensors
 
-| Characteristic               | UUID | Format | Permissions | Values                    |
-| ---------------------------- | ---- | ------ | ----------- | ------------------------- |
-| **ContactSensorState**       | 0x6A | uint8  | pr, ev      | 0=Detected, 1=NotDetected |
-| **LeakDetected**             | 0x70 | uint8  | pr, ev      | 0=NotDetected, 1=Detected |
-| **MotionDetected**           | 0x22 | bool   | pr, ev      | -                         |
-| **OccupancyDetected**        | 0x71 | uint8  | pr, ev      | 0=NotDetected, 1=Detected |
-| **SmokeDetected**            | 0x76 | uint8  | pr, ev      | 0=NotDetected, 1=Detected |
-| **CurrentAmbientLightLevel** | 0x6B | float  | pr, ev      | 0.0001–100000 lux         |
+| Characteristic               | UUID | Format | Permissions | Values                                                  |
+| ---------------------------- | ---- | ------ | ----------- | ------------------------------------------------------- |
+| **ContactSensorState**       | 0x6A | uint8  | pr, ev      | 0=ContactDetected (closed), 1=ContactNotDetected (open) |
+| **LeakDetected**             | 0x70 | uint8  | pr, ev      | 0=NotDetected, 1=Detected                               |
+| **MotionDetected**           | 0x22 | bool   | pr, ev      | -                                                       |
+| **OccupancyDetected**        | 0x71 | uint8  | pr, ev      | 0=NotDetected, 1=Detected                               |
+| **SmokeDetected**            | 0x76 | uint8  | pr, ev      | 0=NotDetected, 1=Detected                               |
+| **CurrentAmbientLightLevel** | 0x6B | float  | pr, ev      | 0.0001–100000 lux                                       |
 
 ### Status
 
@@ -243,15 +250,15 @@ Each characteristic has the following properties:
 
 ### Doors and Locks
 
-| Characteristic                        | UUID | Format | Permissions | Values                                            |
-| ------------------------------------- | ---- | ------ | ----------- | ------------------------------------------------- |
-| **CurrentDoorState**                  | 0x0E | uint8  | pr, ev      | 0=Open, 1=Closed, 2=Opening, 3=Closing, 4=Stopped |
-| **TargetDoorState**                   | 0x32 | uint8  | pr, pw, ev  | 0=Open, 1=Closed                                  |
-| **LockCurrentState**                  | 0x1D | uint8  | pr, ev      | 0=Unsecured, 1=Secured, 2=Jammed, 3=Unknown       |
-| **LockTargetState**                   | 0x1E | uint8  | pr, pw, ev  | 0=Unsecured, 1=Secured                            |
-| **LockControlPoint**                  | 0x19 | tlv8   | pw          | -                                                 |
-| **LockLastKnownAction**               | 0x1C | uint8  | pr, ev      | (see spec)                                        |
-| **LockManagementAutoSecurityTimeout** | 0x1A | uint32 | pr, pw, ev  | seconds                                           |
+| Characteristic                        | UUID | Format | Permissions | Values                                                                                                                                                                          |
+| ------------------------------------- | ---- | ------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CurrentDoorState**                  | 0x0E | uint8  | pr, ev      | 0=Open, 1=Closed, 2=Opening, 3=Closing, 4=Stopped                                                                                                                               |
+| **TargetDoorState**                   | 0x32 | uint8  | pr, pw, ev  | 0=Open, 1=Closed                                                                                                                                                                |
+| **LockCurrentState**                  | 0x1D | uint8  | pr, ev      | 0=Unsecured, 1=Secured, 2=Jammed, 3=Unknown                                                                                                                                     |
+| **LockTargetState**                   | 0x1E | uint8  | pr, pw, ev  | 0=Unsecured, 1=Secured                                                                                                                                                          |
+| **LockControlPoint**                  | 0x19 | tlv8   | pw          | -                                                                                                                                                                               |
+| **LockLastKnownAction**               | 0x1C | uint8  | pr, ev      | 0=SecuredInterior, 1=UnsecuredInterior, 2=SecuredExterior, 3=UnsecuredExterior, 4=SecuredKeypad, 5=UnsecuredKeypad, 6=SecuredRemotely, 7=UnsecuredRemotely, 8=AutoSecureTimeout |
+| **LockManagementAutoSecurityTimeout** | 0x1A | uint32 | pr, pw, ev  | seconds                                                                                                                                                                         |
 
 ### Security System
 
@@ -280,22 +287,22 @@ Each characteristic has the following properties:
 
 ### Television
 
-| Characteristic             | UUID  | Format | Permissions | Values                                                                                                                        |
-| -------------------------- | ----- | ------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **ActiveIdentifier**       | 0xE7  | uint32 | pr, pw, ev  | -                                                                                                                             |
-| **Identifier**             | 0xE6  | uint32 | pr          | -                                                                                                                             |
-| **InputSourceType**        | 0xDB  | uint8  | pr, ev      | 0=Other, 1=HomeScreen, 2=Tuner, 3=HDMI, 4=CompositeVideo, 5=SVideo, 6=ComponentVideo, 7=DVI, 8=AirPlay, 9=USB, 10=Application |
-| **InputDeviceType**        | 0xDC  | uint8  | pr, ev      | 0=Other, 1=TV, 2=Recording, 3=Tuner, 4=Playback, 5=AudioSystem                                                                |
-| **SleepDiscoveryMode**     | 0xE8  | uint8  | pr, ev      | 0=NotDiscoverable, 1=AlwaysDiscoverable                                                                                       |
-| **CurrentVisibilityState** | 0x135 | uint8  | pr, ev      | 0=Shown, 1=Hidden                                                                                                             |
-| **TargetVisibilityState**  | 0x134 | uint8  | pr, pw, ev  | 0=Shown, 1=Hidden                                                                                                             |
-| **ClosedCaptions**         | 0xDD  | uint8  | pr, pw, ev  | 0=Disabled, 1=Enabled                                                                                                         |
-| **DisplayOrder**           | 0x136 | tlv8   | pr, pw, ev  | -                                                                                                                             |
-| **CurrentMediaState**      | 0xE0  | uint8  | pr, ev      | 0=Play, 1=Pause, 2=Stop, 3=Unknown                                                                                            |
-| **TargetMediaState**       | 0x137 | uint8  | pr, pw, ev  | 0=Play, 1=Pause, 2=Stop                                                                                                       |
-| **PictureMode**            | 0xE2  | uint8  | pr, pw, ev  | 0=Other, 1=Standard, 2=Calibrated, ...                                                                                        |
-| **PowerModeSelection**     | 0xDF  | uint8  | pw          | 0=Show, 1=Hide                                                                                                                |
-| **RemoteKey**              | 0xE1  | uint8  | pw          | 4=Up, 5=Down, 6=Left, 7=Right, 8=Select, 9=Back, 11=PlayPause, 15=Info                                                        |
+| Characteristic             | UUID  | Format | Permissions | Values                                                                                                                                 |
+| -------------------------- | ----- | ------ | ----------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **ActiveIdentifier**       | 0xE7  | uint32 | pr, pw, ev  | -                                                                                                                                      |
+| **Identifier**             | 0xE6  | uint32 | pr          | -                                                                                                                                      |
+| **InputSourceType**        | 0xDB  | uint8  | pr, ev      | 0=Other, 1=HomeScreen, 2=Tuner, 3=HDMI, 4=CompositeVideo, 5=SVideo, 6=ComponentVideo, 7=DVI, 8=AirPlay, 9=USB, 10=Application          |
+| **InputDeviceType**        | 0xDC  | uint8  | pr, ev      | 0=Other, 1=TV, 2=Recording, 3=Tuner, 4=Playback, 5=AudioSystem                                                                         |
+| **SleepDiscoveryMode**     | 0xE8  | uint8  | pr, ev      | 0=NotDiscoverable, 1=AlwaysDiscoverable                                                                                                |
+| **CurrentVisibilityState** | 0x135 | uint8  | pr, ev      | 0=Shown, 1=Hidden                                                                                                                      |
+| **TargetVisibilityState**  | 0x134 | uint8  | pr, pw, ev  | 0=Shown, 1=Hidden                                                                                                                      |
+| **ClosedCaptions**         | 0xDD  | uint8  | pr, pw, ev  | 0=Disabled, 1=Enabled                                                                                                                  |
+| **DisplayOrder**           | 0x136 | tlv8   | pr, pw, ev  | -                                                                                                                                      |
+| **CurrentMediaState**      | 0xE0  | uint8  | pr, ev      | 0=Play, 1=Pause, 2=Stop, 3=Unknown                                                                                                     |
+| **TargetMediaState**       | 0x137 | uint8  | pr, pw, ev  | 0=Play, 1=Pause, 2=Stop                                                                                                                |
+| **PictureMode**            | 0xE2  | uint8  | pr, pw, ev  | 0=Other, 1=Standard, 2=Calibrated, ...                                                                                                 |
+| **PowerModeSelection**     | 0xDF  | uint8  | pw          | 0=Show, 1=Hide                                                                                                                         |
+| **RemoteKey**              | 0xE1  | uint8  | pw          | 0=Rewind, 1=FastForward, 2=NextTrack, 3=PreviousTrack, 4=Up, 5=Down, 6=Left, 7=Right, 8=Select, 9=Back, 10=Exit, 11=PlayPause, 15=Info |
 
 ### Audio
 
@@ -349,6 +356,9 @@ Each characteristic has the following properties:
 | **ActiveTransitionCount**            | 0x24B | uint8  | pr, ev      |
 | **TransitionControl**                | 0x143 | tlv8   | pr, pw, wr  |
 | **SupportedTransitionConfiguration** | 0x144 | tlv8   | pr          |
+| **ConfigurationState**               | 0x263 | uint16 | pr, ev      |
+| **NFCAccessControlPoint**            | 0x264 | tlv8   | pr, pw, wr  |
+| **NFCAccessSupportedConfiguration**  | 0x265 | tlv8   | pr          |
 
 ---
 
@@ -479,6 +489,11 @@ Each characteristic has the following properties:
 | SleepDiscoveryMode                    | E8    | 000000E8-0000-1000-8000-0026BB765291 |
 | VolumeControlType                     | E9    | 000000E9-0000-1000-8000-0026BB765291 |
 | VolumeSelector                        | EA    | 000000EA-0000-1000-8000-0026BB765291 |
+| SupportedVideoStreamConfiguration     | 114   | 00000114-0000-1000-8000-0026BB765291 |
+| SupportedAudioStreamConfiguration     | 115   | 00000115-0000-1000-8000-0026BB765291 |
+| SupportedRTPConfiguration             | 116   | 00000116-0000-1000-8000-0026BB765291 |
+| SelectedRTPStreamConfiguration        | 117   | 00000117-0000-1000-8000-0026BB765291 |
+| SetupEndpoints                        | 118   | 00000118-0000-1000-8000-0026BB765291 |
 | Volume                                | 119   | 00000119-0000-1000-8000-0026BB765291 |
 | Mute                                  | 11A   | 0000011A-0000-1000-8000-0026BB765291 |
 | NightVision                           | 11B   | 0000011B-0000-1000-8000-0026BB765291 |

--- a/spec/HAP-Encryption.md
+++ b/spec/HAP-Encryption.md
@@ -28,18 +28,28 @@ ControllerToAccessoryKey = HKDF-SHA-512(
 )
 ```
 
-From `HAPPairingPairVerify.c:556-561`:
+From `HAPPairingPairVerify.c`, function `HAPPairingPairVerifyStartSession`
+(lines 40-59; each `info` constant is local to its own block):
 
 ```c
 static const uint8_t salt[] = "Control-Salt";
-static const uint8_t infoRead[] = "Control-Read-Encryption-Key";
-static const uint8_t infoWrite[] = "Control-Write-Encryption-Key";
+static const uint8_t info[] = "Control-Read-Encryption-Key";
+static const uint8_t info[] = "Control-Write-Encryption-Key";
 ```
 
 **Note:** "Read" and "Write" are from the controller's perspective:
 
 - Accessory uses `Control-Read-Encryption-Key` for **outgoing** data
 - Accessory uses `Control-Write-Encryption-Key` for **incoming** data
+
+**Transient sessions:** A session can also be secured by transient Pair Setup
+(Pair Setup M1-M4 with the Transient flag, used for Software Authentication)
+without any Pair Verify. The frame format and nonce rules below are identical,
+but the keys are derived from the SRP shared secret `K` instead: salt
+`SplitSetupSalt`, info `AccessoryEncrypt-Control` for the
+accessory-to-controller key and `ControllerEncrypt-Control` for the
+controller-to-accessory key; both nonce counters start at 0 (from
+`HAPPairingPairSetup.c`, "Transient Pair Setup Start Session").
 
 ---
 
@@ -72,7 +82,9 @@ const length = Math.min(total - offset, 0x400);
 
 ## 3. Encryption Process
 
-For each HTTP message (request or response):
+For each HTTP message (request, response, or `EVENT/1.0` event notification —
+events share the accessory-to-controller key and nonce counter with regular
+responses):
 
 1. Split plaintext into chunks of at most 1024 bytes
 2. For each chunk:
@@ -93,8 +105,9 @@ From `hapCrypto.ts:96-114`:
 ```typescript
 export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
   let result = Buffer.alloc(0);
-  for (let offset = 0; offset < data.length; ) {
-    const length = Math.min(data.length - offset, 0x400);
+  const total = data.length;
+  for (let offset = 0; offset < total; ) {
+    const length = Math.min(total - offset, 0x400);
     const leLength = Buffer.alloc(2);
     leLength.writeUInt16LE(length, 0);
 

--- a/spec/HAP-Encryption.md
+++ b/spec/HAP-Encryption.md
@@ -100,11 +100,11 @@ responses):
    - Increment counter
 3. Concatenate all frames
 
-From `hapCrypto.ts:96-114`:
+From `hapCrypto.ts` (`layerEncrypt`):
 
 ```typescript
 export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
-  let result = Buffer.alloc(0);
+  const chunks: Buffer[] = [];
   const total = data.length;
   for (let offset = 0; offset < total; ) {
     const length = Math.min(total - offset, 0x400);
@@ -117,19 +117,14 @@ export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
     const encrypted = chacha20_poly1305_encryptAndSeal(
       encryption.accessoryToControllerKey,
       nonce,
-      leLength, // AAD
+      leLength,
       data.subarray(offset, offset + length),
     );
     offset += length;
 
-    result = Buffer.concat([
-      result,
-      leLength,
-      encrypted.ciphertext,
-      encrypted.authTag,
-    ]);
+    chunks.push(leLength, encrypted.ciphertext, encrypted.authTag);
   }
-  return result;
+  return Buffer.concat(chunks);
 }
 ```
 

--- a/spec/HAP-HTTP.md
+++ b/spec/HAP-HTTP.md
@@ -16,7 +16,7 @@ codes used by HAP over IP.
 | GET    | `/accessories`     | Yes           | `application/hap+json`     | Get accessory database     |
 | GET    | `/characteristics` | Yes           | `application/hap+json`     | Read characteristics       |
 | PUT    | `/characteristics` | Yes           | `application/hap+json`     | Write characteristics      |
-| POST   | `/prepare`         | Yes           | `application/hap+json`     | Timed write preparation    |
+| PUT    | `/prepare`         | Yes           | `application/hap+json`     | Timed write preparation    |
 | POST   | `/resource`        | Yes           | `application/hap+json`     | Request resources (images) |
 
 "Auth Required" = must complete Pair Verify first (encrypted session).
@@ -55,7 +55,8 @@ No body required.
 **Response:**
 
 - `204 No Content` — Success
-- `400 Bad Request` — Already paired
+- `400 Bad Request` — Already paired; body is `application/hap+json`
+  `{"status": -70401}` (insufficient privileges)
 
 ---
 
@@ -124,7 +125,11 @@ See [HAP-Pairing.md](HAP-Pairing.md) for TLV format.
 | HTTP Code | Condition                           |
 | --------- | ----------------------------------- |
 | `470`     | Not verified (no encrypted session) |
-| `400`     | Bad request or insufficient perms   |
+| `400`     | Malformed request (bad TLV)         |
+
+Insufficient permissions is not an HTTP-level error: when a non-admin controller
+attempts to add, remove, or list pairings, the accessory responds `200 OK` with
+a TLV8 body containing State `M2` and Error `0x02` (Authentication).
 
 ---
 
@@ -210,6 +215,7 @@ Content-Length: <length>
 | `maxValue`     | number  | No       | Maximum allowed value                 |
 | `minStep`      | number  | No       | Minimum step between values           |
 | `maxLen`       | integer | No       | Maximum string length                 |
+| `maxDataLen`   | integer | No       | Maximum data length (format `data`)   |
 | `valid-values` | array   | No       | List of valid enum values             |
 | `ev`           | boolean | No       | Event notifications enabled           |
 
@@ -285,19 +291,29 @@ Content-Type: application/hap+json
 
 **Write Fields:**
 
-| Field   | Type    | Description                        |
-| ------- | ------- | ---------------------------------- |
-| `aid`   | integer | Accessory ID                       |
-| `iid`   | integer | Instance ID                        |
-| `value` | varies  | New value to write                 |
-| `ev`    | boolean | Enable/disable event notifications |
-| `r`     | boolean | Request write response             |
+| Field      | Type    | Description                          |
+| ---------- | ------- | ------------------------------------ |
+| `aid`      | integer | Accessory ID                         |
+| `iid`      | integer | Instance ID                          |
+| `value`    | varies  | New value to write                   |
+| `ev`       | boolean | Enable/disable event notifications   |
+| `authData` | string  | Base64 additional authorization data |
+| `remote`   | boolean | Write performed via remote access    |
+| `r`        | boolean | Request write response               |
+
+For timed writes, the request object also carries a top-level `pid` field
+(alongside the `characteristics` array) matching a preceding `/prepare` request.
 
 **Response (success):**
 
 ```http
 HTTP/1.1 204 No Content
 ```
+
+`204 No Content` applies only when every write succeeds and no write response
+was requested. If an entry requested a write response (`r: true`), the server
+instead returns `207 Multi-Status` with a body carrying the resulting `value`
+(and `status`) for that entry.
 
 **Response (partial failure):**
 
@@ -315,14 +331,14 @@ Content-Type: application/hap+json
 
 ---
 
-## 10. POST /prepare
+## 10. PUT /prepare
 
 Prepare for a timed write operation.
 
 **Request:**
 
 ```http
-POST /prepare HTTP/1.1
+PUT /prepare HTTP/1.1
 Content-Type: application/hap+json
 
 {
@@ -347,7 +363,21 @@ Content-Type: application/hap+json
 }
 ```
 
-The subsequent PUT `/characteristics` must include the `pid`.
+The subsequent PUT `/characteristics` must include the same `pid` as a top-level
+field of the request object, alongside the `characteristics` array (not inside
+the individual characteristic objects):
+
+```http
+PUT /characteristics HTTP/1.1
+Content-Type: application/hap+json
+
+{
+  "pid": 12345678,
+  "characteristics": [
+    {"aid": 1, "iid": 10, "value": true}
+  ]
+}
+```
 
 ---
 

--- a/spec/HAP-HTTP.md
+++ b/spec/HAP-HTTP.md
@@ -510,8 +510,10 @@ Exceptions (immediate delivery):
 
 - `ProgrammableSwitchEvent` (0x73) — button press
 - `ButtonEvent` (0x126)
+- `MotionDetected` (0x22)
+- `ContactSensorState` (0x6A)
 
-From `eventedhttp.ts`.
+From `Accessory.ts` (`handleCharacteristicChangeEvent`).
 
 **Subscription Persistence:**
 

--- a/spec/HAP-Pairing.md
+++ b/spec/HAP-Pairing.md
@@ -478,7 +478,8 @@ All HKDF operations use:
 | Session Read Key       | `Control-Salt`                    | `Control-Read-Encryption-Key`     |
 | Session Write Key      | `Control-Salt`                    | `Control-Write-Encryption-Key`    |
 
-From `hap_handler.py` and `HAPPairingPairVerify.c:556-561`.
+From `hap_handler.py` and `HAPPairingPairVerify.c` (function
+`HAPPairingPairVerifyStartSession`).
 
 ---
 

--- a/spec/HAP-Pairing.md
+++ b/spec/HAP-Pairing.md
@@ -96,6 +96,27 @@ Controller sends:
 | Transient | `1 << 4`  | Pair Setup M1-M4 only, no key exchange |
 | Split     | `1 << 24` | Used with Transient for split pairing  |
 
+If M1 contained flags, the accessory returns the granted flags in a Flags TLV in
+M2, omitted when the resulting value is zero (HomeKitADK echoes
+`Transient | Split` together, or `Split` alone, but never `Transient` alone).
+When a transient Pair Setup completes at M4, no pairing is stored; the session
+immediately becomes encrypted using keys derived from the SRP shared secret `K`:
+
+```
+AccessoryToControllerKey = HKDF-SHA-512(
+    Salt: "SplitSetupSalt",
+    IKM:  K,
+    Info: "AccessoryEncrypt-Control",
+    L:    32
+)
+ControllerToAccessoryKey = HKDF-SHA-512(
+    Salt: "SplitSetupSalt",
+    IKM:  K,
+    Info: "ControllerEncrypt-Control",
+    L:    32
+)
+```
+
 ### 2.4 M2: SRP Start Response
 
 Accessory generates:
@@ -103,7 +124,8 @@ Accessory generates:
 1. Random 16-byte salt `s`
 2. Computes verifier: `v = g^x mod N` where `x = H(s | H(I | ":" | P))`
 3. Generates random 256-bit `b`
-4. Computes public value: `B = (kv + g^b) mod N` where `k = H(N | g)`
+4. Computes public value: `B = (kv + g^b) mod N` where `k = H(N | PAD(g))`;
+   `PAD()` left-pads the value with zeros to the 384-byte length of N (RFC 5054)
 
 Response TLVs:
 
@@ -122,7 +144,7 @@ Response TLVs:
 
 Common errors:
 
-- `0x06` Unavailable: Already paired (except for PairSetupWithAuth)
+- `0x06` Unavailable: Already paired (regardless of pairing method)
 - `0x07` Busy: Another pairing in progress
 - `0x05` MaxTries: Too many failed attempts (limit: 100)
 
@@ -132,7 +154,8 @@ Controller computes:
 
 1. Generates random 256-bit `a`
 2. Computes public value: `A = g^a mod N`
-3. Computes: `u = H(A | B)`, `x = H(s | H(I | ":" | P))`
+3. Computes: `u = H(PAD(A) | PAD(B))` (both values left-padded with zeros to 384
+   bytes, RFC 5054), `x = H(s | H(I | ":" | P))`
 4. Computes: `S = (B - kg^x)^(a + ux) mod N`
 5. Computes session key: `K = H(S)`
 6. Computes proof: `M1 = H(H(N) xor H(g) | H(I) | s | A | B | K)`
@@ -150,7 +173,8 @@ Request TLVs:
 Accessory:
 
 1. Verifies `A mod N != 0`
-2. Computes `u = H(A | B)`
+2. Computes `u = H(PAD(A) | PAD(B))` (values left-padded with zeros to 384
+   bytes, RFC 5054)
 3. Computes `S = (Av^u)^b mod N`
 4. Computes `K = H(S)`
 5. Verifies M1
@@ -162,6 +186,13 @@ Response TLVs:
 | -------- | --------------------- |
 | State    | `0x04` (M4)           |
 | Proof    | 64 bytes (SHA-512 M2) |
+
+For `PairSetupWithAuth` (Method `0x01`), M4 additionally carries an
+EncryptedData TLV: a sub-TLV containing Signature (the MFi proof over a 32-byte
+challenge derived via HKDF-SHA-512 with salt `MFi-Pair-Setup-Salt` and info
+`MFi-Pair-Setup-Info` from the SRP session key `K`) and Certificate (the Apple
+Authentication Coprocessor certificate), encrypted with the Pair Setup
+encryption key (see 2.7) and nonce `PS-Msg04`.
 
 **Error Response:**
 
@@ -212,7 +243,7 @@ iOSDeviceSignature = Ed25519_Sign(iOSDeviceLTSK, iOSDeviceInfo)
 ```
 EncryptedData = ChaCha20-Poly1305-Encrypt(
     Key:   EncryptionKey,
-    Nonce: "PS-Msg05" (padded to 12 bytes with zeros),
+    Nonce: 4 zero bytes then "PS-Msg05" (12 bytes; see Nonce Format section),
     AAD:   empty,
     Data:  SubTLV
 )
@@ -268,6 +299,16 @@ Response TLVs:
 | ------------- | ----------------------------- |
 | State         | `0x06` (M6)                   |
 | EncryptedData | Ciphertext + 16-byte auth tag |
+
+**Error Response:**
+
+| TLV Type | Value                          |
+| -------- | ------------------------------ |
+| State    | `0x06` (M6)                    |
+| Error    | `0x02` (Authentication failed) |
+
+Sent when the M5 EncryptedData fails to decrypt (bad auth tag) or the
+iOSDeviceInfo signature does not verify.
 
 ---
 
@@ -527,9 +568,11 @@ Response:
 When the last admin pairing is removed, accessory should:
 
 1. Remove all pairings
-2. Clear accessory LTPK/LTSK
-3. Generate new identity
-4. Update mDNS to show unpaired
+2. Update mDNS to show unpaired
+
+The accessory keeps its long-term identity (LTPK/LTSK): reference
+implementations generate a new LTSK only when none exists in persistent storage
+(i.e. after a factory reset), not when the last pairing is removed.
 
 ### 7.3 List Pairings
 
@@ -550,6 +593,20 @@ Response (for each pairing, separated by 0xFF):
 | Permissions | Permission byte         |
 | Separator   | (between pairings)      |
 
+### 7.4 Error Responses
+
+On failure, all three methods respond with State `0x02` (M2) plus an Error TLV:
+
+| Error  | Condition                                                         |
+| ------ | ----------------------------------------------------------------- |
+| `0x02` | Requesting controller lacks Admin permission (all three methods)  |
+| `0x01` | Add Pairing: identifier exists but LTPK differs; storage failures |
+| `0x04` | Add Pairing: no free pairing slots (MaxPeers)                     |
+
+If Add Pairing is called with an identifier that already exists and a matching
+LTPK, the accessory updates the stored permissions and returns success. Remove
+Pairing for a pairing that does not exist returns success.
+
 ---
 
 ## 8. Authentication Attempt Limits
@@ -558,5 +615,6 @@ From `HAPPairingPairSetup.c`:
 
 - Maximum unsuccessful attempts: **100**
 - After limit reached, respond with error `0x05` (MaxTries)
-- Counter may reset on successful pairing or after reboot (implementation
-  choice)
+- Counter is stored persistently (HomeKitADK keeps it in the key-value store) so
+  it survives reboots, and is reset only after a successful SRP proof
+  verification

--- a/spec/HAP-Services.md
+++ b/spec/HAP-Services.md
@@ -72,7 +72,8 @@ itself (`aid=1`) carries this service; bridged accessories do not.
 
 **Required Characteristics:**
 
-- Version (0x37) — fixed at `1.1.0` for HAP over IP
+- Version (0x37) — the HAP version; HAP-NodeJS reports `1.1.0`, HAP-python the
+  equivalent zero-padded `01.01.00`
 
 ---
 

--- a/spec/HAP-Services.md
+++ b/spec/HAP-Services.md
@@ -55,15 +55,33 @@ information.
 **Optional Characteristics:**
 
 - HardwareRevision (0x53)
+- SoftwareRevision (0x54)
 - AccessoryFlags (0xA6)
-- HardwareFinish
+- ProductData (0x220)
+- HardwareFinish (0x26C)
+
+---
+
+### ProtocolInformation (0xA2)
+
+Required on every accessory. For a bridge, only the bridge accessory object
+itself (`aid=1`) carries this service; bridged accessories do not.
+
+| UUID | `000000A2-0000-1000-8000-0026BB765291` |
+| ---- | -------------------------------------- |
+
+**Required Characteristics:**
+
+- Version (0x37) — fixed at `1.1.0` for HAP over IP
 
 ---
 
 ## 4. Service Catalog
 
-The following table lists all standard HAP services with their UUIDs and
-required/optional characteristics.
+The following table lists the standard HAP services most relevant to this
+project, with their UUIDs and required/optional characteristics. Apple defines
+further services (remote control, Siri, Wi-Fi router, data stream management,
+and others) that are out of scope here.
 
 ### Lights, Power, and Switches
 
@@ -190,7 +208,7 @@ Common linking patterns:
 - **IrrigationSystem** → **Valve** (for zone control)
 - **Faucet** → **Valve** (for tap control)
 - **AirPurifier** → **FilterMaintenance** (for filter status)
-- **ServiceLabel** → **StatelessProgrammableSwitch** (for button numbering)
+- **StatelessProgrammableSwitch** → **ServiceLabel** (for button numbering)
 
 ---
 
@@ -228,6 +246,7 @@ Common linking patterns:
 | NFCAccess                   | 266        | 00000266-0000-1000-8000-0026BB765291 |
 | OccupancySensor             | 86         | 00000086-0000-1000-8000-0026BB765291 |
 | Outlet                      | 47         | 00000047-0000-1000-8000-0026BB765291 |
+| ProtocolInformation         | A2         | 000000A2-0000-1000-8000-0026BB765291 |
 | SecuritySystem              | 7E         | 0000007E-0000-1000-8000-0026BB765291 |
 | ServiceLabel                | CC         | 000000CC-0000-1000-8000-0026BB765291 |
 | Slat                        | B9         | 000000B9-0000-1000-8000-0026BB765291 |

--- a/spec/HAP-TLV8.md
+++ b/spec/HAP-TLV8.md
@@ -39,12 +39,21 @@ Record 2: Type=X, Length=245, Value[255..499]
 **Decoding rule:** When encountering consecutive TLV records with the same Type,
 concatenate their Values into a single logical value.
 
+Every fragment except the last MUST be exactly 255 bytes; only the final
+fragment may be shorter. Strict decoders depend on this: HAP-NodeJS's
+`decodeWithLists` merges a record into the previous one only when the preceding
+record has the same Type and a Length of exactly 255, and rejects adjacent
+same-type records otherwise.
+
 ---
 
 ## 3. Separators
 
 To encode multiple distinct values with the same Type (a list), separate them
-with a zero-length TLV (typically Type=0xFF):
+with a zero-length TLV of a different Type. Pairing messages define Type `0xFF`
+(Separator) for this purpose; in generic TLV8 characteristic payloads the
+separator Type is arbitrary, as long as the characteristic does not use it for
+something else:
 
 ```
 Record 1: Type=0x01, Length=32, Value[32 bytes]  // First identifier
@@ -96,7 +105,7 @@ These type codes are used in pair-setup, pair-verify, and pairings endpoints:
 | `0x00` | Method        | Pairing method (see Methods table)                    | `HAPPairing.h:108` |
 | `0x01` | Identifier    | Pairing identifier (UTF-8 string, max 36 bytes)       | `HAPPairing.h:114` |
 | `0x02` | Salt          | SRP salt (16+ bytes random)                           | `HAPPairing.h:120` |
-| `0x03` | PublicKey     | Curve25519 or SRP public key                          | `HAPPairing.h:126` |
+| `0x03` | PublicKey     | Curve25519, SRP public key, or signed Ed25519 key     | `HAPPairing.h:126` |
 | `0x04` | Proof         | SRP proof (M1/M2) or Ed25519 password proof           | `HAPPairing.h:132` |
 | `0x05` | EncryptedData | Encrypted payload with auth tag appended              | `HAPPairing.h:138` |
 | `0x06` | State         | Pairing state: 1=M1, 2=M2, 3=M3, 4=M4, 5=M5, 6=M6     | `HAPPairing.h:144` |
@@ -161,10 +170,11 @@ Hex dump: `06 01 01 00 01 00`
 ```
 06 01 02                    // State = 0x02 (M2)
 02 10 <16 bytes salt>       // Salt (16 bytes)
-03 80 01 <384 bytes>        // PublicKey (384 bytes = 0x180, fragmented)
+03 <fragmented>             // PublicKey (384 bytes, see below)
 ```
 
-The 384-byte SRP public key B requires fragmentation:
+A TLV8 length field is a single byte, so the 384-byte value cannot be carried in
+one record; the SRP public key B is split into two fragments:
 
 ```
 03 FF <255 bytes>           // First fragment

--- a/spec/HAP-mDNS.md
+++ b/spec/HAP-mDNS.md
@@ -17,7 +17,8 @@ The service type is `_hap._tcp` (HAP over TCP/IP).
 
 ## 2. TXT Record Fields
 
-All accessories MUST advertise these TXT record fields:
+Accessories MUST advertise the following TXT record fields; only `sh` is
+optional (needed for QR code and NFC pairing):
 
 | Key  | Description                 | Example             | Required |
 | ---- | --------------------------- | ------------------- | -------- |
@@ -29,7 +30,7 @@ All accessories MUST advertise these TXT record fields:
 | `s#` | State number                | `1`                 | Yes      |
 | `sf` | Status flags                | `1`                 | Yes      |
 | `ci` | Category identifier         | `5`                 | Yes      |
-| `sh` | Setup hash                  | `ABCD`              | Optional |
+| `sh` | Setup hash                  | `Duww+A==`          | Optional |
 
 From `Advertiser.ts:155-170`.
 
@@ -41,7 +42,11 @@ From `Advertiser.ts:155-170`.
 
 - Integer starting at 1
 - Increments when accessory database changes (services, characteristics)
+- Also increments after a firmware update, even if the database is otherwise
+  unchanged
 - Maximum value: 65535 (wraps to 1)
+- Must be persisted across restarts — controllers compare it against their
+  cached value, so resetting it on reboot defeats cache validation
 - Controllers use this to detect when to refresh cached data
 
 ### 3.2 Feature Flags (ff)
@@ -222,7 +227,7 @@ pv=1.1
 s#=1
 sf=1
 ci=2
-sh=QRST
+sh=aWcyuQ==
 ```
 
 This describes:

--- a/spec/HAP.md
+++ b/spec/HAP.md
@@ -31,7 +31,7 @@ particular implementation.
 | **Setup Code**     | An 8-digit code in format `XXX-XX-XXX` used during Pair Setup. Also called PIN code.                                                                    |
 | **Setup ID**       | A 4-character alphanumeric code used with the setup code to generate QR codes and NFC tags for pairing.                                                 |
 | **SRP-6a**         | Secure Remote Password protocol variant used by HAP with SHA-512 instead of SHA-1, and a 3072-bit prime from RFC 5054.                                  |
-| **TLV8**           | Type-Length-Value encoding with 8-bit length field. Used for pairing protocol messages.                                                                 |
+| **TLV8**           | Type-Length-Value encoding with 8-bit length field. Used for pairing protocol messages and for characteristic values with format `tlv8`.                |
 | **UUID**           | Universally Unique Identifier. HAP uses Apple's base UUID `XXXXXXXX-0000-1000-8000-0026BB765291` with a 32-bit short form prefix for standard types.    |
 
 ---
@@ -84,16 +84,17 @@ Bridge/Accessory (aid)
 - Has a unique `iid` within its accessory
 - Has a type UUID identifying the service type (e.g., `43` = LightBulb)
 - Contains required and optional characteristics
-- May link to other services (`linkedServices`)
-- May be marked as primary (`isPrimaryService`)
+- May link to other services (`linked`, an array of service instance IDs)
+- May be marked as primary (`primary`) or hidden (`hidden`)
 
 ### 3.3 Characteristic
 
 - Has a unique `iid` within its accessory
 - Has a type UUID identifying the characteristic type (e.g., `25` = On)
-- Has a format (bool, uint8, int, float, string, tlv8, data)
-- Has permissions (pr, pw, ev, hd, wr)
-- May have constraints (minValue, maxValue, minStep, validValues)
+- Has a format (bool, uint8, uint16, uint32, uint64, int, float, string, tlv8,
+  data)
+- Has permissions (pr, pw, ev, aa, tw, hd, wr)
+- May have constraints (minValue, maxValue, minStep, maxLen, valid-values)
 
 ---
 

--- a/spec/HAP.md
+++ b/spec/HAP.md
@@ -144,11 +144,12 @@ For custom/vendor UUIDs, use a different base UUID (not Apple's).
 
 ```
 HAP Protocol Version: 1.1
-Version String: "01.01.00"
 ```
 
 The protocol version is advertised in mDNS TXT records (`pv=1.1`) and reported
-via the HAPProtocolInformation service.
+via the ProtocolInformation service's Version characteristic. Implementations
+format that characteristic value differently: HAP-NodeJS reports `1.1.0`,
+HAP-python the equivalent zero-padded `01.01.00`.
 
 ---
 

--- a/spec/IMPLEMENTATIONS.md
+++ b/spec/IMPLEMENTATIONS.md
@@ -153,14 +153,17 @@ Services are defined with required and optional characteristics:
 ```json
 // external/HAP-python/pyhap/resources/services.json
 {
-  "LightBulb": {
+  "Lightbulb": {
     "UUID": "00000043-0000-1000-8000-0026BB765291",
     "RequiredCharacteristics": ["On"],
     "OptionalCharacteristics": [
       "Brightness",
       "Hue",
       "Saturation",
-      "ColorTemperature"
+      "Name",
+      "ActiveTransitionCount",
+      "TransitionControl",
+      "SupportedTransitionConfiguration"
     ]
   }
 }
@@ -221,13 +224,15 @@ BASE_UUID = "-0000-1000-8000-0026BB765291"
 
 ### Permissions
 
-| Code | Name           | Description                  |
-| ---- | -------------- | ---------------------------- |
-| `pr` | Paired Read    | Client can read when paired  |
-| `pw` | Paired Write   | Client can write when paired |
-| `ev` | Events         | Supports event notifications |
-| `hd` | Hidden         | Not visible in UI            |
-| `wr` | Write Response | Write returns a response     |
+| Code | Name                     | Description                              |
+| ---- | ------------------------ | ---------------------------------------- |
+| `pr` | Paired Read              | Client can read when paired              |
+| `pw` | Paired Write             | Client can write when paired             |
+| `ev` | Events                   | Supports event notifications             |
+| `aa` | Additional Authorization | Write needs additional authorization     |
+| `tw` | Timed Write              | Write must use the timed write procedure |
+| `hd` | Hidden                   | Not visible in UI                        |
+| `wr` | Write Response           | Write returns a response                 |
 
 ---
 
@@ -303,9 +308,17 @@ export const enum TLVValues {
   CERTIFICATE = 0x09, // X.509 certificate
   SIGNATURE = 0x0a, // Ed25519 signature
   PERMISSIONS = 0x0b, // Controller permissions
+  FRAGMENT_DATA = 0x0c, // Non-last fragment (obsolete since R7)
+  FRAGMENT_LAST = 0x0d, // Last fragment (obsolete since R7)
   SEPARATOR = 0xff, // List separator
 }
 ```
+
+The real enum additionally defines alias names for several of these codes —
+`REQUEST_TYPE` = `METHOD` (0x00), `USERNAME` = `IDENTIFIER` (0x01),
+`SEQUENCE_NUM` = `STATE` (0x06), `PROOF` = `SIGNATURE` (0x0a). Code excerpts in
+this document use the aliases (`SEQUENCE_NUM`, `USERNAME`, `PROOF`)
+interchangeably with the names above.
 
 ---
 
@@ -413,7 +426,9 @@ Controller sends:
 
 ### M4: SRP Verify Response
 
-Accessory verifies M1 and sends M2:
+Accessory verifies the controller's SRP proof M1 and answers with its own SRP
+proof M2 (the SRP proofs are conventionally named M1/M2; they are unrelated to
+the pairing message numbers M1-M6 carried in the State TLV):
 
 ```typescript
 // external/HAP-NodeJS/src/lib/HAPServer.ts
@@ -616,6 +631,8 @@ export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
 ### Nonce Handling
 
 - 12-byte nonce: first 4 bytes zero, last 8 bytes = counter (little-endian)
+- The snippet above allocates only the 8-byte counter; HAP-NodeJS left-pads it
+  to 12 bytes with zero bytes inside `chacha20_poly1305_encryptAndSeal`
 - Separate counters for each direction
 - Counter increments after each frame
 
@@ -634,7 +651,7 @@ export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
 | GET    | `/accessories`     | Yes            | Get accessory database                 |
 | GET    | `/characteristics` | Yes            | Read characteristics                   |
 | PUT    | `/characteristics` | Yes            | Write characteristics                  |
-| POST   | `/prepare`         | Yes            | Timed write preparation                |
+| PUT    | `/prepare`         | Yes            | Timed write preparation                |
 | POST   | `/resource`        | Yes            | Request resources (images)             |
 
 ### Content Types
@@ -714,6 +731,21 @@ Request body:
     { "aid": 1, "iid": 10, "value": false },
     { "aid": 1, "iid": 11, "ev": true }
   ]
+}
+```
+
+The accessory replies `204 No Content` when every entry succeeds, or
+`207 Multi-Status` with a body carrying a per-characteristic `status` code when
+any entry fails:
+
+```typescript
+// external/HAP-NodeJS/src/lib/HAPServer.ts
+if (multiStatus) {
+  response.writeHead(HAPHTTPCode.MULTI_STATUS, {
+    "Content-Type": HAPMimeTypes.HAP_JSON,
+  });
+} else {
+  response.writeHead(HAPHTTPCode.NO_CONTENT);
 }
 ```
 
@@ -797,8 +829,9 @@ public sendEvent(aid: number, iid: number, value, immediateDelivery?: boolean): 
 
 ### Event Coalescing
 
-Events are batched with a 250ms delay, except for immediate-delivery
-characteristics:
+HAP-NodeJS batches events with a 250ms delay (`EVENT_COALESCING_DELAY`), except
+for immediate-delivery characteristics. Coalescing is a design choice, not a
+protocol requirement; see Implementation Differences below:
 
 ```typescript
 // external/HAP-NodeJS/src/lib/util/eventedhttp.ts
@@ -813,10 +846,12 @@ if (immediateDelivery) {
 }
 ```
 
-**Immediate delivery characteristics**:
+**Immediate delivery characteristics** (from `Accessory.ts`):
 
 - `ProgrammableSwitchEvent` (0x73)
 - `ButtonEvent` (0x126)
+- `MotionDetected` (0x22)
+- `ContactSensorState` (0x6A)
 
 ---
 
@@ -864,6 +899,10 @@ static computeSetupHash(accessoryInfo: AccessoryInfo): string {
 }
 ```
 
+Here `username` is HAP-NodeJS's name for the accessory's device ID (the mDNS
+`id` field, `XX:XX:XX:XX:XX:XX` format), not a display or account name. The hash
+input is the 4-character Setup ID concatenated with the uppercased device ID.
+
 ### Category Identifiers
 
 ```python
@@ -879,7 +918,8 @@ CATEGORY_SWITCH = 8
 CATEGORY_THERMOSTAT = 9
 CATEGORY_SENSOR = 10
 CATEGORY_ALARM_SYSTEM = 11
-# ... more categories up to 36
+# ... more categories, up to CATEGORY_TARGET_CONTROLLER = 32
+# (HAP-NodeJS's Categories enum extends to 36, TV_STREAMING_STICK)
 ```
 
 ---

--- a/spec/IMPLEMENTATIONS.md
+++ b/spec/IMPLEMENTATIONS.md
@@ -569,15 +569,16 @@ After verification, session keys are derived:
 
 ```c
 // external/HomeKitADK/HAP/HAPPairingPairVerify.c
+// (HAPPairingPairVerifyStartSession; each info constant is local to its
+// own block)
 static const uint8_t salt[] = "Control-Salt";
-static const uint8_t infoRead[] = "Control-Read-Encryption-Key";
-static const uint8_t infoWrite[] = "Control-Write-Encryption-Key";
-
-HAP_hkdf_sha512(accessoryToControllerKey, 32,
-    sharedSecret, 32, salt, 12, infoRead, 27);
-HAP_hkdf_sha512(controllerToAccessoryKey, 32,
-    sharedSecret, 32, salt, 12, infoWrite, 28);
+static const uint8_t info[] = "Control-Read-Encryption-Key";
+static const uint8_t info[] = "Control-Write-Encryption-Key";
 ```
+
+HKDF-SHA-512 derives the 32-byte accessory-to-controller key from the shared
+secret with the read info string, and the 32-byte controller-to-accessory key
+with the write info string.
 
 ---
 
@@ -600,9 +601,10 @@ ChaCha20-Poly1305.
 ```typescript
 // external/HAP-NodeJS/src/lib/util/hapCrypto.ts
 export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
-  let result = Buffer.alloc(0);
-  for (let offset = 0; offset < data.length; ) {
-    const length = Math.min(data.length - offset, 0x400); // Max 1024 bytes
+  const chunks: Buffer[] = [];
+  const total = data.length;
+  for (let offset = 0; offset < total; ) {
+    const length = Math.min(total - offset, 0x400);
     const leLength = Buffer.alloc(2);
     leLength.writeUInt16LE(length, 0);
 
@@ -612,19 +614,14 @@ export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
     const encrypted = chacha20_poly1305_encryptAndSeal(
       encryption.accessoryToControllerKey,
       nonce,
-      leLength, // AAD = length bytes
+      leLength,
       data.subarray(offset, offset + length),
     );
-
-    result = Buffer.concat([
-      result,
-      leLength,
-      encrypted.ciphertext,
-      encrypted.authTag,
-    ]);
     offset += length;
+
+    chunks.push(leLength, encrypted.ciphertext, encrypted.authTag);
   }
-  return result;
+  return Buffer.concat(chunks);
 }
 ```
 

--- a/spec/MQTT.md
+++ b/spec/MQTT.md
@@ -557,7 +557,7 @@ Query comprehensive device state (from `Commands.md`).
     "MqttCount": 1,
     "POWER": "ON",
     "Dimmer": 75,
-    "Color": "FF5500",
+    "Color": "FF55000000",
     "HSBColor": "20,100,100",
     "CT": 300,
     "Wifi": {

--- a/spec/MQTT.md
+++ b/spec/MQTT.md
@@ -87,7 +87,8 @@ Constructed from tokens that are substituted at runtime. Default pattern:
 `%prefix%/%topic%/`.
 
 **FallbackTopic** : An emergency topic (`DVES_XXXXXX_fb` where XXXXXX is derived
-from MAC address) that always works regardless of topic configuration.
+from MAC address) that works regardless of the configured Topic. Not subscribed
+when FullTopic omits the `%topic%` token (see 2.3).
 
 **GroupTopic** : A shared topic that multiple devices can subscribe to for
 synchronized control. Default is `tasmotas`.
@@ -100,7 +101,8 @@ publish a message when a device disconnects ungracefully. Tasmota uses
 broker and delivered to new subscribers immediately upon subscription.
 
 **TelePeriod** : The interval in seconds between automatic telemetry messages.
-Default is 300 seconds (5 minutes). Range: 10-3600 seconds, or 0 to disable.
+Default is 300 seconds (5 minutes). Range: 10-3600 seconds; 0 disables telemetry
+and 1 resets the value to the firmware default (see 8.1).
 
 ---
 
@@ -225,6 +227,16 @@ cmnd/%topic%/<command>
 - Payloads `0`, `off`, `false` are equivalent
 - Payloads `1`, `on`, `true` are equivalent
 - Payloads `2`, `toggle` toggle the current state
+
+**Backlog:** Several commands can be sent in a single message using the
+`Backlog` command — up to 30 commands separated by `;`:
+
+```
+cmnd/%topic%/Backlog Power ON; Dimmer 50; CT 300
+```
+
+`Backlog0` executes the commands without the default delay between them, and a
+`Backlog` without arguments clears a pending queue.
 
 ### 3.2 Response Topics
 
@@ -445,6 +457,11 @@ cmnd/tasmota/Color #FF5500
   ↳ stat/tasmota/RESULT → {"Color":"FF550000"}
 ```
 
+The reported `Color` string contains two hex digits per light channel: six
+digits for an RGB light, eight for RGBW (as in this example), ten for RGBCCT.
+Parse it according to the device's channel count rather than assuming six
+digits.
+
 **SetOption17:**
 
 - `SetOption17 0`: Color shown as hex string (default)
@@ -515,9 +532,13 @@ Query comprehensive device state (from `Commands.md`).
 | Status  | `0`     | All status information (1-11)      |
 | Status  | `1`     | Device parameters                  |
 | Status  | `2`     | Firmware information               |
+| Status  | `3`     | Logging and telemetry parameters   |
+| Status  | `4`     | Memory information                 |
 | Status  | `5`     | Network information                |
 | Status  | `6`     | MQTT information                   |
+| Status  | `7`     | Time and daylight saving settings  |
 | Status  | `8`     | Sensor information (legacy)        |
+| Status  | `9`     | Power thresholds (margins)         |
 | Status  | `10`    | Sensor information                 |
 | Status  | `11`    | Full state (like TelePeriod STATE) |
 
@@ -576,6 +597,18 @@ stat/%topic%/POWER1   → Multi-relay power state
 **PowerRetain setting:** When `PowerRetain 1` is enabled, power state messages
 are published with MQTT retain flag.
 
+**Button and switch events:** By default a physical button or switch toggles the
+device's own relay and only the resulting `POWER` message is published. To
+receive press events directly (e.g. for a HomeKit stateless programmable
+switch), detach them from the relays:
+
+- `SetOption73 1`: buttons stop controlling the relay and each press publishes
+  `stat/%topic%/RESULT` with `{"Button<x>":{"Action":"SINGLE"}}`; actions are
+  `SINGLE`, `DOUBLE`, `TRIPLE`, `QUAD`, `PENTA`, and `HOLD`
+- `SetOption114 1`: switches are detached from all relays and publish
+  `{"Switch<x>":{"Action":"TOGGLE"}}`, with the action depending on the
+  configured SwitchMode
+
 ### 5.2 Periodic Telemetry (tele/)
 
 Periodic telemetry is published at intervals defined by TelePeriod (from
@@ -608,7 +641,7 @@ The STATE message includes complete device status (from `Commands.md`):
   "MqttCount": 1,
   "POWER": "ON",
   "Dimmer": 75,
-  "Color": "FF550000",
+  "Color": "FF55000000",
   "HSBColor": "20,100,100",
   "White": 0,
   "CT": 300,
@@ -642,7 +675,11 @@ appear based on device configuration:
 
 ### 5.4 RESULT Message Structure
 
-RESULT messages are simpler, containing only the changed values:
+RESULT messages contain the fields relevant to the executed command rather than
+the full device status. Depending on the command and light type, the response
+may include related fields whose values did not change (see the Color and CT
+examples below), so the presence of a field in a RESULT does not imply that it
+changed:
 
 **Power change:**
 
@@ -800,9 +837,9 @@ Sensor data is published on `tele/%topic%/SENSOR` (from `MQTT.md`):
 
 - `DS18B20`: Dallas 1-Wire temperature sensor
 - `DS18S20`: Dallas 1-Wire temperature sensor (older)
-- `AM2301`: DHT21/AM2301 temperature/humidity
+- `AM2301`: DHT21/AM2301, DHT22/AM2302, AM2320, and AM2321 temperature/humidity
+  (all variants report under the `AM2301` key)
 - `DHT11`: DHT11 temperature/humidity
-- `DHT22`: DHT22/AM2302 temperature/humidity
 - `BME280`: Bosch temperature/humidity/pressure
 - `BME680`: Bosch temperature/humidity/pressure/gas
 - `BMP280`: Bosch temperature/pressure
@@ -846,6 +883,8 @@ Sensor data is published on `tele/%topic%/SENSOR` (from `MQTT.md`):
 
 - Default: Celsius
 - `SetOption8 1`: Use Fahrenheit
+- SENSOR messages carry a top-level `TempUnit` field (`"C"` or `"F"`) indicating
+  the unit in use; check it before converting for HomeKit
 
 **Resolution:**
 
@@ -857,12 +896,12 @@ Sensor data is published on `tele/%topic%/SENSOR` (from `MQTT.md`):
 
 ### 7.4 Humidity Sensors
 
-**DHT22 example:**
+**AM2301 (DHT21/DHT22/AM2302) example:**
 
 ```json
 {
   "Time": "2021-01-01T12:00:00",
-  "DHT22": {
+  "AM2301": {
     "Temperature": 22.5,
     "Humidity": 45.0
   }
@@ -1201,7 +1240,9 @@ cmnd/%topic%/TelePeriod     → Trigger immediate telemetry
 ```
 stat/%topic%/RESULT         → Command responses
 stat/%topic%/POWER          → Power state changes
-stat/%topic%/POWER+         → Multi-relay (POWER1, POWER2, etc.)
+stat/%topic%/POWER1         → Multi-relay (POWER1, POWER2, ...); MQTT has
+stat/%topic%/POWER2           no partial-level wildcard, so subscribe to
+                              each relay topic or to stat/%topic%/+
 tele/%topic%/STATE          → Periodic state
 tele/%topic%/SENSOR         → Sensor readings
 tele/%topic%/LWT            → Online/Offline status


### PR DESCRIPTION
## Summary

Adversarial multi-agent review of the `spec/` protocol references. 17 reviewer agents (one per file; two lanes for the five largest files) fact-checked every falsifiable claim against online primary sources — HomeKitADK source, HAP-NodeJS/HAP-python definitions, Tasmota docs, and the relevant RFCs. Every proposed change was then independently peer-reviewed by at least 2 other agents instructed to refute it (split votes went to a third tiebreaker).

- **100** raw findings from 17 reviewers, **88** after dedupe
- **85 accepted** (all unanimous 2-0), **3 rejected** by peer review
- A final consistency agent reviewed the merged diff; its cross-edit findings were fixed and peer-reviewed in a second round (details below)
- `make check` passes (623 tests, lint, formatting)

The full audit trail — all 85 accepted changes grouped by file with category, evidence link, and peer-review vote, plus the 3 rejected findings and the consistency round — is posted as the first comment below (it exceeds comfortable PR-description length).

## Highlights

- **29 factual errors corrected**: fabricated code excerpts that don't exist upstream (`infoRead`/`infoWrite` in HomeKitADK), implementation-internal names presented as wire-format keys (`validValues` → `valid-values`, `linkedServices` → `linked`), wrong citations, stale version/date claims
- **32 gaps filled**: missing characteristic formats (uint16/32/64) and permissions (`aa`, `tw`), accessory categories 33–36 and bridged-accessory category 0, transient Pair Setup key derivation, immediate-delivery event characteristics
- **24 clarity fixes**: self-contradictory or misleading passages
- **8 cross-edit consistency fixes** in a second peer-reviewed round, including reconciling the protocol version strings (`pv=1.1`; ProtocolInformation Version is `1.1.0` in HAP-NodeJS, zero-padded `01.01.00` in HAP-python) and aligning both `layerEncrypt` quotes with the true upstream source

## Process

Deterministic multi-agent workflow: 17 adversarial reviewers → dedupe → 2 independent verifiers per finding (third-agent tiebreak on splits; amended texts got an extra confirmation reviewer) → serial apply → consistency agent → second 2-reviewer round for its findings. 215+ agents, ~7.3M tokens. Every change in this diff was authored by one agent and approved by at least 2 others.

---
_Generated by [Claude Code](https://claude.ai/code/session_01StncPbKiEc6yR1bnXQYmpu)_