### PR TITLE
Implement plan 001: spec-driven test suite restructure

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      - name: Check spec coverage
+        run: make spec-coverage

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual runs against any branch, e.g. to test workflow changes
+  # before merging
+  workflow_dispatch:
 
 concurrency:
   group: integration-${{ github.ref }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -92,16 +92,12 @@ jobs:
 
       - name: Shut down VM
         # A clean shutdown before the cache post-step keeps the cached
-        # qcow2 consistent, but graceful shutdown talks to the guest
-        # over SSH/ACPI and a wedged guest (common after a failed test
-        # run under TCG) can make it block indefinitely. This step runs
-        # `if: always()`, so bound it hard: try a graceful `down`, fall
-        # back to a force stop, then guarantee the QEMU process is gone.
-        # Leftover sockets cannot be archived and are removed.
+        # qcow2 consistent. `openhvf down` is internally bounded (its
+        # guest interactions are time-limited and it force-stops the
+        # QEMU process as a last resort), so it cannot hang the job even
+        # when the guest is wedged. Leftover sockets cannot be archived
+        # and are removed.
         if: always()
         run: |
-          timeout 120 ./bin/openhvf down \
-            || timeout 30 ./bin/openhvf stop --force \
-            || true
-          pkill -9 -f qemu-system-aarch64 2>/dev/null || true
+          ./bin/openhvf down || true
           find .openhvf -type s -delete 2>/dev/null || true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,13 +53,31 @@ jobs:
             openhvf-state-${{ runner.arch }}-${{ hashFiles('.openhvfrc',
             'deps/OpenBSD.txt', 'scripts/vm_provision.sh') }}
 
+      - name: Generate ephemeral SSH key for the VM
+        # The harness installs an authorized_keys entry on the guest and
+        # then uses key-based auth for every later `openhvf ssh`/`scp`.
+        # Developers configure this in ~/.openhvfrc; CI has no key, so
+        # mint a throwaway one per run. Write the public half to the
+        # GLOBAL rc (~/.openhvfrc) rather than the project .openhvfrc so
+        # the disk-cache key (which hashes the project file) stays stable.
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keygen -t ed25519 -N '' -C openhvf-ci -f ~/.ssh/id_ed25519
+          printf 'ssh_pubkey "%s"\n' "$(cat ~/.ssh/id_ed25519.pub)" \
+            > ~/.openhvfrc
+
       - name: Run integration tests
         env:
           # Expect-script step timeout and post-boot SSH wait, both far
           # beyond the defaults to accommodate TCG emulation
           OPENHVF_TIMEOUT: 1800
           OPENHVF_WAIT_TIMEOUT: 1800
-        run: make integration
+        run: |
+          # `openhvf ssh` authenticates via the SSH agent; load the key
+          # so the harness and the test scripts can reach the guest.
+          eval "$(ssh-agent -s)"
+          ssh-add ~/.ssh/id_ed25519
+          make integration
 
       - name: Show VM diagnostics on failure
         if: failure()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,9 +61,16 @@ jobs:
           OPENHVF_WAIT_TIMEOUT: 1800
         run: make integration
 
-      - name: Show VM status on failure
+      - name: Show VM diagnostics on failure
         if: failure()
-        run: ./bin/openhvf status || true
+        run: |
+          echo "==> openhvf status"
+          ./bin/openhvf status || true
+          echo "==> QEMU log tail"
+          tail -n 80 .openhvf/state/*/qemu.log 2>/dev/null || true
+          echo "==> Host virtualization"
+          ls -l /dev/kvm 2>/dev/null || echo "no /dev/kvm"
+          qemu-system-aarch64 --version 2>/dev/null | head -1 || true
 
       - name: Shut down VM
         # A clean shutdown before the cache post-step saves .openhvf

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,72 @@
+name: Integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    name: Integration tests (OpenBSD VM)
+    # arm64 runner: the OpenBSD guest is arm64, so the VM runs without
+    # cross-architecture translation. KVM is picked up automatically by
+    # openhvf if the runner ever exposes /dev/kvm; until then QEMU falls
+    # back to TCG software emulation, which is why the timeouts below
+    # are generous.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The build version derives from `git rev-list --count HEAD`
+          fetch-depth: 0
+
+      - name: Setup Perl
+        uses: ./.github/actions/setup-perl
+
+      - name: Install development dependencies
+        run: make deps-develop
+
+      - name: Cache OpenBSD miniroot image
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/openhvf
+          key: openhvf-image-${{ hashFiles('.openhvfrc') }}
+
+      - name: Cache provisioned VM disk
+        # Saved only after a clean shutdown (see the last step), so a
+        # cache hit boots the already-installed OpenBSD system instead
+        # of reinstalling it from the miniroot on every run.
+        uses: actions/cache@v4
+        with:
+          path: .openhvf
+          key:
+            openhvf-state-${{ runner.arch }}-${{ hashFiles('.openhvfrc',
+            'deps/OpenBSD.txt', 'scripts/vm_provision.sh') }}
+
+      - name: Run integration tests
+        env:
+          # Expect-script step timeout and post-boot SSH wait, both far
+          # beyond the defaults to accommodate TCG emulation
+          OPENHVF_TIMEOUT: 1800
+          OPENHVF_WAIT_TIMEOUT: 1800
+        run: make integration
+
+      - name: Show VM status on failure
+        if: failure()
+        run: ./bin/openhvf status || true
+
+      - name: Shut down VM
+        # A clean shutdown before the cache post-step saves .openhvf
+        # keeps the qcow2 disk image consistent; leftover sockets
+        # cannot be archived and are removed.
+        if: always()
+        run: |
+          ./bin/openhvf down || true
+          find .openhvf -type s -delete 2>/dev/null || true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -91,10 +91,17 @@ jobs:
           qemu-system-aarch64 --version 2>/dev/null | head -1 || true
 
       - name: Shut down VM
-        # A clean shutdown before the cache post-step saves .openhvf
-        # keeps the qcow2 disk image consistent; leftover sockets
-        # cannot be archived and are removed.
+        # A clean shutdown before the cache post-step keeps the cached
+        # qcow2 consistent, but graceful shutdown talks to the guest
+        # over SSH/ACPI and a wedged guest (common after a failed test
+        # run under TCG) can make it block indefinitely. This step runs
+        # `if: always()`, so bound it hard: try a graceful `down`, fall
+        # back to a force stop, then guarantee the QEMU process is gone.
+        # Leftover sockets cannot be archived and are removed.
         if: always()
         run: |
-          ./bin/openhvf down || true
+          timeout 120 ./bin/openhvf down \
+            || timeout 30 ./bin/openhvf stop --force \
+            || true
+          pkill -9 -f qemu-system-aarch64 2>/dev/null || true
           find .openhvf -type s -delete 2>/dev/null || true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ make check          # tidy + lint + test; MUST pass before every commit
 make test           # prove -l -v t/openhvf/*.t t/fugulib/*.t t/openhap/*.t
 prove -l t/openhap/foo.t   # run a single test file
 make lint           # Perl::Critic, severity 4
+make spec-coverage  # spec/ section coverage + stale-citation check
+
 make tidy           # check perltidy formatting
 make tidy-fix       # auto-fix Perl formatting
 make prettier       # check Markdown/JSON/YAML formatting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The repo contains three Perl namespaces with distinct concerns:
 
 ```sh
 make check          # tidy + lint + test; MUST pass before every commit
-make test           # prove -l -v t/openhvf/*.t t/openhap/*.t
+make test           # prove -l -v t/openhvf/*.t t/fugulib/*.t t/openhap/*.t
 prove -l t/openhap/foo.t   # run a single test file
 make lint           # Perl::Critic, severity 4
 make tidy           # check perltidy formatting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,9 @@ make integration    # provision OpenBSD VM and run integration tests
   (`Accessory.pm`, `Service.pm`, `Characteristic.pm`, `Bridge.pm`), config
   (`Config.pm`, `Storage.pm`), integration (`MQTT.pm`, `MDNS.pm`,
   `DeviceLoader.pm`), devices (`Tasmota/*.pm`)
-- `t/openhap/`, `t/fugulib/`, `t/openhvf/` — unit tests;
-  `t/conformance/` — spec-cited conformance tests (see `t/CLAUDE.md`);
-  `t/openhap/integration/` — integration tests, run inside the OpenBSD VM
+- `t/openhap/`, `t/fugulib/`, `t/openhvf/` — unit tests; `t/conformance/` —
+  spec-cited conformance tests (see `t/CLAUDE.md`); `t/openhap/integration/` —
+  integration tests, run inside the OpenBSD VM
 - `man/openhap/` — mdoc(7) man pages: `openhapd.8`, `hapctl.8`,
   `openhapd.conf.5`; `man/openhvf/` — `openhvf.1` (development-only, not
   installed)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The repo contains three Perl namespaces with distinct concerns:
 
 ```sh
 make check          # tidy + lint + test; MUST pass before every commit
-make test           # prove -l -v t/openhvf/*.t t/fugulib/*.t t/openhap/*.t
+make test           # prove -l -v t/{openhvf,fugulib,openhap,conformance}/*.t
 prove -l t/openhap/foo.t   # run a single test file
 make lint           # Perl::Critic, severity 4
 make spec-coverage  # spec/ section coverage + stale-citation check
@@ -43,6 +43,7 @@ make integration    # provision OpenBSD VM and run integration tests
   (`Config.pm`, `Storage.pm`), integration (`MQTT.pm`, `MDNS.pm`,
   `DeviceLoader.pm`), devices (`Tasmota/*.pm`)
 - `t/openhap/`, `t/fugulib/`, `t/openhvf/` — unit tests;
+  `t/conformance/` — spec-cited conformance tests (see `t/CLAUDE.md`);
   `t/openhap/integration/` — integration tests, run inside the OpenBSD VM
 - `man/openhap/` — mdoc(7) man pages: `openhapd.8`, `hapctl.8`,
   `openhapd.conf.5`; `man/openhvf/` — `openhvf.1` (development-only, not

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ package: clean
 
 test:
 	prove -l -v t/openhvf/*.t
+	prove -l -v t/fugulib/*.t
 	prove -l -v t/openhap/*.t
 
 tidy:

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ install: install-man
 	install -d $(DESTDIR)$(LIBDIR)/OpenHAP
 	install -d $(DESTDIR)$(LIBDIR)/OpenHAP/Tasmota
 	install -d $(DESTDIR)$(LIBDIR)/OpenHAP/Test
+	install -d $(DESTDIR)$(LIBDIR)/OpenHAP/Test/Controller
 	install -d $(DESTDIR)$(LIBDIR)/FuguLib
 	install -m 644 lib/OpenHAP/*.pm $(DESTDIR)$(LIBDIR)/OpenHAP/
 	install -m 644 lib/OpenHAP/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/
@@ -75,6 +76,8 @@ install: install-man
 	install -m 644 lib/OpenHAP/Tasmota/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/Tasmota/
 	[ ! -e lib/OpenHAP/Test/*.pm ] || install -m 644 lib/OpenHAP/Test/*.pm $(DESTDIR)$(LIBDIR)/OpenHAP/Test/
 	[ ! -e lib/OpenHAP/Test/*.pod ] || install -m 644 lib/OpenHAP/Test/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/Test/
+	[ ! -e lib/OpenHAP/Test/Controller/*.pm ] || install -m 644 lib/OpenHAP/Test/Controller/*.pm $(DESTDIR)$(LIBDIR)/OpenHAP/Test/Controller/
+	[ ! -e lib/OpenHAP/Test/Controller/*.pod ] || install -m 644 lib/OpenHAP/Test/Controller/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/Test/Controller/
 	install -m 644 lib/FuguLib/*.pm $(DESTDIR)$(LIBDIR)/FuguLib/
 	install -m 644 lib/FuguLib/*.pod $(DESTDIR)$(LIBDIR)/FuguLib/
 	# Install rc.d script
@@ -122,7 +125,7 @@ spec-coverage:
 package: clean
 	mkdir -p build/$(PACKAGE)/bin
 	mkdir -p build/$(PACKAGE)/lib/OpenHAP/Tasmota
-	mkdir -p build/$(PACKAGE)/lib/OpenHAP/Test
+	mkdir -p build/$(PACKAGE)/lib/OpenHAP/Test/Controller
 	mkdir -p build/$(PACKAGE)/lib/FuguLib
 	mkdir -p build/$(PACKAGE)/etc/rc.d
 	mkdir -p build/$(PACKAGE)/share/openhap/examples
@@ -135,6 +138,7 @@ package: clean
 	cp lib/OpenHAP/*.pm lib/OpenHAP/*.pod build/$(PACKAGE)/lib/OpenHAP/
 	cp lib/OpenHAP/Tasmota/*.pm lib/OpenHAP/Tasmota/*.pod build/$(PACKAGE)/lib/OpenHAP/Tasmota/
 	cp lib/OpenHAP/Test/*.pm lib/OpenHAP/Test/*.pod build/$(PACKAGE)/lib/OpenHAP/Test/
+	cp lib/OpenHAP/Test/Controller/*.pm lib/OpenHAP/Test/Controller/*.pod build/$(PACKAGE)/lib/OpenHAP/Test/Controller/
 	cp lib/FuguLib/*.pm lib/FuguLib/*.pod build/$(PACKAGE)/lib/FuguLib/
 	# rc.d script
 	cp etc/rc.d/openhapd build/$(PACKAGE)/etc/rc.d/

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ test:
 	prove -l -v t/openhvf/*.t
 	prove -l -v t/fugulib/*.t
 	prove -l -v t/openhap/*.t
+	prove -l -v t/conformance/*.t
 
 tidy:
 	@find lib bin -name '*.pm' -o -name 'openhapd' -o -name 'hapctl' | while read f; do \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build check clean clean-man deps deps-develop deps-test install install-man integration lint man package prettier prettier-fix test tidy tidy-fix uninstall upgrade vm-provision vm-up
+.PHONY: all build check clean clean-man deps deps-develop deps-test install install-man integration lint man package prettier prettier-fix spec-coverage test tidy tidy-fix uninstall upgrade vm-provision vm-up
 
 # Filesystem configuration
 PREFIX			?= /usr/local
@@ -106,6 +106,9 @@ prettier:
 
 prettier-fix:
 	npx prettier --write '**/*.md' '**/*.json' '**/*.yml'
+
+spec-coverage:
+	@perl scripts/spec-coverage --quiet
 
 %.cat1: %.1
 	$(MANDOC) -Tascii $< > $@

--- a/bin/openhapd
+++ b/bin/openhapd
@@ -100,12 +100,17 @@ else {
 my $loader = OpenHAP::DeviceLoader->new();
 $loader->load_devices( $config, $hap, $mqtt );
 
-# Create mDNS handler (registration happens after privilege drop)
+# Bump c# if the accessory database changed since the last run
+$hap->update_config_number();
+
+# Create mDNS handler (registration happens after privilege drop);
+# the HAP server re-advertises the TXT record on pairing changes
 my $mdns = OpenHAP::MDNS->new(
 	service_name => $hap_name,
 	port         => $hap_port,
 	txt_records  => $hap->get_mdns_txt_records(),
 );
+$hap->set_mdns($mdns);
 
 # Drop privileges before registering mDNS
 # _openhap must be in wheel group to access /var/run/mdnsd.sock

--- a/cpanfile
+++ b/cpanfile
@@ -9,6 +9,11 @@ requires 'CryptX';
 # JSON parsing
 requires 'JSON::XS';
 
+# GMP backend for Math::BigInt: SRP does 3072-bit modular exponentiation,
+# which is impractically slow in the pure-Perl backend. Math::BigInt loads
+# this automatically when present.
+requires 'Math::BigInt::GMP';
+
 # MQTT client for device integration
 requires 'Net::MQTT::Simple';
 

--- a/deps/Darwin.txt
+++ b/deps/Darwin.txt
@@ -4,6 +4,7 @@ runtime cpan Crypt::Ed25519
 runtime cpan Crypt::Curve25519
 runtime cpan CryptX
 runtime cpan Net::MQTT::Simple
+runtime cpan Math::BigInt::GMP
 
 test cpan Perl::Critic
 test cpan Perl::Tidy

--- a/deps/Darwin.txt
+++ b/deps/Darwin.txt
@@ -11,5 +11,6 @@ test cpan Net::SSH2
 
 develop pkg libssh2
 develop pkg qemu
+develop pkg telnet
 develop cpan HTTP::Daemon
 develop cpan LWP::UserAgent

--- a/deps/Linux.txt
+++ b/deps/Linux.txt
@@ -1,6 +1,7 @@
 runtime pkg mosquitto
 runtime pkg avahi-daemon
 runtime pkg libperl-dev
+runtime pkg libmath-bigint-gmp-perl
 runtime cpan JSON::XS
 runtime cpan Crypt::Ed25519
 runtime cpan Crypt::Curve25519

--- a/deps/Linux.txt
+++ b/deps/Linux.txt
@@ -12,7 +12,9 @@ test cpan Perl::Critic
 test cpan Perl::Tidy
 test cpan Net::SSH2
 
-develop pkg qemu-system-aarch64
+develop pkg qemu-system-arm
 develop pkg qemu-efi-aarch64
+develop pkg expect
+develop pkg telnet
 develop cpan HTTP::Daemon
 develop cpan LWP::UserAgent

--- a/deps/OpenBSD.txt
+++ b/deps/OpenBSD.txt
@@ -4,6 +4,7 @@ runtime pkg p5-Crypt-Ed25519
 runtime pkg p5-Crypt-Curve25519
 runtime pkg p5-CryptX
 runtime pkg p5-JSON-XS
+runtime pkg p5-Math-BigInt-GMP
 runtime cpan Net::MQTT::Simple
 
 test pkg p5-Perl-Critic

--- a/lib/OpenHAP/Bridge.pm
+++ b/lib/OpenHAP/Bridge.pm
@@ -18,7 +18,33 @@ sub new ( $class, %args )
 
 	$self->{bridged_accessories} = [];
 
+	# ProtocolInformation is required on the bridge accessory object
+	# itself; bridged accessories do not carry it (HAP-Services.md §3)
+	$self->_add_protocol_info_service;
+
 	return $self;
+}
+
+sub _add_protocol_info_service ($self)
+{
+	require OpenHAP::Service;
+	require OpenHAP::Characteristic;
+
+	my $protocol = OpenHAP::Service->new(
+		type => 'ProtocolInformation',
+		iid  => 8,
+	);
+
+	$protocol->add_characteristic(
+		OpenHAP::Characteristic->new(
+			type   => 'Version',
+			iid    => 9,
+			format => 'string',
+			perms  => ['pr'],
+			value  => '1.1.0',
+		) );
+
+	$self->add_service($protocol);
 }
 
 sub add_bridged_accessory ( $self, $accessory )

--- a/lib/OpenHAP/Bridge.pod
+++ b/lib/OpenHAP/Bridge.pod
@@ -15,7 +15,9 @@ OpenHAP::Bridge - HAP bridge accessory
 =head1 DESCRIPTION
 
 This module represents a HAP bridge that can contain multiple
-bridged accessories.
+bridged accessories. The bridge accessory carries the mandatory
+AccessoryInformation and ProtocolInformation services; bridged
+accessories carry only AccessoryInformation.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Characteristic.pm
+++ b/lib/OpenHAP/Characteristic.pm
@@ -28,6 +28,18 @@ our %CHAR_TYPES = (
 	# Switch/Outlet
 	'On'          => '00000025-0000-1000-8000-0026BB765291',
 	'OutletInUse' => '00000026-0000-1000-8000-0026BB765291',
+
+	# Lightbulb
+	'Brightness'       => '00000008-0000-1000-8000-0026BB765291',
+	'Hue'              => '00000013-0000-1000-8000-0026BB765291',
+	'Saturation'       => '0000002F-0000-1000-8000-0026BB765291',
+	'ColorTemperature' => '000000CE-0000-1000-8000-0026BB765291',
+
+	# Sensors
+	'CurrentRelativeHumidity' => '00000010-0000-1000-8000-0026BB765291',
+
+	# Protocol information
+	'Version' => '00000037-0000-1000-8000-0026BB765291',
 );
 
 # _uuid_to_short($uuid) - Convert full UUID to short form for JSON
@@ -63,6 +75,7 @@ our %PERMISSIONS = (
 	'aa' => 1,    # Additional Authorization
 	'tw' => 1,    # Timed Write
 	'hd' => 1,    # Hidden
+	'wr' => 1,    # Write Response
 );
 
 sub new ( $class, %args )
@@ -166,24 +179,28 @@ sub to_json ( $self, $include_value = 1 )
 
 	# Add value if requested and readable
 	if ( $include_value && grep { $_ eq 'pr' } @{ $self->{perms} } ) {
-		my $value = $self->get_value();
-
-		# Convert value to proper JSON type
-		if ( $self->{format} eq 'bool' ) {
-			$json->{value} = $value ? \1 : \0;
-		}
-		elsif ( $self->{format} =~ /^(uint|int)/ ) {
-			$json->{value} = $value + 0;
-		}
-		elsif ( $self->{format} eq 'float' ) {
-			$json->{value} = $value + 0.0;
-		}
-		else {
-			$json->{value} = $value;
-		}
+		$json->{value} = $self->json_value;
 	}
 
 	return $json;
+}
+
+# json_value() - Current value converted to its JSON type per the
+# characteristic format (HAP-HTTP.md §15.1)
+sub json_value ($self)
+{
+	my $value = $self->get_value();
+
+	if ( $self->{format} eq 'bool' ) {
+		return $value ? \1 : \0;
+	}
+	if ( $self->{format} =~ /^(uint|int)/ ) {
+		return $value + 0;
+	}
+	if ( $self->{format} eq 'float' ) {
+		return $value + 0.0;
+	}
+	return $value;
 }
 
 1;

--- a/lib/OpenHAP/Characteristic.pm
+++ b/lib/OpenHAP/Characteristic.pm
@@ -73,7 +73,7 @@ sub new ( $class, %args )
 
 	my $self = bless {
 		type   => $uuid,
-		iid    => $args{iid}    // die "Instance ID required",
+		iid    => $args{iid}    // die('Instance ID required'),
 		format => $args{format} // 'string',
 		perms  => $args{perms}  // ['pr'],
 

--- a/lib/OpenHAP/HAP.pm
+++ b/lib/OpenHAP/HAP.pm
@@ -394,7 +394,7 @@ sub _handle_characteristics_get ( $self, $request, $session )
 		my $result = {
 			aid   => $aid + 0,
 			iid   => $iid + 0,
-			value => $char->get_value(),
+			value => $char->json_value,
 		};
 
 		# Add optional metadata if requested
@@ -582,10 +582,10 @@ sub _handle_pairings ( $self, $request, $session )
 {
 	my %tlv = OpenHAP::TLV::decode( $request->{body} );
 
-	my $method =
-	    unpack( 'C', $tlv{ OpenHAP::Pairing::kTLVType_Method() } // '' );
+	my $method_raw = $tlv{ OpenHAP::Pairing::kTLVType_Method() };
+	my $method     = defined $method_raw ? unpack( 'C', $method_raw ) : -1;
 
-	$OpenHAP::logger->debug( 'Pairings request method=%d', $method // -1 );
+	$OpenHAP::logger->debug( 'Pairings request method=%d', $method );
 
 	# Method values: 3=Add, 4=Remove, 5=List
 	if ( $method == 3 ) {
@@ -633,6 +633,25 @@ sub _handle_add_pairing ( $self, $tlv, $session )
 			OpenHAP::Pairing::kTLVType_Error(),
 			pack( 'C',
 				OpenHAP::Pairing::kTLVError_Authentication() ),
+		);
+		return OpenHAP::HTTP::build_response(
+			status  => 200,
+			headers =>
+			    { 'Content-Type' => 'application/pairing+tlv8' },
+			body => $error,
+		);
+	}
+
+	# An existing identifier with a different LTPK is an error;
+	# with a matching LTPK only the permissions are updated
+	# (HAP-Pairing.md §7.4)
+	my $existing = $pairings->{$identifier};
+	if ( $existing && $existing->{ltpk} ne $ltpk ) {
+		my $error = OpenHAP::TLV::encode(
+			OpenHAP::Pairing::kTLVType_State(),
+			pack( 'C', 2 ),
+			OpenHAP::Pairing::kTLVType_Error(),
+			pack( 'C', OpenHAP::Pairing::kTLVError_Unknown() ),
 		);
 		return OpenHAP::HTTP::build_response(
 			status  => 200,

--- a/lib/OpenHAP/HAP.pm
+++ b/lib/OpenHAP/HAP.pm
@@ -102,6 +102,33 @@ sub set_mqtt_client ( $self, $mqtt )
 	$self->{mqtt_client} = $mqtt;
 }
 
+# $self->set_mdns($mdns):
+#	set the mDNS registration handle so the TXT record can be
+#	re-advertised when the pairing state changes (HAP-mDNS.md §8)
+sub set_mdns ( $self, $mdns )
+{
+	$self->{mdns}              = $mdns;
+	$self->{last_paired_state} = $self->is_paired() ? 1 : 0;
+}
+
+# $self->_refresh_mdns():
+#	re-advertise the TXT record if the pairing state changed
+sub _refresh_mdns ($self)
+{
+	return unless defined $self->{mdns};
+
+	my $paired = $self->is_paired() ? 1 : 0;
+	return if ( $self->{last_paired_state} // -1 ) == $paired;
+
+	$self->{last_paired_state} = $paired;
+	$self->{mdns}->update_txt_records( $self->get_mdns_txt_records );
+	$OpenHAP::logger->info(
+		'Pairing state changed, re-advertised mDNS TXT (sf=%d)',
+		$paired ? 0 : 1 );
+
+	return;
+}
+
 sub run ($self)
 {
 	my $server = IO::Socket::INET->new(
@@ -198,7 +225,10 @@ sub _handle_client ( $self, $sock, $select )
 
 	if ( !$bytes ) {
 
-		# Connection closed
+		# Connection closed: release the pairing lock if this
+		# session held it, so an aborted pair-setup cannot lock
+		# out pairing until restart
+		OpenHAP::Pairing->clear_pairing_state($session);
 		$OpenHAP::logger->info( 'Client disconnected from %s',
 			$sock->peerhost );
 		$select->remove($sock);
@@ -216,6 +246,7 @@ sub _handle_client ( $self, $sock, $select )
 		unless ( defined $data ) {
 			$OpenHAP::logger->warning(
 				'Decryption failed for client session');
+			OpenHAP::Pairing->clear_pairing_state($session);
 			$select->remove($sock);
 			delete $self->{sessions}{$sock};
 			$sock->close();
@@ -243,6 +274,9 @@ sub _handle_client ( $self, $sock, $select )
 
 	# Send response
 	$sock->syswrite($response);
+
+	# Re-advertise mDNS if this request changed the pairing state
+	$self->_refresh_mdns;
 }
 
 sub _dispatch ( $self, $request, $session )
@@ -949,6 +983,45 @@ sub is_paired ($self)
 sub get_config_number ($self)
 {
 	return $self->{storage}->get_config_number();
+}
+
+# $self->update_config_number():
+#	Increment c# when the accessory database changed since the last
+#	run (HAP-mDNS.md §3.1). Called after device loading; compares a
+#	digest of the accessory structure against the stored one.
+sub update_config_number ($self)
+{
+	my @parts;
+	for my $accessory ( $self->{bridge}->get_all_accessories ) {
+		push @parts, "a$accessory->{aid}";
+		for my $service ( $accessory->get_services ) {
+			push @parts,
+			    "s$service->{iid}:" . $service->to_json->{type};
+			for my $char ( $service->get_characteristics ) {
+				push @parts,
+				      "c$char->{iid}:"
+				    . $char->to_json->{type} . ':'
+				    . $char->{format};
+			}
+		}
+	}
+	my $digest = unpack( 'H*', sha512( join( ';', @parts ) ) );
+
+	my $stored = $self->{storage}->get_config_digest;
+	if ( !defined $stored ) {
+
+		# First run: record the digest, c# stays at its initial 1
+		$self->{storage}->save_config_digest($digest);
+	}
+	elsif ( $stored ne $digest ) {
+		$self->{storage}->increment_config_number;
+		$self->{storage}->save_config_digest($digest);
+		$OpenHAP::logger->info(
+			'Accessory database changed, c# is now %d',
+			$self->get_config_number );
+	}
+
+	return $self->get_config_number;
 }
 
 sub get_device_id ($self)

--- a/lib/OpenHAP/HAP.pm
+++ b/lib/OpenHAP/HAP.pm
@@ -207,8 +207,11 @@ sub _handle_client ( $self, $sock, $select )
 		return;
 	}
 
-	# Decrypt if session is encrypted
-	if ( $session->is_encrypted() ) {
+	# Decrypt if session is encrypted. Remember the state: pair-verify
+	# M4 enables encryption during dispatch, but the M4 response itself
+	# is still sent in the clear; only subsequent traffic is encrypted.
+	my $was_encrypted = $session->is_encrypted();
+	if ($was_encrypted) {
 		$data = $session->decrypt($data);
 		unless ( defined $data ) {
 			$OpenHAP::logger->warning(
@@ -232,8 +235,9 @@ sub _handle_client ( $self, $sock, $select )
 	# Dispatch request
 	my $response = $self->_dispatch( $request, $session );
 
-	# Encrypt if session is encrypted
-	if ( $session->is_encrypted() ) {
+	# Encrypt only if the session was already encrypted when the
+	# request arrived (see note above)
+	if ($was_encrypted) {
 		$response = $session->encrypt($response);
 	}
 

--- a/lib/OpenHAP/MDNS.pm
+++ b/lib/OpenHAP/MDNS.pm
@@ -171,6 +171,19 @@ sub unregister_service ($self)
 	return 1;
 }
 
+# $self->update_txt_records($records):
+#	Replace the TXT records and re-register the service so the
+#	advertisement reflects state changes (HAP-mDNS.md §8)
+sub update_txt_records ( $self, $records )
+{
+	$self->{txt_records} = $records;
+
+	return 1 unless $self->{registered};
+
+	$self->unregister_service;
+	return $self->register_service;
+}
+
 # $self->is_registered():
 #	Check if service is currently registered
 sub is_registered ($self)

--- a/lib/OpenHAP/Pairing.pm
+++ b/lib/OpenHAP/Pairing.pm
@@ -59,6 +59,11 @@ sub new ( $class, %args )
 		accessory_ltpk => $args{accessory_ltpk},
 	}, $class;
 
+	# Restore the persisted attempt counter so the limit survives
+	# restarts (HAP-Pairing.md §8)
+	$failed_auth_attempts = $self->{storage}->get_auth_attempts
+	    if $self->{storage};
+
 	return $self;
 }
 
@@ -77,10 +82,20 @@ sub clear_pairing_state ( $class_or_self, $session = undef )
 }
 
 # reset_auth_attempts() - Reset failed authentication counter
-# Called after successful pairing or administratively
+# Called after successful SRP proof verification or administratively
 sub reset_auth_attempts ($class_or_self)
 {
 	$failed_auth_attempts = 0;
+	$class_or_self->{storage}->set_auth_attempts(0)
+	    if ref $class_or_self && $class_or_self->{storage};
+}
+
+# _record_failed_attempt() - Count and persist a failed attempt (§8)
+sub _record_failed_attempt ($self)
+{
+	$failed_auth_attempts++;
+	$self->{storage}->set_auth_attempts($failed_auth_attempts)
+	    if $self->{storage};
 }
 
 # get_failed_attempts() - Get current failed attempt count (for testing)
@@ -100,8 +115,16 @@ sub handle_pair_setup ( $self, $body, $session )
 {
 
 	my %request = OpenHAP::TLV::decode($body);
-	my $state   = unpack( 'C', $request{ kTLVType_State() } );
-	my $method  = unpack( 'C', $request{ kTLVType_Method() } // "\x00" );
+
+	# Reject malformed TLV or missing State ([HAP-TLV8 §10])
+	unless ( defined $request{ kTLVType_State() } ) {
+		$OpenHAP::logger->warning(
+			'Pair-setup rejected: malformed TLV request');
+		return $self->_error_response( kTLVError_Unknown, 2 );
+	}
+
+	my $state  = unpack( 'C', $request{ kTLVType_State() } );
+	my $method = unpack( 'C', $request{ kTLVType_Method() } // "\x00" );
 	$OpenHAP::logger->debug( 'Pair-setup M%d received (method=%d)',
 		$state, $method );
 
@@ -189,7 +212,7 @@ sub _pair_setup_m3_m4 ( $self, $request, $session )
 	# Compute session key (returns undef if A mod N == 0)
 	my $K = $srp->compute_session_key($A);
 	unless ( defined $K ) {
-		$failed_auth_attempts++;
+		$self->_record_failed_attempt;
 		$OpenHAP::logger->warning(
 			'Pair-setup M3 rejected: invalid public key A');
 		if ( $failed_auth_attempts >= MAX_AUTH_ATTEMPTS ) {
@@ -199,7 +222,7 @@ sub _pair_setup_m3_m4 ( $self, $request, $session )
 	}
 
 	unless ( $srp->verify_client_proof($M1) ) {
-		$failed_auth_attempts++;
+		$self->_record_failed_attempt;
 		$OpenHAP::logger->warning(
 'Pair-setup M3 proof verification failed (attempt %d/%d)',
 			$failed_auth_attempts, MAX_AUTH_ATTEMPTS
@@ -209,6 +232,9 @@ sub _pair_setup_m3_m4 ( $self, $request, $session )
 		}
 		return $self->_error_response( kTLVError_Authentication, 4 );
 	}
+
+	# Successful SRP proof resets the attempt counter (§8)
+	$self->reset_auth_attempts;
 
 	# Generate server proof
 	my $M2 = $srp->generate_server_proof();
@@ -275,9 +301,9 @@ sub _pair_setup_m5_m6 ( $self, $request, $session )
 		$ios_device_pairing_id );
 
 	# Pairing successful - reset attempt counter and clear pairing lock
-	$failed_auth_attempts = 0;
-	$pairing_in_progress  = 0;
-	$pairing_session_id   = undef;
+	$self->reset_auth_attempts;
+	$pairing_in_progress = 0;
+	$pairing_session_id  = undef;
 
 	# Generate accessory signature
 	my $accessory_x = OpenHAP::Crypto::hkdf_sha512(
@@ -319,7 +345,15 @@ sub handle_pair_verify ( $self, $body, $session )
 {
 
 	my %request = OpenHAP::TLV::decode($body);
-	my $state   = unpack( 'C', $request{ kTLVType_State() } );
+
+	# Reject malformed TLV or missing State ([HAP-TLV8 §10])
+	unless ( defined $request{ kTLVType_State() } ) {
+		$OpenHAP::logger->warning(
+			'Pair-verify rejected: malformed TLV request');
+		return $self->_error_response( kTLVError_Unknown, 2 );
+	}
+
+	my $state = unpack( 'C', $request{ kTLVType_State() } );
 	$OpenHAP::logger->debug( 'Pair-verify M%d received', $state );
 
 	if ( $state == 1 ) {
@@ -395,6 +429,10 @@ sub _pair_verify_m3_m4 ( $self, $request, $session )
 	my $shared_secret    = $session->{pairing_state}{shared_secret};
 	my $accessory_public = $session->{pairing_state}{accessory_public};
 	my $ios_public_key   = $session->{pairing_state}{ios_public_key};
+
+	# M3 without a preceding M1 exchange is a protocol error
+	return $self->_error_response( kTLVError_Unknown, 4 )
+	    unless defined $shared_secret;
 
 	# Derive session key
 	my $session_key = OpenHAP::Crypto::hkdf_sha512( $shared_secret,

--- a/lib/OpenHAP/SRP.pm
+++ b/lib/OpenHAP/SRP.pm
@@ -1,7 +1,12 @@
 use v5.36;
 
 package OpenHAP::SRP;
-use Math::BigInt;
+
+# Prefer the GMP backend: SRP's 3072-bit modular exponentiation is
+# impractically slow in the pure-Perl Calc backend (seconds per op,
+# far worse under emulation). 'try' falls back to Calc silently when
+# Math::BigInt::GMP is not installed, so this stays correct everywhere.
+use Math::BigInt try => 'GMP';
 use Digest::SHA qw(sha512);
 use OpenHAP::Crypto;
 use OpenHAP::PIN qw(normalize_pin);

--- a/lib/OpenHAP/SRP.pm
+++ b/lib/OpenHAP/SRP.pm
@@ -77,7 +77,8 @@ sub compute_verifier ( $self, $salt = undef, $password = undef )
 	my $x       = Math::BigInt->from_hex( unpack( 'H*', $x_bytes ) );
 
 	# v = g^x mod N
-	my $v = $self->{g}->bmodpow( $x, $self->{N} );
+	# bmodpow mutates its invocant, so work on a copy of g
+	my $v = $self->{g}->copy->bmodpow( $x, $self->{N} );
 
 	$self->{v} = $v;
 	return $v;
@@ -99,8 +100,10 @@ sub generate_server_public ($self)
 	my $k        = Math::BigInt->from_hex( unpack( 'H*', $k_bytes ) );
 
 	# B = (k*v + g^b) mod N
+	# bmodpow mutates its invocant, so work on a copy of g
 	my $B =
-	    ( $k * $self->{v} + $self->{g}->bmodpow( $self->{b}, $self->{N} ) )
+	    ( $k * $self->{v} +
+		    $self->{g}->copy->bmodpow( $self->{b}, $self->{N} ) )
 	    % $self->{N};
 
 	$self->{B} = $B;
@@ -119,15 +122,17 @@ sub compute_session_key ( $self, $A_bytes )
 	$self->{A} = $A;
 
 	# u = H(PAD(A) | PAD(B)) - Both A and B must be padded to N_LEN
-	# per HAP-Pairing.md and SRP-6a spec (see HAP-python hsrp.py)
-	my $A_bytes = _bigint_to_bytes( $self->{A}, N_LEN );
-	my $B_bytes = _bigint_to_bytes( $self->{B}, N_LEN );
-	my $u_bytes = sha512( $A_bytes . $B_bytes );
-	my $u       = Math::BigInt->from_hex( unpack( 'H*', $u_bytes ) );
+	# per HAP-Pairing.md §2.6 and SRP-6a spec
+	my $A_padded = _bigint_to_bytes( $self->{A}, N_LEN );
+	my $B_padded = _bigint_to_bytes( $self->{B}, N_LEN );
+	my $u_bytes  = sha512( $A_padded . $B_padded );
+	my $u        = Math::BigInt->from_hex( unpack( 'H*', $u_bytes ) );
 
 	# S = (A * v^u)^b mod N
+	# bmodpow mutates its invocant, so work on a copy of v; the
+	# multiplication result is a fresh object, safe to mutate
 	my $S =
-	    ( $self->{A} * $self->{v}->bmodpow( $u, $self->{N} ) )
+	    ( $self->{A} * $self->{v}->copy->bmodpow( $u, $self->{N} ) )
 	    ->bmodpow( $self->{b}, $self->{N} );
 
 	$self->{S} = $S;
@@ -143,9 +148,11 @@ sub verify_client_proof ( $self, $M1_client )
 {
 
 	# M1 = H(H(N) XOR H(g) | H(username) | salt | A | B | K)
+	# use the string xor operator: v5.36 enables the 'bitwise'
+	# feature, under which plain ^ is numeric-only
 	my $N_hash = sha512( _bigint_to_bytes( $self->{N} ) );
 	my $g_hash = sha512( _bigint_to_bytes( $self->{g} ) );
-	my $xor    = $N_hash ^ $g_hash;
+	my $xor    = $N_hash ^. $g_hash;
 
 	my $user_hash = sha512( $self->{username} );
 

--- a/lib/OpenHAP/Service.pm
+++ b/lib/OpenHAP/Service.pm
@@ -8,10 +8,13 @@ use constant HAP_BASE_UUID => '-0000-1000-8000-0026BB765291';
 # HAP Service Type UUIDs
 our %SERVICE_TYPES = (
 	'AccessoryInformation' => '0000003E-0000-1000-8000-0026BB765291',
+	'ProtocolInformation'  => '000000A2-0000-1000-8000-0026BB765291',
 	'Thermostat'           => '0000004A-0000-1000-8000-0026BB765291',
 	'Switch'               => '00000049-0000-1000-8000-0026BB765291',
 	'TemperatureSensor'    => '0000008A-0000-1000-8000-0026BB765291',
+	'HumiditySensor'       => '00000082-0000-1000-8000-0026BB765291',
 	'Outlet'               => '00000047-0000-1000-8000-0026BB765291',
+	'Lightbulb'            => '00000043-0000-1000-8000-0026BB765291',
 );
 
 # _uuid_to_short($uuid) - Convert full UUID to short form for JSON

--- a/lib/OpenHAP/Session.pm
+++ b/lib/OpenHAP/Session.pm
@@ -76,17 +76,21 @@ sub decrypt ( $self, $data )
 	my $decrypted = '';
 	my $pos       = 0;
 
-	# HAP decrypts data in frames
+	# HAP decrypts data in frames; a truncated frame or a frame
+	# claiming more than 1024 bytes of plaintext is an error
+	# (HAP-Encryption.md §9)
 	while ( $pos < length($data) ) {
 
 		# Read frame header (2-byte length)
-		last if $pos + 2 > length($data);
+		return if $pos + 2 > length($data);
 		my $length = unpack( 'v', substr( $data, $pos, 2 ) );
 		my $aad    = substr( $data, $pos, 2 );
 		$pos += 2;
 
+		return if $length > 1024;
+
 		# Read ciphertext + tag
-		last if $pos + $length + 16 > length($data);
+		return if $pos + $length + 16 > length($data);
 		my $ciphertext = substr( $data, $pos, $length );
 		$pos += $length;
 		my $tag = substr( $data, $pos, 16 );

--- a/lib/OpenHAP/Session.pod
+++ b/lib/OpenHAP/Session.pod
@@ -20,7 +20,9 @@ OpenHAP::Session - Encrypted session state for HAP connections
 
 This module manages the encrypted session state for HAP connections,
 including ChaCha20-Poly1305 encryption/decryption with proper nonce
-management and frame handling.
+management and frame handling. C<decrypt> returns undef on a failed
+authentication tag, a truncated frame, or a frame claiming more than
+1024 bytes of plaintext; the caller must close the connection.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Storage.pm
+++ b/lib/OpenHAP/Storage.pm
@@ -181,6 +181,26 @@ sub increment_config_number ($self)
 	return $num;
 }
 
+sub get_config_digest ($self)
+{
+	my $digest_file = "$self->{db_path}/config_digest";
+	if ( -f $digest_file ) {
+		my $digest = $self->_read_file($digest_file);
+		chomp $digest;
+		return $digest;
+	}
+
+	return;
+}
+
+sub save_config_digest ( $self, $digest )
+{
+	my $digest_file = "$self->{db_path}/config_digest";
+	$self->_write_file( $digest_file, "$digest\n", 0600 );
+
+	return;
+}
+
 sub get_auth_attempts ($self)
 {
 	my $attempts_file = "$self->{db_path}/auth_attempts";

--- a/lib/OpenHAP/Storage.pm
+++ b/lib/OpenHAP/Storage.pm
@@ -181,6 +181,26 @@ sub increment_config_number ($self)
 	return $num;
 }
 
+sub get_auth_attempts ($self)
+{
+	my $attempts_file = "$self->{db_path}/auth_attempts";
+	if ( -f $attempts_file ) {
+		my $num = $self->_read_file($attempts_file);
+		chomp $num;
+		return $num if $num =~ /^\d+$/;
+	}
+
+	return 0;
+}
+
+sub set_auth_attempts ( $self, $count )
+{
+	my $attempts_file = "$self->{db_path}/auth_attempts";
+	$self->_write_file( $attempts_file, "$count\n", 0600 );
+
+	return;
+}
+
 sub _read_file ( $self, $path )
 {
 	open my $fh, '<', $path or croak "Cannot open $path: $!";

--- a/lib/OpenHAP/Storage.pod
+++ b/lib/OpenHAP/Storage.pod
@@ -20,6 +20,8 @@ OpenHAP::Storage - Persistent storage for pairing data
 =head1 DESCRIPTION
 
 This module handles persistent storage of pairing data, accessory keys,
-and configuration state.
+and configuration state, including the failed pairing attempt counter
+(C<get_auth_attempts>/C<set_auth_attempts>) that must survive restarts
+per F<spec/HAP-Pairing.md> section 8.
 
 =cut

--- a/lib/OpenHAP/TLV.pm
+++ b/lib/OpenHAP/TLV.pm
@@ -45,15 +45,24 @@ sub encode_separator()
 	return pack( 'CC', kTLVType_Separator, 0 );
 }
 
+# decode($data) - Decode TLV8 buffer into a type => value hash
+# Consecutive records with the same type are concatenated (fragmentation).
+# Returns the empty list if the buffer is malformed: a truncated record
+# header or a length field pointing past the end of the buffer.
 sub decode ($data)
 {
 	my %items;
 	my $pos = 0;
 
 	while ( $pos < length($data) ) {
+
+		# Reject a truncated record header
+		return if $pos + 2 > length($data);
 		my ( $type, $len ) = unpack( 'CC', substr( $data, $pos, 2 ) );
 		$pos += 2;
 
+		# Reject a length running past the end of the buffer
+		return if $pos + $len > length($data);
 		my $value = substr( $data, $pos, $len );
 		$pos += $len;
 

--- a/lib/OpenHAP/TLV.pod
+++ b/lib/OpenHAP/TLV.pod
@@ -32,6 +32,9 @@ Values longer than 255 bytes are automatically split into chunks.
 Decodes TLV8 data into a hash of type => value pairs.
 Automatically concatenates chunks with the same type.
 
+Returns the empty list if the buffer is malformed: a truncated record
+header, or a length field pointing past the end of the buffer.
+
 =head1 SEE ALSO
 
 F<spec/HAP-TLV8.md>

--- a/lib/OpenHAP/Tasmota/Lightbulb.pm
+++ b/lib/OpenHAP/Tasmota/Lightbulb.pm
@@ -135,7 +135,7 @@ sub new ( $class, %args )
 			OpenHAP::Characteristic->new(
 				type   => 'ColorTemperature',
 				iid    => 15,
-				format => 'int',
+				format => 'uint32',
 				perms  => [ 'pr', 'pw', 'ev' ],
 				value  => \$self->{ct},
 				min    => 153,    # M4: Match Tasmota range

--- a/lib/OpenHAP/Test/Controller.pm
+++ b/lib/OpenHAP/Test/Controller.pm
@@ -40,7 +40,12 @@ sub new ( $class, %args )
 		port      => $args{port} // 51827,
 		pin       => $args{pin}  // '031-45-154',
 		transport => $args{transport},
-		timeout   => $args{timeout} // 5,
+
+		# Socket read timeout. The default suits fast in-process and
+		# native runs; integration tests against a real daemon under
+		# TCG emulation, where a single SRP modexp can take many
+		# seconds, raise it via OPENHAP_TEST_TIMEOUT.
+		timeout => $args{timeout} // $ENV{OPENHAP_TEST_TIMEOUT} // 5,
 
 		controller_id => $args{controller_id} // 'openhap-test-ctrl',
 

--- a/lib/OpenHAP/Test/Controller.pm
+++ b/lib/OpenHAP/Test/Controller.pm
@@ -1,0 +1,668 @@
+# ex:ts=8 sw=4:
+# $OpenBSD$
+#
+# Copyright (c) 2026 Dick Olsson <hi@ekkis.net>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use v5.36;
+
+package OpenHAP::Test::Controller;
+
+use IO::Socket::INET;
+use IO::Select;
+use OpenHAP::Crypto;
+use OpenHAP::TLV;
+use OpenHAP::Pairing;
+use OpenHAP::Test::Controller::SRP;
+
+# A minimal HomeKit controller for tests: completes pair-setup (SRP
+# M1-M6), pair-verify (X25519), and speaks the encrypted session
+# framing, against a live accessory over TCP or in-process through an
+# injected transport code ref.
+
+use constant MAX_FRAME => 1024;
+
+sub new ( $class, %args )
+{
+	my $self = bless {
+		host      => $args{host} // '127.0.0.1',
+		port      => $args{port} // 51827,
+		pin       => $args{pin}  // '031-45-154',
+		transport => $args{transport},
+		timeout   => $args{timeout} // 5,
+
+		controller_id => $args{controller_id} // 'openhap-test-ctrl',
+
+		# Controller long-term identity (generated once)
+		ltsk => undef,
+		ltpk => undef,
+
+		# Learned during pair-setup
+		accessory_ltpk => undef,
+		accessory_id   => undef,
+
+		# Session state after pair-verify
+		encrypted     => 0,
+		encrypt_key   => undef,
+		decrypt_key   => undef,
+		encrypt_count => 0,
+		decrypt_count => 0,
+
+		socket     => undef,
+		inbuf      => '',
+		last_error => undef,
+	}, $class;
+
+	( $self->{ltsk}, $self->{ltpk} ) =
+	    OpenHAP::Crypto::generate_keypair_ed25519();
+
+	return $self;
+}
+
+# $self->last_error():
+#	TLV error code (or message string) of the last failed exchange.
+sub last_error ($self)
+{
+	return $self->{last_error};
+}
+
+sub is_encrypted ($self)
+{
+	return $self->{encrypted};
+}
+
+# --- transport ---------------------------------------------------------
+
+sub _connect ($self)
+{
+	return 1 if $self->{transport} || $self->{socket};
+
+	my $socket = IO::Socket::INET->new(
+		PeerAddr => $self->{host},
+		PeerPort => $self->{port},
+		Proto    => 'tcp',
+		Timeout  => $self->{timeout},
+	);
+	unless ( defined $socket ) {
+		$self->{last_error} = "connect: $!";
+		return;
+	}
+
+	$self->{socket} = $socket;
+	return 1;
+}
+
+sub close ($self)
+{
+	if ( $self->{socket} ) {
+		$self->{socket}->close;
+		$self->{socket} = undef;
+	}
+	$self->{encrypted} = 0;
+	$self->{inbuf}     = '';
+	return 1;
+}
+
+# $self->_round_trip($request_bytes):
+#	Send raw bytes and return the raw response bytes (one HTTP
+#	response; encrypted responses are returned still encrypted).
+sub _round_trip ( $self, $request )
+{
+	if ( $self->{transport} ) {
+		return $self->{transport}->($request);
+	}
+
+	return unless $self->_connect;
+
+	my $socket = $self->{socket};
+	$socket->syswrite($request);
+
+	# Read until a full HTTP response is decodable from the buffer
+	my $select = IO::Select->new($socket);
+	my $raw    = '';
+	while (1) {
+		last unless $select->can_read( $self->{timeout} );
+		my $bytes = $socket->sysread( my $chunk, 65535 );
+		unless ($bytes) {
+			$self->{last_error} = 'connection closed';
+			last;
+		}
+		$raw .= $chunk;
+
+		my $plain =
+		      $self->{encrypted}
+		    ? $self->_decrypt_peek($raw)
+		    : $raw;
+		last if defined $plain && _message_complete($plain);
+	}
+
+	return $raw;
+}
+
+# _message_complete($text):
+#	True once $text holds a complete HTTP message (headers plus
+#	Content-Length bytes of body).
+sub _message_complete ($text)
+{
+	return unless $text =~ /\r\n\r\n/;
+	my ( $head, $body ) = split /\r\n\r\n/, $text, 2;
+	my ($length) = $head =~ /Content-Length:\s*(\d+)/i;
+	return 1 unless $length;
+	return length($body) >= $length;
+}
+
+# --- session framing (HAP-Encryption.md §2-§5) -------------------------
+
+sub _encrypt ( $self, $data )
+{
+	my $out = '';
+	while ( length($data) > 0 ) {
+		my $chunk = substr( $data, 0, MAX_FRAME, '' );
+		my $aad   = pack( 'v',      length($chunk) );
+		my $nonce = pack( 'x[4]Q<', $self->{encrypt_count}++ );
+		my ( $ciphertext, $tag ) =
+		    OpenHAP::Crypto::chacha20_poly1305_encrypt(
+			$self->{encrypt_key},
+			$nonce, $chunk, $aad );
+		$out .= $aad . $ciphertext . $tag;
+	}
+	return $out;
+}
+
+# _decrypt_peek($data):
+#	Decrypt without consuming the counter state (used while
+#	accumulating frames from the socket).
+sub _decrypt_peek ( $self, $data )
+{
+	my $count = $self->{decrypt_count};
+	my $plain = $self->_decrypt($data);
+	$self->{decrypt_count} = $count;
+	return $plain;
+}
+
+sub _decrypt ( $self, $data )
+{
+	my $out = '';
+	my $pos = 0;
+	while ( $pos < length($data) ) {
+		return if $pos + 2 > length($data);
+		my $length = unpack( 'v', substr( $data, $pos, 2 ) );
+		my $aad    = substr( $data, $pos, 2 );
+		$pos += 2;
+		return if $length > MAX_FRAME;
+		return if $pos + $length + 16 > length($data);
+		my $ciphertext = substr( $data, $pos, $length );
+		$pos += $length;
+		my $tag = substr( $data, $pos, 16 );
+		$pos += 16;
+
+		my $nonce = pack( 'x[4]Q<', $self->{decrypt_count}++ );
+		my $plain =
+		    OpenHAP::Crypto::chacha20_poly1305_decrypt(
+			$self->{decrypt_key}, $nonce, $ciphertext, $tag, $aad );
+		return unless defined $plain;
+		$out .= $plain;
+	}
+	return $out;
+}
+
+# --- HTTP --------------------------------------------------------------
+
+sub _build_request ( $self, $method, $path, $body = undef, $headers = {} )
+{
+	my $request = "$method $path HTTP/1.1\r\n";
+	$request .= "Host: $self->{host}:$self->{port}\r\n";
+	for my $name ( sort keys %$headers ) {
+		$request .= "$name: $headers->{$name}\r\n";
+	}
+	if ( defined $body ) {
+		$request .= 'Content-Length: ' . length($body) . "\r\n";
+	}
+	$request .= "\r\n";
+	$request .= $body if defined $body;
+	return $request;
+}
+
+sub _parse_response ( $self, $raw )
+{
+	unless ( defined $raw && length $raw ) {
+		$self->{last_error} = 'no response';
+		return;
+	}
+
+	my ( $head, $body ) = split /\r\n\r\n/, $raw, 2;
+	my ($status) = $head =~ m{^HTTP/1\.[01]\s+(\d+)};
+	unless ( defined $status ) {
+		$self->{last_error} = 'malformed response';
+		return;
+	}
+
+	my %headers;
+	for my $line ( split /\r\n/, $head ) {
+		$headers{ lc $1 } = $2 if $line =~ /^([^:]+):\s*(.*)$/;
+	}
+
+	return {
+		status  => $status,
+		headers => \%headers,
+		body    => $body // '',
+	};
+}
+
+# $self->request($method, $path, $body?, $headers?):
+#	Perform one HTTP request over the session (encrypted framing
+#	once pair-verify has completed). Returns a hash ref with
+#	status, headers and body, or undef on transport error.
+sub request ( $self, $method, $path, $body = undef, $headers = {} )
+{
+	my $raw = $self->_build_request( $method, $path, $body, $headers );
+	$raw = $self->_encrypt($raw) if $self->{encrypted};
+
+	my $response = $self->_round_trip($raw);
+	return unless defined $response && length $response;
+
+	if ( $self->{encrypted} ) {
+		$response = $self->_decrypt($response);
+		unless ( defined $response ) {
+			$self->{last_error} = 'response decryption failed';
+			return;
+		}
+	}
+
+	# Keep anything beyond the first complete message (e.g. an event
+	# that arrived back-to-back with the response) for next_event
+	if ( $response =~ /\A(.*?\r\n\r\n)(.*)\z/s ) {
+		my ( $head, $rest ) = ( $1, $2 );
+		my ($length) = $head =~ /Content-Length:\s*(\d+)/i;
+		$length //= 0;
+		my $body = substr( $rest, 0, $length );
+		$self->{inbuf} .= substr( $rest, $length );
+		$response = $head . $body;
+	}
+
+	return $self->_parse_response($response);
+}
+
+# --- pairing ------------------------------------------------------------
+
+sub _tlv_request ( $self, $path, %tlv_items )
+{
+	my $body     = OpenHAP::TLV::encode(%tlv_items);
+	my $response = $self->request( 'POST', $path, $body,
+		{ 'Content-Type' => 'application/pairing+tlv8' } );
+	return unless defined $response;
+
+	unless ( $response->{status} == 200 ) {
+		$self->{last_error} = "HTTP $response->{status}";
+		return;
+	}
+
+	my %tlv   = OpenHAP::TLV::decode( $response->{body} );
+	my $error = $tlv{ OpenHAP::Pairing::kTLVType_Error() };
+	if ( defined $error ) {
+		$self->{last_error} = unpack( 'C', $error );
+		return;
+	}
+
+	return \%tlv;
+}
+
+# $self->pair_setup():
+#	Complete SRP pair-setup M1-M6. On success the accessory LTPK is
+#	stored and true is returned; on any protocol error undef is
+#	returned with the TLV error code in last_error.
+sub pair_setup ($self)
+{
+	$self->{last_error} = undef;
+
+	# M1 -> M2
+	my $m2 = $self->_tlv_request(
+		'/pair-setup',
+		OpenHAP::Pairing::kTLVType_State()  => pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method() => pack( 'C', 0 ),
+	) or return;
+
+	my $salt = $m2->{ OpenHAP::Pairing::kTLVType_Salt() };
+	my $B    = $m2->{ OpenHAP::Pairing::kTLVType_PublicKey() };
+	unless ( defined $salt && defined $B ) {
+		$self->{last_error} = 'M2 missing salt or public key';
+		return;
+	}
+
+	# M3 -> M4
+	my $srp =
+	    OpenHAP::Test::Controller::SRP->new( password => $self->{pin} );
+	my $A  = $srp->compute_public;
+	my $M1 = $srp->compute_proof( $salt, $B );
+	unless ( defined $M1 ) {
+		$self->{last_error} = 'bogus server public key';
+		return;
+	}
+
+	my $m4 = $self->_tlv_request(
+		'/pair-setup',
+		OpenHAP::Pairing::kTLVType_State()     => pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_PublicKey() => $A,
+		OpenHAP::Pairing::kTLVType_Proof()     => $M1,
+	) or return;
+
+	my $M2 = $m4->{ OpenHAP::Pairing::kTLVType_Proof() };
+	unless ( $srp->verify_server_proof($M2) ) {
+		$self->{last_error} = 'server proof verification failed';
+		return;
+	}
+
+	# M5 -> M6
+	my $K           = $srp->session_key;
+	my $encrypt_key = OpenHAP::Crypto::hkdf_sha512( $K,
+		'Pair-Setup-Encrypt-Salt', 'Pair-Setup-Encrypt-Info', 32 );
+
+	my $ios_x = OpenHAP::Crypto::hkdf_sha512(
+		$K,
+		'Pair-Setup-Controller-Sign-Salt',
+		'Pair-Setup-Controller-Sign-Info', 32
+	);
+	my $signature = OpenHAP::Crypto::sign_ed25519(
+		$ios_x . $self->{controller_id} . $self->{ltpk},
+		$self->{ltsk}, $self->{ltpk} );
+
+	my $inner = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_Identifier() =>
+		    $self->{controller_id},
+		OpenHAP::Pairing::kTLVType_PublicKey() => $self->{ltpk},
+		OpenHAP::Pairing::kTLVType_Signature() => $signature,
+	);
+	my ( $encrypted, $tag ) =
+	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $encrypt_key,
+		pack('x[4]') . 'PS-Msg05', $inner );
+
+	my $m6 = $self->_tlv_request(
+		'/pair-setup',
+		OpenHAP::Pairing::kTLVType_State()         => pack( 'C', 5 ),
+		OpenHAP::Pairing::kTLVType_EncryptedData() => $encrypted . $tag,
+	) or return;
+
+	my $m6_data = $m6->{ OpenHAP::Pairing::kTLVType_EncryptedData() };
+	unless ( defined $m6_data && length($m6_data) > 16 ) {
+		$self->{last_error} = 'M6 missing encrypted data';
+		return;
+	}
+	my $m6_tag = substr( $m6_data, -16, 16, '' );
+	my $m6_plain =
+	    OpenHAP::Crypto::chacha20_poly1305_decrypt( $encrypt_key,
+		pack('x[4]') . 'PS-Msg06',
+		$m6_data, $m6_tag );
+	unless ( defined $m6_plain ) {
+		$self->{last_error} = 'M6 decryption failed';
+		return;
+	}
+
+	my %m6_inner = OpenHAP::TLV::decode($m6_plain);
+	my $acc_id   = $m6_inner{ OpenHAP::Pairing::kTLVType_Identifier() };
+	my $acc_ltpk = $m6_inner{ OpenHAP::Pairing::kTLVType_PublicKey() };
+	my $acc_sig  = $m6_inner{ OpenHAP::Pairing::kTLVType_Signature() };
+
+	my $acc_x = OpenHAP::Crypto::hkdf_sha512(
+		$K,
+		'Pair-Setup-Accessory-Sign-Salt',
+		'Pair-Setup-Accessory-Sign-Info', 32
+	);
+	unless (
+		OpenHAP::Crypto::verify_ed25519(
+			$acc_sig, $acc_x . $acc_id . $acc_ltpk, $acc_ltpk
+		) )
+	{
+		$self->{last_error} = 'accessory signature invalid';
+		return;
+	}
+
+	$self->{accessory_ltpk} = $acc_ltpk;
+	$self->{accessory_id}   = $acc_id;
+
+	return 1;
+}
+
+# $self->pair_verify():
+#	Complete pair-verify M1-M4 and switch the connection to
+#	encrypted session framing. Requires a completed pair_setup (or
+#	an accessory_ltpk supplied by the caller).
+sub pair_verify ($self)
+{
+	$self->{last_error} = undef;
+
+	my ( $secret, $public ) = OpenHAP::Crypto::generate_keypair_x25519();
+
+	# M1 -> M2
+	my $m2 = $self->_tlv_request(
+		'/pair-verify',
+		OpenHAP::Pairing::kTLVType_State()     => pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_PublicKey() => $public,
+	) or return;
+
+	my $acc_public = $m2->{ OpenHAP::Pairing::kTLVType_PublicKey() };
+	my $m2_data    = $m2->{ OpenHAP::Pairing::kTLVType_EncryptedData() };
+	unless ( defined $acc_public && defined $m2_data ) {
+		$self->{last_error} = 'M2 missing public key or data';
+		return;
+	}
+
+	my $shared =
+	    OpenHAP::Crypto::derive_shared_secret( $secret, $acc_public );
+	my $pv_key = OpenHAP::Crypto::hkdf_sha512( $shared,
+		'Pair-Verify-Encrypt-Salt', 'Pair-Verify-Encrypt-Info', 32 );
+
+	my $m2_tag = substr( $m2_data, -16, 16, '' );
+	my $m2_plain =
+	    OpenHAP::Crypto::chacha20_poly1305_decrypt( $pv_key,
+		pack('x[4]') . 'PV-Msg02',
+		$m2_data, $m2_tag );
+	unless ( defined $m2_plain ) {
+		$self->{last_error} = 'M2 decryption failed';
+		return;
+	}
+
+	my %m2_inner = OpenHAP::TLV::decode($m2_plain);
+	my $acc_id   = $m2_inner{ OpenHAP::Pairing::kTLVType_Identifier() };
+	my $acc_sig  = $m2_inner{ OpenHAP::Pairing::kTLVType_Signature() };
+
+	# Verify the accessory signature when we know its LTPK
+	if ( defined $self->{accessory_ltpk} ) {
+		unless (
+			OpenHAP::Crypto::verify_ed25519(
+				$acc_sig,
+				$acc_public . $acc_id . $public,
+				$self->{accessory_ltpk} ) )
+		{
+			$self->{last_error} = 'accessory signature invalid';
+			return;
+		}
+	}
+
+	# M3 -> M4
+	my $signature = OpenHAP::Crypto::sign_ed25519(
+		$public . $self->{controller_id} . $acc_public,
+		$self->{ltsk}, $self->{ltpk} );
+	my $inner = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_Identifier() =>
+		    $self->{controller_id},
+		OpenHAP::Pairing::kTLVType_Signature() => $signature,
+	);
+	my ( $encrypted, $tag ) =
+	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $pv_key,
+		pack('x[4]') . 'PV-Msg03', $inner );
+
+	$self->_tlv_request(
+		'/pair-verify',
+		OpenHAP::Pairing::kTLVType_State()         => pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_EncryptedData() => $encrypted . $tag,
+	) or return;
+
+	# Session keys: the controller writes with the Write key and
+	# reads with the Read key (HAP-Encryption.md §1)
+	$self->{encrypt_key} =
+	    OpenHAP::Crypto::hkdf_sha512( $shared, 'Control-Salt',
+		'Control-Write-Encryption-Key', 32 );
+	$self->{decrypt_key} =
+	    OpenHAP::Crypto::hkdf_sha512( $shared, 'Control-Salt',
+		'Control-Read-Encryption-Key', 32 );
+	$self->{encrypt_count} = 0;
+	$self->{decrypt_count} = 0;
+	$self->{encrypted}     = 1;
+
+	return 1;
+}
+
+# --- pairings management (HAP-Pairing.md §7) ----------------------------
+
+sub add_pairing ( $self, $identifier, $ltpk, $permissions = 0 )
+{
+	$self->{last_error} = undef;
+
+	my $result = $self->_tlv_request(
+		'/pairings',
+		OpenHAP::Pairing::kTLVType_State()       => pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method()      => pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_Identifier()  => $identifier,
+		OpenHAP::Pairing::kTLVType_PublicKey()   => $ltpk,
+		OpenHAP::Pairing::kTLVType_Permissions() =>
+		    pack( 'C', $permissions ),
+	) or return;
+
+	return 1;
+}
+
+sub remove_pairing ( $self, $identifier = undef )
+{
+	$self->{last_error} = undef;
+	$identifier //= $self->{controller_id};
+
+	my $result = $self->_tlv_request(
+		'/pairings',
+		OpenHAP::Pairing::kTLVType_State()      => pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method()     => pack( 'C', 4 ),
+		OpenHAP::Pairing::kTLVType_Identifier() => $identifier,
+	) or return;
+
+	return 1;
+}
+
+sub list_pairings ($self)
+{
+	$self->{last_error} = undef;
+
+	my $body = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State()  => pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method() => pack( 'C', 5 ),
+	);
+	my $response = $self->request( 'POST', '/pairings', $body,
+		{ 'Content-Type' => 'application/pairing+tlv8' } );
+	return unless defined $response;
+
+	unless ( $response->{status} == 200 ) {
+		$self->{last_error} = "HTTP $response->{status}";
+		return;
+	}
+
+	# Split entries on the zero-length separator; TLV::decode would
+	# concatenate the repeated Identifier/PublicKey types
+	my @pairings;
+	for my $entry ( split /\xFF\x00/, $response->{body} ) {
+		my %tlv = OpenHAP::TLV::decode($entry);
+		my $id  = $tlv{ OpenHAP::Pairing::kTLVType_Identifier() };
+		next unless defined $id;
+
+		my $error = $tlv{ OpenHAP::Pairing::kTLVType_Error() };
+		if ( defined $error ) {
+			$self->{last_error} = unpack( 'C', $error );
+			return;
+		}
+
+		push @pairings,
+		    {
+			identifier => $id,
+			ltpk => $tlv{ OpenHAP::Pairing::kTLVType_PublicKey() },
+			permissions => unpack(
+				'C',
+				$tlv{
+					OpenHAP::Pairing::kTLVType_Permissions(
+					)
+				} // "\x00"
+			),
+		    };
+	}
+
+	# A lone error TLV (no identifiers) means the request failed
+	if ( !@pairings ) {
+		my %tlv   = OpenHAP::TLV::decode( $response->{body} );
+		my $error = $tlv{ OpenHAP::Pairing::kTLVType_Error() };
+		if ( defined $error ) {
+			$self->{last_error} = unpack( 'C', $error );
+			return;
+		}
+	}
+
+	return \@pairings;
+}
+
+# --- events -------------------------------------------------------------
+
+# $self->next_event($timeout):
+#	Wait for an EVENT/1.0 message on the socket, decrypt and parse
+#	it. Returns { status, headers, body } or undef on timeout.
+#	Requires a socket connection (not an injected transport).
+sub next_event ( $self, $timeout = 5 )
+{
+	return unless $self->{socket};
+
+	my $select = IO::Select->new( $self->{socket} );
+	my $end    = time + $timeout;
+
+	while (1) {
+
+		# A complete event may already be buffered
+		if ( $self->{inbuf} =~ s{\A(EVENT/1\.0.*?\r\n\r\n)}{}s ) {
+			my $head = $1;
+			my ($length) = $head =~ /Content-Length:\s*(\d+)/i;
+			$length //= 0;
+			my $body = substr( $self->{inbuf}, 0, $length, '' );
+
+			my %headers;
+			for my $line ( split /\r\n/, $head ) {
+				$headers{ lc $1 } = $2
+				    if $line =~ /^([^:]+):\s*(.*)$/;
+			}
+			my ($status) = $head =~ m{^EVENT/1\.0\s+(\d+)};
+
+			return {
+				status  => $status,
+				headers => \%headers,
+				body    => $body,
+			};
+		}
+
+		my $remaining = $end - time;
+		return if $remaining <= 0;
+		next unless $select->can_read($remaining);
+
+		my $bytes = $self->{socket}->sysread( my $chunk, 65535 );
+		return unless $bytes;
+
+		my $plain =
+		    $self->{encrypted} ? $self->_decrypt($chunk) : $chunk;
+		return unless defined $plain;
+		$self->{inbuf} .= $plain;
+	}
+}
+
+1;

--- a/lib/OpenHAP/Test/Controller.pod
+++ b/lib/OpenHAP/Test/Controller.pod
@@ -1,0 +1,115 @@
+=head1 NAME
+
+OpenHAP::Test::Controller - minimal HomeKit controller for tests
+
+=head1 SYNOPSIS
+
+    use OpenHAP::Test::Controller;
+
+    my $c = OpenHAP::Test::Controller->new(
+        host => '127.0.0.1',
+        port => 51827,
+        pin  => '031-45-154',
+    );
+
+    $c->pair_setup  or die 'pair-setup failed: ' . $c->last_error;
+    $c->pair_verify or die 'pair-verify failed: ' . $c->last_error;
+
+    my $res = $c->request('GET', '/accessories');
+    my $put = $c->request('PUT', '/characteristics',
+        '{"characteristics":[{"aid":2,"iid":11,"value":true}]}',
+        { 'Content-Type' => 'application/hap+json' });
+
+    my $event = $c->next_event(5);
+
+    $c->remove_pairing;    # cleanup for test teardown
+
+=head1 DESCRIPTION
+
+A minimal HomeKit controller used by conformance and integration
+tests. It completes SRP-6a pair-setup (M1-M6), X25519 pair-verify, and
+speaks the ChaCha20-Poly1305 session framing, either over TCP against
+a live accessory or in-process through an injected transport.
+
+The controller follows the repository error convention: methods return
+undef (bare return) on protocol or transport errors, recording the TLV
+error code (or a message string) in C<last_error>; they die only on
+programming errors.
+
+=head1 METHODS
+
+=head2 new(%args)
+
+Create a controller. Arguments: C<host> (default 127.0.0.1), C<port>
+(default 51827), C<pin> (setup code, default 031-45-154),
+C<controller_id> (pairing identifier, default openhap-test-ctrl),
+C<timeout> (socket timeout in seconds, default 5), and C<transport>.
+
+C<transport>, when given, is a code ref C<($request_bytes) ->
+$response_bytes> replacing the TCP socket; this enables in-process use
+against an OpenHAP::HAP instance without sockets. Request and response
+bytes are pre-encryption/post-encryption wire bytes.
+
+An Ed25519 controller identity is generated once per controller.
+
+=head2 pair_setup()
+
+Complete pair-setup M1-M6 with the configured PIN. On success the
+accessory LTPK and pairing identifier are stored on the controller and
+true is returned.
+
+=head2 pair_verify()
+
+Complete pair-verify M1-M4 and switch the connection to encrypted
+session framing. When the accessory LTPK is known from a prior
+C<pair_setup>, the accessory signature in M2 is verified against it.
+
+=head2 request($method, $path, $body?, $headers?)
+
+Perform one HTTP request over the session, encrypted once pair-verify
+has completed. Returns a hash ref with C<status>, C<headers> (lower
+cased names) and C<body>.
+
+=head2 next_event($timeout)
+
+Wait up to $timeout seconds for an EVENT/1.0 message, decrypt and
+parse it. Returns a hash ref with C<status>, C<headers> and C<body>,
+or undef on timeout. Requires a socket connection.
+
+=head2 add_pairing($identifier, $ltpk, $permissions)
+
+Add a pairing over POST /pairings (method AddPairing).
+
+=head2 remove_pairing($identifier?)
+
+Remove a pairing (default: this controller's own).
+
+=head2 list_pairings()
+
+Return an array ref of hashes with C<identifier>, C<ltpk> and
+C<permissions>.
+
+=head2 last_error()
+
+The TLV error code (numeric) or message string of the last failure.
+
+=head2 is_encrypted()
+
+True once pair-verify has switched the session to encrypted framing.
+
+=head2 close()
+
+Close the socket connection and reset session state.
+
+=head1 ENVIRONMENT
+
+Test-only namespace: not part of the production daemon and never a
+dependency of production modules. Ships to the integration VM together
+with the integration tests.
+
+=head1 SEE ALSO
+
+L<OpenHAP::Test::Controller::SRP>, L<OpenHAP::Test::Integration>,
+F<spec/HAP-Pairing.md>, F<spec/HAP-Encryption.md>
+
+=cut

--- a/lib/OpenHAP/Test/Controller/SRP.pm
+++ b/lib/OpenHAP/Test/Controller/SRP.pm
@@ -1,0 +1,144 @@
+# ex:ts=8 sw=4:
+# $OpenBSD$
+#
+# Copyright (c) 2026 Dick Olsson <hi@ekkis.net>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use v5.36;
+
+package OpenHAP::Test::Controller::SRP;
+
+use Math::BigInt;
+use Digest::SHA qw(sha512);
+use OpenHAP::Crypto;
+use OpenHAP::PIN qw(normalize_pin);
+
+# SRP-6a client role for tests (HAP-Pairing.md §2.5): the controller
+# side of the exchange OpenHAP::SRP serves. Same 3072-bit RFC 5054
+# group, SHA-512 hash, and 384-byte padding rules as the server.
+
+use constant N_LEN => 384;
+
+sub _b2i ($bytes)
+{
+	return Math::BigInt->from_hex( unpack( 'H*', $bytes ) );
+}
+
+sub _i2b ( $int, $length = undef )
+{
+	my $hex = $int->as_hex();
+	$hex =~ s/^0x//;
+	$hex = '0' . $hex if length($hex) % 2;
+	my $bytes = pack( 'H*', $hex );
+	if ( defined $length && length($bytes) < $length ) {
+		$bytes = ( "\x00" x ( $length - length($bytes) ) ) . $bytes;
+	}
+	return $bytes;
+}
+
+sub new ( $class, %args )
+{
+	my $password = normalize_pin( $args{password} ) // $args{password};
+
+	my $self = bless {
+		username => $args{username} // 'Pair-Setup',
+		password => $password,
+
+		N => _b2i($OpenHAP::Crypto::N_3072),
+		g => Math::BigInt->new(5),
+
+		a  => undef,
+		A  => undef,
+		K  => undef,
+		M1 => undef,
+	}, $class;
+
+	return $self;
+}
+
+# $self->compute_public():
+#	Generate the ephemeral secret a and return the padded public
+#	value A = g^a mod N (384 bytes).
+sub compute_public ($self)
+{
+	my $a_bytes = OpenHAP::Crypto::generate_random_bytes(32);
+	$self->{a} = _b2i($a_bytes);
+	$self->{A} = $self->{g}->copy->bmodpow( $self->{a}, $self->{N} );
+
+	return _i2b( $self->{A}, N_LEN );
+}
+
+# $self->compute_proof($salt, $B_bytes):
+#	Complete the client side with the server's salt and public key
+#	B: derive the session key K and return the client proof M1.
+#	Returns undef if B mod N == 0 (bogus server value).
+sub compute_proof ( $self, $salt, $B_bytes )
+{
+	die 'SRP: compute_public not called' unless defined $self->{A};
+
+	my $N = $self->{N};
+	my $g = $self->{g};
+	my $B = _b2i($B_bytes);
+
+	return if ( $B % $N )->is_zero();
+
+	# u = H(PAD(A) | PAD(B))
+	my $u =
+	    _b2i( sha512( _i2b( $self->{A}, N_LEN ) . _i2b( $B, N_LEN ) ) );
+
+	# x = H(s | H(I ":" P)), k = H(N | PAD(g))
+	my $x = _b2i(
+		sha512( $salt . sha512("$self->{username}:$self->{password}") )
+	);
+	my $k = _b2i( sha512( _i2b($N) . _i2b( $g, N_LEN ) ) );
+
+	# S = (B - k*g^x)^(a + u*x) mod N
+	my $gx   = $g->copy->bmodpow( $x, $N );
+	my $base = ( $B - ( $k * $gx ) ) % $N;
+	my $S    = $base->bmodpow( $self->{a} + $u * $x, $N );
+
+	$self->{K} = sha512( _i2b($S) );
+
+	# M1 = H(H(N) xor H(g) | H(I) | s | PAD(A) | PAD(B) | K)
+	$self->{M1} =
+	    sha512( ( sha512( _i2b($N) ) ^. sha512( _i2b($g) ) )
+		. sha512( $self->{username} )
+		    . $salt
+		    . _i2b( $self->{A}, N_LEN )
+		    . _i2b( $B,         N_LEN )
+		    . $self->{K} );
+
+	return $self->{M1};
+}
+
+# $self->verify_server_proof($M2):
+#	Check the server proof M2 = H(PAD(A) | M1 | K).
+sub verify_server_proof ( $self, $M2 )
+{
+	die 'SRP: compute_proof not called' unless defined $self->{M1};
+
+	my $expected =
+	    sha512( _i2b( $self->{A}, N_LEN ) . $self->{M1} . $self->{K} );
+
+	return $expected eq ( $M2 // '' );
+}
+
+# $self->session_key():
+#	Return the shared session key K (64 bytes).
+sub session_key ($self)
+{
+	return $self->{K};
+}
+
+1;

--- a/lib/OpenHAP/Test/Controller/SRP.pm
+++ b/lib/OpenHAP/Test/Controller/SRP.pm
@@ -19,7 +19,10 @@ use v5.36;
 
 package OpenHAP::Test::Controller::SRP;
 
-use Math::BigInt;
+# Match the server: prefer the GMP backend so the controller's own
+# 3072-bit modexp is not the bottleneck when it runs inside the slow
+# emulated test guest. Falls back to pure-Perl Calc when GMP is absent.
+use Math::BigInt try => 'GMP';
 use Digest::SHA qw(sha512);
 use OpenHAP::Crypto;
 use OpenHAP::PIN qw(normalize_pin);

--- a/lib/OpenHAP/Test/Controller/SRP.pod
+++ b/lib/OpenHAP/Test/Controller/SRP.pod
@@ -1,0 +1,55 @@
+=head1 NAME
+
+OpenHAP::Test::Controller::SRP - SRP-6a client role for tests
+
+=head1 SYNOPSIS
+
+    use OpenHAP::Test::Controller::SRP;
+
+    my $srp = OpenHAP::Test::Controller::SRP->new(
+        password => '031-45-154');
+
+    my $A  = $srp->compute_public;              # 384 bytes, send in M3
+    my $M1 = $srp->compute_proof($salt, $B);    # from the server's M2
+    my $K  = $srp->session_key;                 # 64 bytes shared key
+
+    $srp->verify_server_proof($M2) or die 'server proof invalid';
+
+=head1 DESCRIPTION
+
+The client (controller) role of the SRP-6a exchange served by
+L<OpenHAP::SRP>: the same RFC 5054 3072-bit group, g = 5, SHA-512
+hash, fixed username C<Pair-Setup>, and 384-byte padding rules
+(F<spec/HAP-Pairing.md> section 2). The setup code is normalized like
+the server side (dashes and spaces stripped).
+
+=head1 METHODS
+
+=head2 new(%args)
+
+C<password> is the 8-digit setup code; C<username> defaults to
+C<Pair-Setup>.
+
+=head2 compute_public()
+
+Generate the ephemeral secret and return the padded 384-byte public
+value A.
+
+=head2 compute_proof($salt, $B_bytes)
+
+Derive the session key from the server's salt and public key B, and
+return the client proof M1. Returns undef if B mod N == 0.
+
+=head2 verify_server_proof($M2)
+
+True iff $M2 equals H(PAD(A) | M1 | K).
+
+=head2 session_key()
+
+The 64-byte shared session key K, available after C<compute_proof>.
+
+=head1 SEE ALSO
+
+L<OpenHAP::Test::Controller>, L<OpenHAP::SRP>, F<spec/HAP-Pairing.md>
+
+=cut

--- a/lib/OpenHAP/Test/Integration.pm
+++ b/lib/OpenHAP/Test/Integration.pm
@@ -23,6 +23,8 @@ use Exporter 'import';
 use IO::Socket::INET;
 use Time::HiRes qw(sleep);
 
+use FuguLib::Log;
+
 our @EXPORT_OK = qw(
     setup teardown
     http_request parse_http_response
@@ -65,6 +67,16 @@ sub setup ($self)
 	# Verify we're in integration test mode
 	die "OPENHAP_INTEGRATION_TEST not set\n"
 	    unless $ENV{OPENHAP_INTEGRATION_TEST};
+
+	# The controller drives the accessory's own crypto/pairing library
+	# code in this process, which logs through the $OpenHAP::logger the
+	# daemon normally installs. Give it a quiet logger so those calls
+	# do not die on an undefined logger, matching how the unit tests
+	# set one up per file.
+	$OpenHAP::logger //= FuguLib::Log->new(
+		mode  => 'quiet',
+		ident => 'openhap-integration'
+	);
 
 	# Verify system prerequisites
 	$self->_verify_system or die "System prerequisites not met\n";

--- a/lib/OpenHAP/Test/Integration.pm
+++ b/lib/OpenHAP/Test/Integration.pm
@@ -27,6 +27,7 @@ our @EXPORT_OK = qw(
     setup teardown
     http_request parse_http_response
     get_config_value get_device_topics
+    get_controller ensure_unpaired
     clear_logs get_log_lines
     ensure_daemon_running ensure_daemon_stopped
     ensure_mqtt_running
@@ -35,10 +36,12 @@ our @EXPORT_OK = qw(
 use constant {
 	DEFAULT_CONFIG    => '/etc/openhapd.conf',
 	DEFAULT_HAP_PORT  => 51827,
+	DEFAULT_HAP_PIN   => '1995-1018',
 	DEFAULT_MQTT_HOST => '127.0.0.1',
 	DEFAULT_MQTT_PORT => 1883,
 	SYSLOG_FILE       => '/var/log/daemon',
 	PIDFILE           => '/var/run/openhapd.pid',
+	DB_PATH           => '/var/db/openhapd',
 };
 
 sub new ( $class, %options )
@@ -50,6 +53,7 @@ sub new ( $class, %options )
 		mqtt_port    => $options{mqtt_port}   // DEFAULT_MQTT_PORT,
 		log_baseline => 0,
 		sockets      => [],
+		controllers  => [],
 		mqtt         => undef,
 	}, $class;
 
@@ -79,6 +83,12 @@ sub setup ($self)
 
 sub teardown ($self)
 {
+	# Close any controller connections
+	for my $controller ( @{ $self->{controllers} } ) {
+		$controller->close if defined $controller;
+	}
+	$self->{controllers} = [];
+
 	# Close any open sockets
 	for my $socket ( @{ $self->{sockets} } ) {
 		$socket->close if defined $socket;
@@ -89,6 +99,45 @@ sub teardown ($self)
 	if ( defined $self->{mqtt} ) {
 		eval { undef $self->{mqtt}; };
 	}
+
+	return 1;
+}
+
+# $self->get_controller(%args):
+#	Construct an OpenHAP::Test::Controller for the configured
+#	host/port/PIN. The connection is tracked and closed in teardown.
+sub get_controller ( $self, %args )
+{
+	require OpenHAP::Test::Controller;
+
+	my $controller = OpenHAP::Test::Controller->new(
+		host => '127.0.0.1',
+		port => $self->{hap_port},
+		pin  => $self->get_config_value('hap_pin') // DEFAULT_HAP_PIN,
+		%args,
+	);
+
+	push @{ $self->{controllers} }, $controller;
+
+	return $controller;
+}
+
+# $self->ensure_unpaired():
+#	Guarantee the daemon starts unpaired: when stored pairings
+#	exist, stop the daemon, wipe the pairing state (keeping the
+#	accessory identity), and start it again.
+sub ensure_unpaired ($self)
+{
+	my $pairings_file = DB_PATH . '/pairings';
+	return 1 unless -s $pairings_file;
+
+	$self->ensure_daemon_stopped or return;
+
+	unlink $pairings_file
+	    or do { warn "Cannot remove $pairings_file: $!\n"; return; };
+	unlink DB_PATH . '/auth_attempts';
+
+	$self->ensure_daemon_running or return;
 
 	return 1;
 }
@@ -167,6 +216,14 @@ sub get_config_value ( $self, $key )
 sub get_device_topics ($self)
 {
 	return @{ $self->{device_topics} // [] };
+}
+
+# $self->get_devices():
+#	Return the configured device records as a list of hashes with
+#	type, subtype, id, name, and topic.
+sub get_devices ($self)
+{
+	return @{ $self->{devices} // [] };
 }
 
 sub ensure_daemon_running ($self)
@@ -281,38 +338,52 @@ sub _parse_config ($self)
 
 	my %config;
 	my @device_topics;
-	my $in_device = 0;
+	my @devices;
+	my $device;
 
 	while (<$fh>) {
 
 		# Skip comments and empty lines
 		next if /^\s*#/ || /^\s*$/;
 
+		# Device blocks: device <type> <subtype> <id> {
+		if (/^\s*device\s+(\w+)\s+(\w+)\s+(\w+)/) {
+			$device = {
+				type    => $1,
+				subtype => $2,
+				id      => $3,
+			};
+			next;
+		}
+		if (/^\s*\}/) {
+			push @devices, $device if defined $device;
+			$device = undef;
+			next;
+		}
+
 		# Simple key = value
 		if (/^\s*(\w+)\s*=\s*(.+)/) {
 			my ( $key, $value ) = ( $1, $2 );
 			$value =~ s/^"(.*)"$/$1/;    # Remove quotes
+
+			if ( defined $device ) {
+				$device->{$key} = $value;
+				push @device_topics, $value
+				    if $key eq 'topic';
+				next;
+			}
+
 			$config{$key} = $value;
 
 			# Update hap_port if configured
 			$self->{hap_port} = $value if $key eq 'hap_port';
-		}
-
-		# Device blocks
-		if (/^\s*device\s+/) {
-			$in_device = 1;
-		}
-		elsif ( $in_device && /^\s*topic\s*=\s*(\S+)/ ) {
-			push @device_topics, $1;
-		}
-		elsif (/^\s*\}/) {
-			$in_device = 0;
 		}
 	}
 	close $fh;
 
 	$self->{config}        = \%config;
 	$self->{device_topics} = \@device_topics;
+	$self->{devices}       = \@devices;
 
 	return 1;
 }

--- a/lib/OpenHAP/Test/Integration.pod
+++ b/lib/OpenHAP/Test/Integration.pod
@@ -76,7 +76,27 @@ Validate environment and prepare for testing. Dies if environment is not ready.
 
     $env->teardown;
 
-Clean up resources after testing.
+Clean up resources after testing, including any controller connections
+handed out by C<get_controller>.
+
+=head2 get_controller
+
+    my $c = $env->get_controller;
+    $c->pair_setup or die 'pair-setup: ' . $c->last_error;
+
+Construct an L<OpenHAP::Test::Controller> for the configured host,
+port, and setup code (read from the C<hap_pin> configuration key). The
+connection is tracked and closed in C<teardown>. Extra arguments are
+passed through to the controller constructor.
+
+=head2 ensure_unpaired
+
+    $env->ensure_unpaired or die 'cannot unpair';
+
+Guarantee the daemon starts unpaired. When stored pairings exist, the
+daemon is stopped, the pairing state under /var/db/openhapd is wiped
+(the accessory identity is kept), and the daemon is started again.
+Every integration test file starts unpaired unless it pairs itself.
 
 =head2 http_request
 
@@ -102,6 +122,13 @@ Get a configuration value.
     my @topics = $env->get_device_topics;
 
 Get all device MQTT topics.
+
+=head2 get_devices
+
+    my ($light) = grep { $_->{subtype} eq 'lightbulb' } $env->get_devices;
+
+Get the configured device records: hashes with C<type>, C<subtype>,
+C<id>, C<name>, and C<topic>.
 
 =head2 ensure_daemon_running
 

--- a/lib/OpenHVF/CLI.pm
+++ b/lib/OpenHVF/CLI.pm
@@ -75,7 +75,8 @@ sub new ( $class, %opts )
 	my $self = bless {
 		vm_name => $opts{vm} // 'default',
 		project => $opts{project},
-		quiet   => $opts{quiet} // 0,
+		quiet   => $opts{quiet}   // 0,
+		emulate => $opts{emulate} // 0,
 		log     => $log,
 	}, $class;
 
@@ -131,7 +132,7 @@ sub run ( $class, @argv )
 		$self->{config} = OpenHVF::Config->new($project_root);
 		$self->{state} =
 		    OpenHVF::State->new( $self->{config}->state_dir,
-			$self->{vm_name}, emulate => $opts{emulate} // 0, );
+			$self->{vm_name} );
 		if ( !defined $self->{state} ) {
 			$self->{log}->error(
 "Cannot initialize state for VM '$self->{vm_name}'"
@@ -152,9 +153,10 @@ sub _load_vm ($self)
 	}
 
 	return OpenHVF::VM->new(
-		config => $vm_config,
-		state  => $self->{state},
-		log    => $self->{log},
+		config  => $vm_config,
+		state   => $self->{state},
+		log     => $self->{log},
+		emulate => $self->{emulate},
 	);
 }
 

--- a/lib/OpenHVF/CLI.pm
+++ b/lib/OpenHVF/CLI.pm
@@ -221,9 +221,11 @@ sub cmd_ssh ( $self, @args )
 {
 	my $vm = $self->_load_vm or return EXIT_VM_NOT_FOUND;
 
-	# Uses SSH agent for authentication
+	# Uses SSH agent for authentication. Connect over IPv4: QEMU
+	# forwards the guest SSH port on 127.0.0.1 only, but 'localhost'
+	# resolves to ::1 first on dual-stack hosts (e.g. CI runners).
 	my $ssh = OpenHVF::SSH->new(
-		host => 'localhost',
+		host => '127.0.0.1',
 		port => $vm->ssh_port,
 		user => 'root',
 	);

--- a/lib/OpenHVF/Expect.pm
+++ b/lib/OpenHVF/Expect.pm
@@ -27,7 +27,7 @@ sub new ( $class, %args )
 	my $self = bless {
 		host    => $args{host} // 'localhost',
 		port    => $args{port},
-		timeout => $args{timeout} // 180,
+		timeout => $args{timeout} // $ENV{OPENHVF_TIMEOUT} // 180,
 	}, $class;
 
 	return $self;

--- a/lib/OpenHVF/SSH.pm
+++ b/lib/OpenHVF/SSH.pm
@@ -169,7 +169,23 @@ sub interactive ($self)
 		"$self->{user}\@$self->{host}",
 	);
 
-	return system(@cmd);
+	# Return the child's exit code, not the raw wait status: callers
+	# (and ultimately the openhvf exit status) expect a 0-255 code. A
+	# raw status of, say, 256 for a remote exit code of 1 would become
+	# exit(256) -> 0, silently turning a failed remote command (e.g. a
+	# failing `prove` run driven over stdin) into success.
+	return _exit_code( system(@cmd) );
+}
+
+# _exit_code($status):
+#	Map a raw system()/$? wait status to a 0-255 exit code: the low
+#	byte encodes the terminating signal, the high byte the exit code.
+#	system() returns -1 when the child could not be run at all.
+sub _exit_code ($status)
+{
+	return EXIT_ERROR               if $status == -1;
+	return 128 + ( $status & 0x7f ) if $status & 0x7f;
+	return $status >> 8;
 }
 
 # $self->write_file($remote_path, $content, $mode):

--- a/lib/OpenHVF/SSH.pm
+++ b/lib/OpenHVF/SSH.pm
@@ -33,7 +33,7 @@ use constant {
 sub new ( $class, %args )
 {
 	my $self = bless {
-		host     => $args{host} // 'localhost',
+		host     => $args{host} // '127.0.0.1',
 		port     => $args{port} // 22,
 		user     => $args{user} // 'root',
 		password => $args{password},

--- a/lib/OpenHVF/VM.pm
+++ b/lib/OpenHVF/VM.pm
@@ -43,18 +43,22 @@ use constant {
 	EXIT_VM_NOT_RUNNING => 6,
 	EXIT_TIMEOUT        => 7,
 
-	# Fixed configuration for OpenBSD on Apple Silicon
+	# Fixed configuration for OpenBSD arm64 guests
 	QEMU_BINARY    => 'qemu-system-aarch64',
 	MEMORY_DEFAULT => '1G',
 	CPU_COUNT      => 2,
+
+	# Guest CPU model under TCG emulation (no host passthrough)
+	TCG_CPU => 'cortex-a57',
 };
 
 sub new ( $class, %args )
 {
 	my $self = bless {
-		config => $args{config},
-		state  => $args{state},
-		log    => $args{log},
+		config  => $args{config},
+		state   => $args{state},
+		log     => $args{log},
+		emulate => $args{emulate} // 0,
 	}, $class;
 
 	return $self;
@@ -721,10 +725,9 @@ sub _start_qemu ( $self, $boot_image = undef )
 
 	my @cmd = (QEMU_BINARY);
 
-	# Machine type for arm64 with HVF acceleration
-	push @cmd, '-M',     'virt,highmem=off';
-	push @cmd, '-cpu',   'host';
-	push @cmd, '-accel', 'hvf';
+	# Machine type for arm64, acceleration by host capability
+	push @cmd, '-M', 'virt,highmem=off';
+	push @cmd, $self->_accel_args;
 
 	# Memory and CPU
 	push @cmd, '-m',   $config->{memory} // MEMORY_DEFAULT;
@@ -811,11 +814,50 @@ sub _start_qemu ( $self, $boot_image = undef )
 	return;
 }
 
+# $self->_accel_args():
+#	Pick the QEMU accelerator for the host: HVF on macOS, KVM on
+#	aarch64 Linux hosts with /dev/kvm, TCG software emulation
+#	otherwise or when --emulate was given. Host CPU passthrough is
+#	only valid with hardware acceleration; TCG needs a named model.
+sub _accel_args ($self)
+{
+	my $accel;
+	if ( $self->{emulate} ) {
+		$accel = 'tcg';
+	}
+	elsif ( $^O eq 'darwin' ) {
+		$accel = 'hvf';
+	}
+	elsif ( $^O eq 'linux' && -w '/dev/kvm' && _host_arch() eq 'aarch64' ) {
+		$accel = 'kvm';
+	}
+	else {
+		$accel = 'tcg';
+	}
+
+	$self->{log}->debug("Using QEMU accelerator: $accel")
+	    if $self->{log};
+
+	return ( '-accel', $accel, '-cpu', $accel eq 'tcg' ? TCG_CPU : 'host' );
+}
+
+# _host_arch():
+#	Host machine architecture from uname
+sub _host_arch ()
+{
+	require POSIX;
+	my @uname = POSIX::uname();
+	return $uname[4] // '';
+}
+
 sub _find_efi_firmware ($self)
 {
 	my @paths = (
 		'/opt/homebrew/share/qemu/edk2-aarch64-code.fd',
 		'/usr/local/share/qemu/edk2-aarch64-code.fd',
+		'/usr/share/qemu-efi-aarch64/QEMU_EFI.fd',
+		'/usr/share/AAVMF/AAVMF_CODE.fd',
+		'/usr/share/qemu/edk2-aarch64-code.fd',
 	);
 
 	for my $path (@paths) {

--- a/lib/OpenHVF/VM.pm
+++ b/lib/OpenHVF/VM.pm
@@ -36,6 +36,8 @@ use OpenHVF::Util;
 use OpenHVF::QMP;
 use OpenHVF::QGA;
 
+use FuguLib::Process;
+
 use constant {
 	EXIT_SUCCESS        => 0,
 	EXIT_ERROR          => 1,
@@ -277,7 +279,7 @@ sub down ($self)
 		"Graceful shutdown failed, force stopping (risk of corruption)"
 	);
 	$state->mark_unclean_shutdown;
-	$self->_qmp_quit;
+	$self->_force_stop;
 	$state->clear_vm_pid;
 	$log->info("VM stopped");
 
@@ -365,7 +367,7 @@ sub stop ( $self, $force = 0 )
 		$log->warning(
 			"Force stopping VM (filesystem may be corrupted)");
 		$state->mark_unclean_shutdown;
-		$self->_qmp_quit;
+		$self->_force_stop;
 		$state->clear_vm_pid;
 		$log->info("VM stopped");
 		return EXIT_SUCCESS;
@@ -385,7 +387,7 @@ sub stop ( $self, $force = 0 )
 "Graceful shutdown timed out, force stopping (risk of corruption)"
 	);
 	$state->mark_unclean_shutdown;
-	$self->_qmp_quit;
+	$self->_force_stop;
 	$state->clear_vm_pid;
 	$log->info("VM stopped");
 	return EXIT_SUCCESS;
@@ -594,39 +596,33 @@ sub _graceful_shutdown ($self)
 	my $config = $self->{config};
 	my $log    = $self->{log};
 
-	# Method 1: SSH sync + ACPI powerdown
-	# First sync filesystems via SSH, then use QMP to send ACPI power button
-	# This avoids the problem of SSH connection being killed by halt
-	my $ssh = OpenHVF::SSH->new(
-		host => '127.0.0.1',
-		port => $config->{ssh_port},
-		user => 'root',
-	);
+	# Best-effort filesystem sync over SSH before pulling the power.
+	# Hard-bounded: a wedged guest must never stall shutdown, and
+	# libssh2 does not reliably honor its own timeout on the connect
+	# and handshake. A failure or timeout here is fine - the ACPI
+	# powerdown below runs the guest's own orderly shutdown (which
+	# syncs), and a force stop is the ultimate fallback.
+	$self->_bounded(
+		OpenHVF::SSH::DEFAULT_TIMEOUT + 5,
+		sub {
+			my $ssh = OpenHVF::SSH->new(
+				host => '127.0.0.1',
+				port => $config->{ssh_port},
+				user => 'root',
+			);
+			return $ssh->run_command('sync; sync; sync');
+		} );
 
-	# Try to sync filesystems via SSH (non-blocking command)
-	my $sync_result = $ssh->run_command('sync; sync; sync');
-
-	if ( $sync_result->{exit_code} == 0 ) {
-
-		# Synced successfully, now use ACPI powerdown via QMP
-		if ( $self->_qmp_powerdown ) {
-			if ( $self->_wait_exit(60) ) {
-				$log->info(
-					"Shutdown via SSH sync + ACPI powerdown"
-				);
-				return 1;
-			}
-		}
+	# Ask the guest to power off via the ACPI power button, then wait.
+	if ( $self->_qmp_powerdown && $self->_wait_exit(60) ) {
+		$log->info("Shutdown via ACPI powerdown");
+		return 1;
 	}
 
-	# Method 2: Try QGA shutdown (if guest agent is available)
+	# Guest-agent shutdown, if the agent is available.
 	my $qga = $self->_qga_connect;
 	if ($qga) {
-
-		# Sync filesystems first
 		$qga->sync;
-
-		# Request shutdown via guest agent
 		$qga->shutdown('powerdown');
 		$qga->disconnect;
 
@@ -636,15 +632,41 @@ sub _graceful_shutdown ($self)
 		}
 	}
 
-	# Method 3: Try direct ACPI powerdown as last resort
-	if ( $self->_qmp_powerdown ) {
-		if ( $self->_wait_exit(30) ) {
-			$log->info("Shutdown via ACPI powerdown");
-			return 1;
-		}
-	}
-
 	return 0;
+}
+
+# $self->_bounded($seconds, $code):
+#	Run $code under a hard wall-clock deadline so a blocking guest
+#	interaction cannot stall the caller. Returns $code's return value,
+#	or undef if the deadline elapsed. Mirrors the alarm guard used for
+#	the MQTT connect in OpenHAP::MQTT.
+sub _bounded ( $self, $seconds, $code )
+{
+	my $result;
+	my $ok = eval {
+		local $SIG{ALRM} = sub { die "timeout\n" };
+		alarm $seconds;
+		$result = $code->();
+		alarm 0;
+		1;
+	};
+	alarm 0;
+	return $result if $ok;
+
+	$self->{log}->warning("Guest did not respond within ${seconds}s");
+	return;
+}
+
+# $self->_force_stop:
+#	Terminate the QEMU process deterministically: SIGTERM (QEMU exits
+#	and flushes its disk caches), escalating to SIGKILL if it lingers.
+#	Unlike a QMP 'quit', this cannot hang on an unresponsive monitor
+#	socket, so it is a safe last resort.
+sub _force_stop ($self)
+{
+	my $pid = $self->{state}->get_vm_pid;
+	return 1 if !defined $pid;
+	return FuguLib::Process->terminate( $pid, grace_period => 5 );
 }
 
 # QGA methods

--- a/lib/OpenHVF/VM.pm
+++ b/lib/OpenHVF/VM.pm
@@ -173,7 +173,7 @@ sub up ($self)
 
 		$log->info("Installing OpenBSD...");
 		my $expect = OpenHVF::Expect->new(
-			host => 'localhost',
+			host => '127.0.0.1',
 			port => $config->{console_port},
 		);
 
@@ -448,7 +448,7 @@ sub wait_ssh ( $self, $timeout = 120, $sig = undef )
 
 	# Uses SSH agent for authentication
 	my $ssh = OpenHVF::SSH->new(
-		host => 'localhost',
+		host => '127.0.0.1',
 		port => $config->{ssh_port},
 		user => 'root',
 	);
@@ -464,7 +464,7 @@ sub _wait_ssh_password ( $self, $password, $timeout = 120 )
 	my $config = $self->{config};
 
 	my $ssh = OpenHVF::SSH->new(
-		host     => 'localhost',
+		host     => '127.0.0.1',
 		port     => $config->{ssh_port},
 		user     => 'root',
 		password => $password,
@@ -554,7 +554,7 @@ sub _install_ssh_key ( $self, $password )
 
 	# Connect with password
 	my $ssh = OpenHVF::SSH->new(
-		host     => 'localhost',
+		host     => '127.0.0.1',
 		port     => $config->{ssh_port},
 		user     => 'root',
 		password => $password,
@@ -598,7 +598,7 @@ sub _graceful_shutdown ($self)
 	# First sync filesystems via SSH, then use QMP to send ACPI power button
 	# This avoids the problem of SSH connection being killed by halt
 	my $ssh = OpenHVF::SSH->new(
-		host => 'localhost',
+		host => '127.0.0.1',
 		port => $config->{ssh_port},
 		user => 'root',
 	);
@@ -793,23 +793,93 @@ sub _start_qemu ( $self, $boot_image = undef )
 
 	# Wait for QEMU to write PID file
 	my $start = time;
+	my $pid;
 	while ( time - $start < 5 ) {
 		if ( -f $state->{vm_pid_file} ) {
 			my $qemu_pid = $state->get_vm_pid;
 			if ( defined $qemu_pid && kill( 0, $qemu_pid ) ) {
-				return $qemu_pid;
+				$pid = $qemu_pid;
+				last;
 			}
 		}
 		usleep(100_000);    # 0.1 seconds
 	}
 
 	# Fallback: use forked PID from FuguLib::Process
-	my $pid = $result->{pid};
-	if ( kill( 0, $pid ) ) {
-		$state->set_vm_pid($pid);
-		$state->mark_running;
-		return $pid;
+	unless ( defined $pid ) {
+		my $forked = $result->{pid};
+		if ( kill( 0, $forked ) ) {
+			$state->set_vm_pid($forked);
+			$state->mark_running;
+			$pid = $forked;
+		}
 	}
+
+	unless ( defined $pid ) {
+		$self->_dump_qemu_log($log_file);
+		return;
+	}
+
+	# Confirm QEMU is actually accepting console connections before the
+	# installer tries to attach. A QEMU that exited at startup (bad
+	# accelerator, missing firmware) leaves the port closed; catching
+	# that here fails fast with the QEMU log instead of a long telnet
+	# timeout later.
+	unless ( $self->_wait_console_ready( $config->{console_port}, 30 ) ) {
+		$self->{log}
+		    ->error( 'QEMU console port %d not listening after start',
+			$config->{console_port} );
+		$self->_dump_qemu_log($log_file);
+		return;
+	}
+
+	return $pid;
+}
+
+# $self->_wait_console_ready($port, $timeout):
+#	Poll the console TCP port until it accepts a connection, so the
+#	installer's telnet attaches to a live console. The bind happens
+#	at QEMU startup (before guest boot), so this is quick when QEMU
+#	is healthy and bounded when it is not.
+sub _wait_console_ready ( $self, $port, $timeout )
+{
+	require IO::Socket::INET;
+
+	my $start = time;
+	while ( time - $start < $timeout ) {
+		my $sock = IO::Socket::INET->new(
+			PeerAddr => '127.0.0.1',
+			PeerPort => $port,
+			Proto    => 'tcp',
+			Timeout  => 2,
+		);
+		if ( defined $sock ) {
+			$sock->close;
+			return 1;
+		}
+
+		# Give up early if QEMU has already exited
+		my $qemu_pid = $self->{state}->get_vm_pid;
+		return 0 if defined $qemu_pid && !kill( 0, $qemu_pid );
+
+		usleep(200_000);    # 0.2 seconds
+	}
+
+	return 0;
+}
+
+# $self->_dump_qemu_log($log_file):
+#	Emit the tail of the QEMU log so a startup failure is visible in
+#	CI output instead of requiring shell access to the runner.
+sub _dump_qemu_log ( $self, $log_file )
+{
+	open my $fh, '<', $log_file or return;
+	my @lines = <$fh>;
+	close $fh;
+
+	@lines = splice( @lines, -40 ) if @lines > 40;
+	$self->{log}->error('QEMU log tail:');
+	$self->{log}->error( '  %s', $_ ) for map { chomp; $_ } @lines;
 
 	return;
 }

--- a/man/openhvf/openhvf.1
+++ b/man/openhvf/openhvf.1
@@ -80,8 +80,11 @@ as the project root instead of auto-discovering it.
 .It Fl q , Fl Fl quiet
 Suppress informational output.
 .It Fl Fl emulate
-Force TCG emulation instead of hardware acceleration,
-for testing on aarch64 hosts.
+Force TCG software emulation instead of hardware acceleration.
+Without this flag the accelerator is chosen automatically:
+HVF on macOS, KVM on aarch64 Linux hosts with
+.Pa /dev/kvm ,
+and TCG everywhere else.
 .It Fl h , Fl Fl help
 Display usage information.
 .El

--- a/plans/002-integration-ci-green/design.md
+++ b/plans/002-integration-ci-green/design.md
@@ -1,0 +1,100 @@
+# Integration CI — Design
+
+## Problem
+
+The `Integration` workflow (`.github/workflows/integration.yml`) provisions an
+OpenBSD guest under QEMU and runs `t/openhap/integration/*.t` on every push and
+pull request. Standing the pipeline up exposed a chain of defects. The harness
+defects (console/SSH addressing, install halt, SSH-key provisioning, bounded
+shutdown, exit-code propagation) and the SRP performance defect are fixed; what
+remains is to make the integration **suite** pass reliably in that environment
+and keep it green.
+
+Two properties of the CI environment shape the remaining failures:
+
+1. **No hardware virtualization.** The `ubuntu-24.04-arm` runner has no
+   `/dev/kvm`, so QEMU uses TCG software emulation — an order of magnitude
+   slower than native, which is why CPU-bound crypto needed the GMP backend and
+   why timing-sensitive tests are fragile.
+2. **User-mode (SLIRP) networking.** The guest reaches the network through
+   QEMU's user-mode stack, which does not forward link-local multicast — the
+   transport mDNS relies on.
+
+## Current state (baseline for this plan)
+
+Run of commit `796b1c6` (GMP backend landed):
+
+- Green: `environment`, `accessories`, **`characteristics` (16/16)**,
+  `configuration`, `daemon`, `hap-protocol`, `hapctl`, `mqtt`.
+- Failing: `pairing`, `tasmota-protocol`, `events`, `mdns`, `mdns-cleanup`.
+
+The GMP fix worked: `characteristics.t` now completes full pair-setup,
+pair-verify, and encrypted reads/writes. The remaining failures are no longer
+about crypto speed.
+
+## Failure taxonomy
+
+| Class                   | Tests                                     | Root cause                                                                                                                                                             | Status                                                       |
+| ----------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| SRP performance         | (was `characteristics`, `pairing` crypto) | pure-Perl `Math::BigInt`; 3072-bit `bmodpow` ~2s native, far worse under TCG                                                                                           | **Fixed** — `use Math::BigInt try => 'GMP'` + GMP dependency |
+| Pairing state isolation | `pairing`, `tasmota-protocol`             | `pair_setup` returns `kTLVError_Unavailable` (6) in the late-running tests, though both call `ensure_unpaired`; early tests (`characteristics`, `events`) pair cleanly | Open                                                         |
+| Event delivery          | `events` (subtests 5–6)                   | a subscribed controller never receives the async `EVENT/1.0` notification; the body then decodes as undef and the test dies                                            | Open                                                         |
+| mDNS availability       | `mdns`, `mdns-cleanup`                    | `mdnsd` is not running at test time (suspected SLIRP multicast limitation; not yet confirmed)                                                                          | Open                                                         |
+| Provisioning noise      | (none failing)                            | `make install`'s `[ ! -e <glob> ]` guard errors when the glob matches multiple files                                                                                   | Open                                                         |
+
+## Goals
+
+1. The full `t/openhap/integration/*.t` suite passes in the workflow, on both a
+   cold cache (fresh install) and a warm cache (reused disk).
+2. Failures stay legible: no silent fallback that turns a broken environment
+   into a slow-but-green or falsely-green run.
+3. `t/openhap/integration/CLAUDE.md` rules hold — tests never `skip`; a missing
+   prerequisite is a hard, diagnosed failure or a capability the harness
+   genuinely provides.
+
+## Non-goals
+
+- Changing the HAP or MQTT protocol implementations beyond what a test failure
+  proves is wrong.
+- Restructuring the test tiers or conformance suite (owned by plan 001).
+- Making the integration job fast; TCG is inherently slow and the generous
+  timeouts stand.
+- Real Apple-device or certified-controller interop.
+
+## Strategy
+
+Four independently shippable phases, each ending with a named set of integration
+files green in CI. Order is by blast radius and independence:
+
+- **Phase 1 — Pairing state isolation.** Root-cause the `kTLVError_Unavailable`
+  returned to the late-running tests and make every pairing test start from a
+  genuinely unpaired accessory. Unblocks the largest group and everything that
+  pairs first.
+- **Phase 2 — Event delivery.** Determine why the subscribed controller does not
+  receive the `EVENT/1.0` push, fix it, and make the event read fail cleanly
+  instead of dying on an undef body.
+- **Phase 3 — mDNS under emulated networking.** Confirm why `mdnsd` does not
+  survive to test time, then either make it run under the guest's network or
+  give the harness a network mode that carries multicast — rather than weakening
+  the tests.
+- **Phase 4 — Cleanup and regression guards.** Fix the `make install` glob
+  guard, guard against a silent regression to the pure-Perl bigint backend,
+  remove the temporary diagnostics added while chasing these failures, and
+  confirm cold- and warm-cache runs are both green.
+
+## Contracts for the target state
+
+- **Crypto backend.** `OpenHAP::SRP` and the controller SRP obtain the GMP
+  `Math::BigInt` backend in the guest; a missing backend is a visible error, not
+  a silent multi-minute pair-setup.
+- **Pairing isolation.** After `ensure_unpaired`, `/pair-setup` from a fresh
+  controller reaches M6 regardless of what earlier tests did.
+- **Events.** A controller subscribed to a characteristic receives an
+  `EVENT/1.0` notification after a value change, within the emulated-timing
+  budget.
+- **mDNS.** `mdnsd` is running and answering `mdnsctl` for the duration of the
+  mDNS tests, on the interface `openhapd` advertises on.
+
+Once a phase's acceptance criteria hold in CI, the code, tests, and
+`t/openhap/integration/CLAUDE.md` are the source of truth; this plan records
+intent at the time of writing.

--- a/plans/002-integration-ci-green/plan-1.md
+++ b/plans/002-integration-ci-green/plan-1.md
@@ -1,0 +1,70 @@
+# Phase 1 — Pairing state isolation
+
+`pairing.t` and `tasmota-protocol.t` fail with `pair_setup error: 6`
+(`kTLVError_Unavailable`) even though both call `ensure_unpaired` in setup. The
+early-running `characteristics.t` and `events.t` pair cleanly, so the accessory
+_can_ pair from a clean state; the late-running tests cannot. This phase finds
+why and makes every pairing test deterministic.
+
+## Hypotheses to confirm first
+
+Do not fix blind — the run log shows every `/pair-setup` in the failing files
+returns `6`, including the wrong-PIN case, which means the accessory believes it
+is already paired (or a pair-setup is already in progress). Candidates:
+
+- `ensure_unpaired` (`lib/OpenHAP/Test/Integration.pm`) only wipes when
+  `-s pairings_file`; a pairing persisted elsewhere (e.g. in-memory across the
+  stop/start, or a second state file) survives it.
+- `pairing.t`'s raw M1 probe (test 2) opens a pair-setup session; the stop/start
+  meant to release it does not, and the server rejects the next M1 with
+  `Unavailable`. (Does not explain `tasmota-protocol.t`, which has no probe — so
+  this is at most a second, additive cause.)
+- The daemon does not reset a stale/incomplete pair-setup session, so once one
+  is left dangling every later attempt is `Unavailable` until restart.
+
+## Tasks
+
+### 1.1 Reproduce and localize
+
+- Run the two failing files in isolation and in suite order in a local VM
+  (`make integration`, now fast with GMP) to see whether order alone triggers
+  it.
+- Capture `/var/db/openhapd/pairings` and the daemon log around a failing
+  `pair_setup` to see the accessory's paired/in-progress state at M1.
+
+### 1.2 Make `ensure_unpaired` authoritative
+
+- Ensure it removes every persisted pairing artifact (pairings, any
+  in-progress/session state) and that the daemon reloads a clean state — verify
+  the daemon is actually stopped before the unlink and fully up after.
+- Add a post-condition check: after `ensure_unpaired`, an unauthenticated
+  `GET /accessories` returns 470 (unpaired), failing loudly if not.
+
+### 1.3 Fix the server side if it is at fault
+
+- If the daemon returns `Unavailable` because of a stale in-progress pair-setup
+  rather than an established pairing, reset a prior incomplete session when a
+  new M1 arrives (per HAP: a fresh M1 starts a new session), citing
+  `spec/HAP-Pairing.md`. Keep the correct `Unavailable` when a real admin
+  pairing already exists.
+
+### 1.4 Harden the tests
+
+- `pairing.t`: after the raw M1 probe, guarantee the session is released before
+  the controller flow (explicit reset, not only a daemon bounce).
+- Keep assertions spec-cited; do not weaken them to pass.
+
+## Deliverables
+
+- Root-cause note (in the PR description or commit body) distinguishing test bug
+  vs. daemon bug.
+- Fixes in `lib/OpenHAP/Test/Integration.pm` and/or the daemon pairing code
+  and/or the two test files.
+
+## Acceptance criteria
+
+- `pairing.t` (18/18) and `tasmota-protocol.t` (11/11) pass in the Integration
+  workflow, in suite order, on both cold and warm cache.
+- `characteristics.t` and `events.t` still pass (no regression from changes to
+  shared `ensure_unpaired`).
+- `make check` stays green.

--- a/plans/002-integration-ci-green/plan-2.md
+++ b/plans/002-integration-ci-green/plan-2.md
@@ -1,0 +1,56 @@
+# Phase 2 — Event delivery
+
+With pairing fixed (Phase 1) and GMP in place, `events.t` reaches its event
+assertions: subtests 1–4 pass (subscription accepted, second controller verifies
+its session, value changed), but subtest 5
+`[HAP-HTTP §14] EVENT/1.0 message received` fails and the test then dies:
+
+```
+malformed JSON string, neither array, object, number, string or atom,
+at character offset 0 ... at t/openhap/integration/events.t line 74
+```
+
+So the subscribed controller never receives the asynchronous `EVENT/1.0`
+notification, and the code then tries to JSON-decode an undef/empty body and
+dies instead of failing the assertion cleanly.
+
+## Tasks
+
+### 2.1 Determine why the event is not received
+
+- Confirm the daemon actually emits the event: change a value from a second
+  connection (as the test does) and watch the daemon log / the subscriber
+  socket. Establish whether the push is never sent, sent on the wrong
+  connection, or sent but not read in time.
+- Check the controller's event read path
+  (`OpenHAP::Test::Controller::next_event` and the `inbuf` handling in
+  `request`) for a timing or framing issue: under TCG the event may arrive after
+  a short read window that is too tight.
+
+### 2.2 Fix the delivery gap
+
+- If it is a controller-side read/timing issue, extend the event wait using the
+  same `OPENHAP_TEST_TIMEOUT` knob as the request path and ensure a back-to-back
+  event framed after a response is not dropped.
+- If the daemon does not push events to a subscribed session, fix the daemon
+  (cite `spec/HAP-HTTP.md §14`) and add/extend a conformance test so the
+  regression is caught host-side, not only in the VM.
+
+### 2.3 Make the read fail cleanly
+
+- `events.t` line ~74: never feed an undef/empty body to the JSON decoder;
+  assert the event was received first and `diag` the raw bytes on failure, so a
+  missed event is a clean `not ok`, not a `die`.
+
+## Deliverables
+
+- Fix in the controller and/or daemon event path; hardened `events.t`.
+- If a daemon bug is found, a host-side conformance assertion covering it.
+
+## Acceptance criteria
+
+- `events.t` (8/8) passes in the Integration workflow on both cold and warm
+  cache, and does not die on a missing event.
+- No new flakiness: the event wait is bounded by `OPENHAP_TEST_TIMEOUT`, not a
+  fixed short sleep.
+- `make check` stays green.

--- a/plans/002-integration-ci-green/plan-3.md
+++ b/plans/002-integration-ci-green/plan-3.md
@@ -1,0 +1,57 @@
+# Phase 3 — mDNS under emulated networking
+
+`mdns.t` fails at subtest 3 (`mdnsd daemon is running`) and `mdns-cleanup.t`
+dies at its `mdnsd required` precondition. Both files then cannot run. The
+provisioning hardening added this session (set flags to the default-route
+interface, enable, restart, verify) did not change the outcome, and the
+foreground-`mdnsd` diagnostics did not print — meaning either the provisioning
+block did not reach them or `mdnsd` was alive at provisioning time but not at
+test time. mDNS depends on link-local multicast, which QEMU user-mode (SLIRP)
+networking does not carry.
+
+## Tasks
+
+### 3.1 Establish the actual failure
+
+- Read the provisioning-phase diagnostics already emitted
+  (`scripts/vm_provision.sh`): the chosen interface, `rcctl get mdnsd`, and the
+  short foreground `mdnsd -d` output. Determine definitively whether `mdnsd`
+  fails to start, starts then exits, or runs but `rcctl check` misreports it.
+- In a local VM, start `mdnsd` by hand on the guest interface and observe
+  whether it stays up and whether `mdnsctl browse` returns anything under
+  user-mode networking.
+
+### 3.2 Decide the resolution path
+
+Pick based on 3.1, in preference order:
+
+1. **Make mdnsd run as-is.** If it is a flags/interface/rc issue (not a
+   transport limit), fix provisioning so `mdnsd` is reliably up before the
+   tests, and the tests pass unchanged.
+2. **Give the guest real multicast.** If user-mode networking is the blocker,
+   switch the VM's network for CI to a mode that carries multicast (e.g. a
+   tap/bridged backend) in `lib/OpenHVF/VM.pm` / `.openhvfrc`, gated so local
+   development is unaffected. Document the requirement.
+
+Do **not** add a `skip` to the mDNS tests — `t/openhap/integration/CLAUDE.md`
+forbids it. If mDNS genuinely cannot run in the chosen CI network, that is a
+harness capability to provide (option 2), not a test to soften.
+
+### 3.3 Implement and verify
+
+- Apply the chosen fix; confirm `mdnsd` is up and `mdnsctl browse` sees the
+  `_hap._tcp` service `openhapd` registers.
+
+## Deliverables
+
+- Provisioning and/or `OpenHVF` networking change with a one-paragraph rationale
+  in the commit body (which of 3.2's paths and why).
+- Any doc updates (`INSTALL.md` / `man/openhvf/openhvf.1`) if the VM network
+  configuration changes.
+
+## Acceptance criteria
+
+- `mdns.t` (12/12) and `mdns-cleanup.t` (6/6) pass in the Integration workflow.
+- Local `make integration` on a developer host (HVF/KVM) still passes, i.e. the
+  networking change does not regress the non-CI path.
+- `make check` stays green.

--- a/plans/002-integration-ci-green/plan-4.md
+++ b/plans/002-integration-ci-green/plan-4.md
@@ -1,0 +1,52 @@
+# Phase 4 — Cleanup and regression guards
+
+With Phases 1–3 landed the integration suite is green. This phase removes the
+scaffolding added while chasing the failures and guards against silent
+regressions, so a future change cannot quietly re-break what was fixed.
+
+## Tasks
+
+### 4.1 Fix the `make install` glob guard
+
+- `Makefile`: `[ ! -e lib/OpenHAP/Test/*.pm ] || install ...` errors with
+  `[: ...: unexpected operator/operand` when the glob matches more than one file
+  (it now matches `Integration.pm` and others). Rewrite so the guard works with
+  zero, one, or many matches (e.g. a `for` loop, or a `set --` on the glob and
+  test `$#`), and produces no stderr noise. Confirm the `Test/` and
+  `Test/Controller/` modules still install.
+
+### 4.2 Guard the GMP backend in the guest
+
+- The `try => 'GMP'` selection falls back silently to pure-Perl `Math::BigInt`,
+  which under TCG reintroduces multi-minute pair-setups. Make the loss of GMP
+  visible where it matters: e.g. an integration/environment assertion that
+  `Math::BigInt->config->{lib}` is the GMP backend in the VM, or a daemon
+  startup warning. Keep `make check` on hosts without GMP green (the guard is a
+  warning/CI assertion, not a hard `require`).
+
+### 4.3 Remove temporary diagnostics
+
+- `scripts/vm_provision.sh`: drop the foreground-`mdnsd` diagnostic block once
+  Phase 3 resolves mDNS, keeping only what a normal run needs.
+- `.github/workflows/integration.yml`: keep the failure-only VM diagnostics step
+  (it is cheap and useful) but prune anything made redundant.
+
+### 4.4 Full-suite verification
+
+- Confirm a **cold-cache** run (cache miss → fresh install) and a **warm-cache**
+  run (reused disk) are both fully green — the warm path was rarely exercised
+  while every change invalidated the disk cache.
+- Confirm the workflow's `workflow_dispatch` path still runs against an
+  arbitrary branch.
+
+## Deliverables
+
+- `Makefile` glob fix; GMP-presence guard; trimmed provisioning/workflow.
+
+## Acceptance criteria
+
+- `make install` runs with no stderr noise and installs all shipped modules.
+- The Integration workflow is green end-to-end on cold and warm cache, and a
+  missing GMP backend fails or warns visibly rather than silently slowing the
+  run.
+- `make check` stays green.

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -20,7 +20,7 @@ echo "==> Copying test files..."
 cd "${PROJECT_ROOT}"
 TARBALL="/tmp/tests-$$.tar.gz"
 tar czf "${TARBALL}" t/openhap/integration/ t/lib/ lib/OpenHAP/Test/
-vm_scp "${TARBALL}" "root@localhost:/tmp/tests.tar.gz"
+vm_scp "${TARBALL}" "root@127.0.0.1:/tmp/tests.tar.gz"
 rm -f "${TARBALL}"
 
 echo "==> Running integration tests..."

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -41,21 +41,19 @@ sleep 2
 export OPENHAP_INTEGRATION_TEST=1
 
 # Run tests in order (environment first, then others)
+TESTS="t/openhap/integration/environment.t"
+for test in t/openhap/integration/*.t; do
+	[ "$test" = "t/openhap/integration/environment.t" ] && continue
+	TESTS="$TESTS $test"
+done
+
 if command -v prove >/dev/null 2>&1; then
-	prove -I/usr/local/libdata/perl5/site_perl -v t/openhap/integration/
+	prove -I/usr/local/libdata/perl5/site_perl -v $TESTS
 	result=$?
 else
 	result=0
-	# Run environment test first
-	for test in t/openhap/integration/environment.t; do
+	for test in $TESTS; do
 		[ -f "$test" ] || continue
-		echo "Running $test..."
-		perl -I/usr/local/libdata/perl5/site_perl "$test" || result=1
-	done
-	# Run remaining tests
-	for test in t/openhap/integration/*.t; do
-		[ "$test" = "t/openhap/integration/environment.t" ] && continue
-		[ "$test" = "t/openhap/integration/README.md" ] && continue
 		echo "Running $test..."
 		perl -I/usr/local/libdata/perl5/site_perl "$test" || result=1
 	done

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -19,13 +19,17 @@ vm_scp() { scp ${SSH_OPTS} -P "${SSH_PORT}" "$@"; }
 echo "==> Copying test files..."
 cd "${PROJECT_ROOT}"
 TARBALL="/tmp/tests-$$.tar.gz"
-tar czf "${TARBALL}" t/openhap/integration/
+tar czf "${TARBALL}" t/openhap/integration/ t/lib/ lib/OpenHAP/Test/
 vm_scp "${TARBALL}" "root@localhost:/tmp/tests.tar.gz"
 rm -f "${TARBALL}"
 
 echo "==> Running integration tests..."
 vm_run <<'EOF'
 cd /tmp && tar xzf tests.tar.gz
+
+# Refresh the shipped test helper modules (Test::Controller and the
+# shared mocks in t/lib) over the installed copies
+cp -R lib/OpenHAP/Test /usr/local/libdata/perl5/site_perl/OpenHAP/
 
 # Clean up any orphaned processes from previous test runs
 # This ensures a known-good state before running tests
@@ -48,18 +52,18 @@ for test in t/openhap/integration/*.t; do
 done
 
 if command -v prove >/dev/null 2>&1; then
-	prove -I/usr/local/libdata/perl5/site_perl -v $TESTS
+	prove -I/usr/local/libdata/perl5/site_perl -It/lib -v $TESTS
 	result=$?
 else
 	result=0
 	for test in $TESTS; do
 		[ -f "$test" ] || continue
 		echo "Running $test..."
-		perl -I/usr/local/libdata/perl5/site_perl "$test" || result=1
+		perl -I/usr/local/libdata/perl5/site_perl -It/lib "$test" || result=1
 	done
 fi
 
-rm -rf /tmp/t /tmp/tests.tar.gz
+rm -rf /tmp/t /tmp/lib /tmp/tests.tar.gz
 exit $result
 EOF
 

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -44,6 +44,11 @@ sleep 2
 # Set integration test flag
 export OPENHAP_INTEGRATION_TEST=1
 
+# The test controller talks to the real daemon, whose SRP modexp is slow
+# under TCG emulation. Give its socket reads a generous timeout so
+# pair-setup/pair-verify do not give up before the daemon responds.
+export OPENHAP_TEST_TIMEOUT="${OPENHAP_TEST_TIMEOUT:-60}"
+
 # Run tests in order (environment first, then others)
 TESTS="t/openhap/integration/environment.t"
 for test in t/openhap/integration/*.t; do

--- a/scripts/spec-coverage
+++ b/scripts/spec-coverage
@@ -1,0 +1,199 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# $OpenBSD$
+#
+# Copyright (c) 2026 Dick Olsson <hi@ekkis.net>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+# spec-coverage: cross-verify spec/ section anchors against test citations.
+#
+# Parses the numbered ##/### headings of spec/*.md into a section
+# inventory, scans t/ for [<spec-stem> §<section>] citations, and prints
+# a coverage matrix. Exits non-zero iff a citation points at a section
+# that does not exist (stale after spec regeneration). Low coverage is
+# informative, never fatal. See t/CLAUDE.md for the citation convention.
+
+use v5.36;
+use File::Basename qw(dirname);
+use File::Find     qw(find);
+use Getopt::Long   qw(GetOptions);
+
+my $quiet     = 0;
+my $uncovered = 0;
+my $spec_dir;
+my $test_dir;
+
+GetOptions(
+	'quiet'      => \$quiet,
+	'uncovered'  => \$uncovered,
+	'spec-dir=s' => \$spec_dir,
+	'test-dir=s' => \$test_dir,
+) or die "usage: spec-coverage [--quiet] [--uncovered] "
+    . "[--spec-dir dir] [--test-dir dir]\n";
+
+my $root = dirname(dirname(__FILE__));
+$spec_dir //= "$root/spec";
+$test_dir //= "$root/t";
+
+-d $spec_dir or die "spec-coverage: no such directory: $spec_dir\n";
+-d $test_dir or die "spec-coverage: no such directory: $test_dir\n";
+
+# _read_inventory($dir):
+#	Parse numbered ##/### headings of every *.md file in $dir.
+#	Returns a hash: stem => {
+#		file     => basename,
+#		index    => 1 for index files (stem without '-'),
+#		sections => { '2.6' => 1, ... },
+#		order    => [ '1', '1.1', '2', ... ],
+#	}
+sub _read_inventory ($dir)
+{
+	my %inventory;
+
+	opendir my $dh, $dir or die "spec-coverage: opendir $dir: $!\n";
+	my @files = sort grep { /\.md$/ && $_ ne 'CLAUDE.md' } readdir $dh;
+	closedir $dh;
+
+	for my $file (@files) {
+		my ($stem) = $file =~ /^(.*)\.md$/;
+		my %entry = (
+			file     => $file,
+			index    => ( $stem =~ /-/ ? 0 : 1 ),
+			sections => {},
+			order    => [],
+		);
+
+		open my $fh, '<', "$dir/$file"
+		    or die "spec-coverage: open $dir/$file: $!\n";
+		while ( my $line = <$fh> ) {
+			next unless $line =~ /^#{2,3}\s+(\d+(?:\.\d+)*)\.?\s/;
+			my $section = $1;
+			next if $entry{sections}{$section}++;
+			push @{ $entry{order} }, $section;
+		}
+		close $fh;
+
+		$inventory{$stem} = \%entry;
+	}
+
+	return %inventory;
+}
+
+# _scan_citations($dir):
+#	Grep test files recursively for the citation pattern.
+#	Returns a list of { stem, section, row, site => 'file:line' }.
+sub _scan_citations ($dir)
+{
+	my @citations;
+
+	my $wanted = sub {
+		return unless -f && /\.(?:t|pm)$/;
+		my $path = $File::Find::name;
+		$path =~ s{^\./}{};
+
+		open my $fh, '<', $_
+		    or die "spec-coverage: open $path: $!\n";
+		while ( my $line = <$fh> ) {
+			while ( $line =~
+			    /\[((?:HAP|MQTT)[A-Za-z-]*) §([0-9][0-9.]*)(?:\/([^\]]+))?\]/g
+			    )
+			{
+				my ( $stem, $section, $row ) = ( $1, $2, $3 );
+				$section =~ s/\.+$//;
+				push @citations, {
+					stem    => $stem,
+					section => $section,
+					row     => $row,
+					site    => "$path:$.",
+				};
+			}
+		}
+		close $fh;
+	};
+
+	find( { wanted => $wanted, no_chdir => 0 }, $dir );
+
+	return @citations;
+}
+
+my %inventory = _read_inventory($spec_dir);
+my @citations = _scan_citations($test_dir);
+
+# Join citations against the inventory
+my %cited;    # stem => section => { site => 1 }
+my @stale;
+
+for my $c (@citations) {
+	my $entry = $inventory{ $c->{stem} };
+	if ( !defined $entry ) {
+		push @stale, sprintf '%s cites %s §%s (no such spec file)',
+		    $c->{site}, $c->{stem}, $c->{section};
+		next;
+	}
+	if ( !exists $entry->{sections}{ $c->{section} } ) {
+		push @stale, sprintf '%s cites %s §%s (no such section)',
+		    $c->{site}, $c->{stem}, $c->{section};
+		next;
+	}
+	$cited{ $c->{stem} }{ $c->{section} }{ $c->{site} } = 1;
+}
+
+# Report
+my $total_sections = 0;
+my $total_cited    = 0;
+
+for my $stem ( sort keys %inventory ) {
+	my $entry    = $inventory{$stem};
+	my @sections = @{ $entry->{order} };
+
+	if ( $entry->{index} ) {
+		printf "%-28s (%s, not counted)\n", "spec/$entry->{file}",
+		    @sections ? 'index' : 'unnumbered'
+		    unless $quiet || $uncovered;
+		next;
+	}
+
+	my $cited_count =
+	    grep { exists $cited{$stem}{$_} } @sections;
+	$total_sections += @sections;
+	$total_cited    += $cited_count;
+
+	next if $quiet;
+
+	printf "%-28s %d/%d sections cited\n", "spec/$entry->{file}",
+	    $cited_count, scalar @sections
+	    unless $uncovered && $cited_count == @sections;
+
+	for my $section (@sections) {
+		my $sites = $cited{$stem}{$section};
+		if ( !defined $sites ) {
+			printf "  §%-6s UNCOVERED\n", $section;
+		}
+		elsif ( !$uncovered ) {
+			printf "  §%-6s %s\n", $section,
+			    join ' ', sort keys %$sites;
+		}
+	}
+}
+
+my $pct =
+    $total_sections ? int( 100 * $total_cited / $total_sections ) : 0;
+printf "TOTAL: %d/%d numbered sections cited (%d%%)\n",
+    $total_cited, $total_sections, $pct;
+
+for my $stale (@stale) {
+	print "STALE: $stale\n";
+}
+
+exit( @stale ? 1 : 0 );

--- a/scripts/spec-coverage
+++ b/scripts/spec-coverage
@@ -106,7 +106,7 @@ sub _scan_citations ($dir)
 		    or die "spec-coverage: open $path: $!\n";
 		while ( my $line = <$fh> ) {
 			while ( $line =~
-			    /\[((?:HAP|MQTT)[A-Za-z-]*) §([0-9][0-9.]*)(?:\/([^\]]+))?\]/g
+			    /\[((?:HAP|MQTT)[A-Za-z0-9-]*) §([0-9][0-9.]*)(?:\/([^\]]+))?\]/g
 			    )
 			{
 				my ( $stem, $section, $row ) = ( $1, $2, $3 );

--- a/scripts/vm_provision.sh
+++ b/scripts/vm_provision.sh
@@ -40,7 +40,7 @@ fi
 EOF
 
 echo "==> Copying to VM..."
-vm_scp "${TARBALL}" "root@localhost:/tmp/openhap.tar.gz"
+vm_scp "${TARBALL}" "root@127.0.0.1:/tmp/openhap.tar.gz"
 
 echo "==> Installing OpenHAP..."
 vm_run <<'EOF'

--- a/scripts/vm_provision.sh
+++ b/scripts/vm_provision.sh
@@ -99,11 +99,21 @@ if rcctl get mdnsd >/dev/null 2>&1; then
 	if [ -n "${IFACE}" ]; then
 		rcctl set mdnsd flags "${IFACE}"
 		rcctl enable mdnsd
-		rcctl restart mdnsd
-		rcctl check mdnsd ||
-			echo "WARNING: mdnsd did not start on ${IFACE}"
+		rcctl restart mdnsd || true
+		if ! rcctl check mdnsd; then
+			# Surface why mdnsd would not stay up so the mDNS
+			# integration tests are diagnosable from CI logs
+			# instead of just reporting a missing daemon.
+			echo "WARNING: mdnsd did not start on ${IFACE}; diagnostics:"
+			rcctl get mdnsd || true
+			ifconfig "${IFACE}" || true
+			echo "-- mdnsd foreground start (2s) --"
+			timeout 2 /usr/local/sbin/mdnsd -d "${IFACE}" 2>&1 |
+				head -n 20 || true
+		fi
 	else
 		echo "WARNING: no network interface found for mdnsd"
+		ifconfig -a || true
 	fi
 fi
 

--- a/scripts/vm_provision.sh
+++ b/scripts/vm_provision.sh
@@ -85,15 +85,25 @@ cd /tmp && rm -rf openhap-* openhap.tar.gz
 rcctl enable mosquitto
 rcctl start mosquitto
 
-# Configure and enable mdnsd with the first active network interface
-# mdnsd requires an interface to be specified for multicast DNS
+# Configure and start mdnsd on the primary network interface. mdnsd
+# needs an interface for multicast DNS; started without one it exits
+# immediately, which later surfaces as failing mDNS integration tests.
+# Prefer the default-route interface, fall back to the first UP, non
+# loopback interface, and verify the daemon actually came up.
 if rcctl get mdnsd >/dev/null 2>&1; then
-	# Find the first active network interface (not loopback)
-	IFACE=$(ifconfig -a | grep '^[a-z]' | grep -v '^lo' | grep -v '^enc' | grep -v '^pflog' | head -1 | cut -d: -f1)
+	IFACE=$(route -n show -inet 2>/dev/null |
+		awk '/^default/ { print $NF; exit }')
+	[ -n "${IFACE}" ] || IFACE=$(ifconfig -a |
+		awk -F: '/^[a-z].*<UP,/ && !/^(lo|enc|pflog)/ { print $1; exit }')
+
 	if [ -n "${IFACE}" ]; then
 		rcctl set mdnsd flags "${IFACE}"
 		rcctl enable mdnsd
-		rcctl start mdnsd 2>/dev/null || true
+		rcctl restart mdnsd
+		rcctl check mdnsd ||
+			echo "WARNING: mdnsd did not start on ${IFACE}"
+	else
+		echo "WARNING: no network interface found for mdnsd"
 	fi
 fi
 

--- a/scripts/vm_up.sh
+++ b/scripts/vm_up.sh
@@ -41,6 +41,8 @@ if [ ${FRESH} -eq 1 ]; then
 	"${OPENHVF}" destroy 2>/dev/null || true
 fi
 
-# Bring up VM (idempotent)
+# Bring up VM (idempotent). Under TCG emulation (e.g. CI runners
+# without hardware acceleration) boot and install take far longer than
+# under HVF/KVM, so the wait timeout is overridable.
 "${OPENHVF}" up
-"${OPENHVF}" wait --timeout 120
+"${OPENHVF}" wait --timeout "${OPENHVF_WAIT_TIMEOUT:-120}"

--- a/share/openhap/examples/openhapd.conf.sample
+++ b/share/openhap/examples/openhapd.conf.sample
@@ -35,3 +35,15 @@ device tasmota thermostat living_room {
     name = "Living Room Thermostat"
     topic = tasmota_DDEEFF
 }
+
+# Dimmable lightbulb example
+device tasmota lightbulb kitchen {
+    name = "Kitchen Light"
+    topic = tasmota_LIGHT1
+}
+
+# Temperature sensor example
+device tasmota sensor outdoor {
+    name = "Outdoor Sensor"
+    topic = tasmota_SENS01
+}

--- a/share/openhvf/expect/command.exp
+++ b/share/openhvf/expect/command.exp
@@ -46,6 +46,10 @@ expect {
     "#" {
         # Already logged in
     }
+    eof {
+        puts stderr "telnet could not connect to the VM console"
+        exit 1
+    }
     timeout {
         puts stderr "Timeout waiting for prompt"
         exit 1

--- a/share/openhvf/expect/firstboot.exp
+++ b/share/openhvf/expect/firstboot.exp
@@ -5,7 +5,17 @@
 # Usage: firstboot.exp <host> <port> [root_password]
 #
 
-set timeout 120
+# Use OPENHVF_TIMEOUT from the environment when it exceeds the
+# script default (slow hosts, e.g. TCG emulation in CI)
+proc env_timeout {default} {
+    global env
+    if {[info exists env(OPENHVF_TIMEOUT)] && $env(OPENHVF_TIMEOUT) > $default} {
+        return $env(OPENHVF_TIMEOUT)
+    }
+    return $default
+}
+
+set timeout [env_timeout 120]
 
 if {[llength $argv] < 2} {
     puts stderr "Usage: firstboot.exp <host> <port> \[root_password\]"

--- a/share/openhvf/expect/firstboot.exp
+++ b/share/openhvf/expect/firstboot.exp
@@ -38,6 +38,10 @@ expect {
     "login:" {
         send "root\r"
     }
+    eof {
+        puts stderr "telnet could not connect to the VM console"
+        exit 1
+    }
     timeout {
         puts stderr "Timeout waiting for login prompt"
         exit 1

--- a/share/openhvf/expect/install.exp
+++ b/share/openhvf/expect/install.exp
@@ -46,12 +46,23 @@ proc respond {response} {
 # Connect to console
 spawn telnet $host $port
 
-# Wait for telnet connection
+# Wait for the console connection. telnet prints "Connected to <host>"
+# on success; match on the host-independent prefix since the host may be
+# an IP address. An eof means telnet could not connect at all (console
+# port not listening) - fail fast rather than hang to the full timeout.
 expect {
-    "Connected to localhost" {
+    "Connected to" {
         # Send an empty line to trigger prompt if already at installer
         sleep 0.5
         send "\r"
+    }
+    "Escape character" {
+        sleep 0.5
+        send "\r"
+    }
+    eof {
+        send_user "\n==> ERROR: telnet could not connect to the VM console\n"
+        exit 1
     }
     timeout {
         send_user "\n==> ERROR: Failed to connect to VM console\n"

--- a/share/openhvf/expect/install.exp
+++ b/share/openhvf/expect/install.exp
@@ -5,7 +5,17 @@
 # Usage: install.exp <host> <port> [root_password] [proxy_url]
 #
 
-set timeout 300
+# Use OPENHVF_TIMEOUT from the environment when it exceeds the
+# script default (slow hosts, e.g. TCG emulation in CI)
+proc env_timeout {default} {
+    global env
+    if {[info exists env(OPENHVF_TIMEOUT)] && $env(OPENHVF_TIMEOUT) > $default} {
+        return $env(OPENHVF_TIMEOUT)
+    }
+    return $default
+}
+
+set timeout [env_timeout 300]
 
 if {[llength $argv] < 2} {
     puts stderr "Usage: install.exp <host> <port> \[root_password\] \[proxy_url\]"
@@ -154,7 +164,7 @@ expect "Set name(s)?" {
 expect "Set name(s)?" { respond "done" }
 
 # Wait for sets to install and prompt for more sets
-set timeout 900
+set timeout [env_timeout 900]
 expect {
     "Continue without verification?" { 
         respond "yes" 
@@ -168,7 +178,7 @@ expect {
 }
 
 # Time confirmation (may or may not appear)
-set timeout 60
+set timeout [env_timeout 60]
 expect {
     "Time appears wrong" { 
         respond "yes"

--- a/share/openhvf/expect/install.exp
+++ b/share/openhvf/expect/install.exp
@@ -188,19 +188,37 @@ expect {
     }
 }
 
-# Time confirmation (may or may not appear)
-set timeout [env_timeout 60]
+# The installer may ask to correct the clock before finishing; answer
+# yes if it does. The (R)eboot? prompt marks the end of the install -
+# choose halt instead of reboot so the harness can restart from the
+# installed disk without the miniroot attached. A single expect block
+# handles both so a missing time prompt never stalls to the timeout.
+set timeout [env_timeout 900]
 expect {
-    "Time appears wrong" { 
+    "Time appears wrong" {
         respond "yes"
         exp_continue
     }
+    "(R)eboot?" {
+        respond "h"
+    }
+    timeout {
+        send_user "\n==> ERROR: Timeout waiting for install to finish\n"
+        exit 1
+    }
 }
 
-# Reboot - choose halt instead so we can restart without miniroot
-expect "(R)eboot?" { respond "h" }
-
-# Wait for system to halt
-expect "The operating system has halted"
-expect eof
-exit 0
+# The install is complete once the system halts. Do NOT wait for eof:
+# OpenBSD's halt stops at the "press any key to reboot" prompt without
+# closing the console, so telnet stays connected and no eof ever
+# arrives. The harness terminates QEMU via QMP once this script
+# returns, then restarts from the installed disk.
+set timeout [env_timeout 120]
+expect {
+    "The operating system has halted" { exit 0 }
+    "press any key to reboot" { exit 0 }
+    timeout {
+        send_user "\n==> ERROR: Timeout waiting for system halt\n"
+        exit 1
+    }
+}

--- a/share/openhvf/expect/login.exp
+++ b/share/openhvf/expect/login.exp
@@ -50,6 +50,10 @@ expect {
         puts "Already logged in"
         exit 0
     }
+    eof {
+        puts stderr "telnet could not connect to the VM console"
+        exit 1
+    }
     timeout {
         puts stderr "Timeout waiting for login prompt"
         exit 1

--- a/share/openhvf/expect/login.exp
+++ b/share/openhvf/expect/login.exp
@@ -5,7 +5,17 @@
 # Usage: login.exp <host> <port> [user] [password]
 #
 
-set timeout 30
+# Use OPENHVF_TIMEOUT from the environment when it exceeds the
+# script default (slow hosts, e.g. TCG emulation in CI)
+proc env_timeout {default} {
+    global env
+    if {[info exists env(OPENHVF_TIMEOUT)] && $env(OPENHVF_TIMEOUT) > $default} {
+        return $env(OPENHVF_TIMEOUT)
+    }
+    return $default
+}
+
+set timeout [env_timeout 30]
 
 if {[llength $argv] < 2} {
     puts stderr "Usage: login.exp <host> <port> \[user\] \[password\]"

--- a/t/CLAUDE.md
+++ b/t/CLAUDE.md
@@ -11,10 +11,10 @@ Applies when working on files under `t/`.
 | Module      | `t/openhvf/`              | test VM harness                      | `make test` (host) |
 | Integration | `t/openhap/integration/`  | real daemon, full protocol flow      | `make integration` |
 
-Module tests follow the unit-test rules in the root `CLAUDE.md` (skip
-gracefully on missing dependencies) and need no citations. Integration tests
-follow the stricter rules in `t/openhap/integration/CLAUDE.md` (never skip, no
-log parsing).
+Module tests follow the unit-test rules in the root `CLAUDE.md` (skip gracefully
+on missing dependencies) and need no citations. Integration tests follow the
+stricter rules in `t/openhap/integration/CLAUDE.md` (never skip, no log
+parsing).
 
 ## Conformance tier
 
@@ -55,13 +55,13 @@ ok($error == 0x02, '[HAP-Pairing §2.6] M4 returns kTLVError_Authentication');
 subtest '[HAP-TLV8 §2] fragmentation' => sub { ... };
 ```
 
-The grep pattern is `\[(HAP|MQTT)[A-Za-z0-9-]* §[0-9][0-9.]*(/[^\]]+)?\]`.
-One test may carry several citations. A citation asserts the section's
-requirement — do not cite a section the test merely mentions.
+The grep pattern is `\[(HAP|MQTT)[A-Za-z0-9-]* §[0-9][0-9.]*(/[^\]]+)?\]`. One
+test may carry several citations. A citation asserts the section's requirement —
+do not cite a section the test merely mentions.
 
 Coverage of `spec/` and stale-citation detection are computed by
 `make spec-coverage` (`scripts/spec-coverage`).
 
-Spec citations replace references to audit findings ("Finding N") and
-compliance IDs: audit scratchpads are gitignored and ephemeral, so tests must
-cite the spec sections directly.
+Spec citations replace references to audit findings ("Finding N") and compliance
+IDs: audit scratchpads are gitignored and ephemeral, so tests must cite the spec
+sections directly.

--- a/t/CLAUDE.md
+++ b/t/CLAUDE.md
@@ -1,0 +1,50 @@
+# t/
+
+Applies when working on files under `t/`.
+
+## Test tiers
+
+| Tier        | Location                  | Verifies                        | Runs via           |
+| ----------- | ------------------------- | ------------------------------- | ------------------ |
+| Module      | `t/openhap/` `t/fugulib/` | Perl API behavior, error paths  | `make test` (host) |
+| Module      | `t/openhvf/`              | test VM harness                 | `make test` (host) |
+| Integration | `t/openhap/integration/`  | real daemon, full protocol flow | `make integration` |
+
+Module tests follow the unit-test rules in the root `CLAUDE.md` (skip
+gracefully on missing dependencies). Integration tests follow the stricter
+rules in `t/openhap/integration/CLAUDE.md` (never skip, no log parsing).
+
+## Spec citations
+
+Any assertion of behavior defined by the protocol references in `spec/` must
+carry a machine-parseable citation as a prefix of its subtest name or assertion
+description:
+
+```
+[<spec-stem> §<section>] <free text>
+[<spec-stem> §<section>/<row>] <free text>      # unnumbered table rows
+```
+
+- `<spec-stem>` is the spec file name without `spec/` and `.md`, e.g.
+  `HAP-Pairing` for `spec/HAP-Pairing.md`.
+- `<section>` is a numbered `##`/`###` heading anchor, e.g. `2.6` or `8`.
+- The `/<row>` form points into an unnumbered table row, e.g.
+  `[HAP-Characteristics §5/Brightness]`.
+
+Examples:
+
+```perl
+ok($error == 0x02, '[HAP-Pairing §2.6] M4 returns kTLVError_Authentication');
+subtest '[HAP-TLV8 §2] fragmentation' => sub { ... };
+```
+
+The grep pattern is `\[(HAP|MQTT)[A-Za-z-]* §[0-9][0-9.]*(/[^\]]+)?\]`. One
+test may carry several citations. A citation asserts the section's
+requirement — do not cite a section the test merely mentions.
+
+Coverage of `spec/` and stale-citation detection are computed by
+`make spec-coverage` (`scripts/spec-coverage`).
+
+Spec citations replace references to audit findings ("Finding N") and
+compliance IDs: audit scratchpads are gitignored and ephemeral, so tests must
+cite the spec sections directly.

--- a/t/CLAUDE.md
+++ b/t/CLAUDE.md
@@ -4,15 +4,32 @@ Applies when working on files under `t/`.
 
 ## Test tiers
 
-| Tier        | Location                  | Verifies                        | Runs via           |
-| ----------- | ------------------------- | ------------------------------- | ------------------ |
-| Module      | `t/openhap/` `t/fugulib/` | Perl API behavior, error paths  | `make test` (host) |
-| Module      | `t/openhvf/`              | test VM harness                 | `make test` (host) |
-| Integration | `t/openhap/integration/`  | real daemon, full protocol flow | `make integration` |
+| Tier        | Location                  | Verifies                             | Runs via           |
+| ----------- | ------------------------- | ------------------------------------ | ------------------ |
+| Conformance | `t/conformance/`          | spec requirements, wire formats, KAT | `make test` (host) |
+| Module      | `t/openhap/` `t/fugulib/` | Perl API behavior, error paths       | `make test` (host) |
+| Module      | `t/openhvf/`              | test VM harness                      | `make test` (host) |
+| Integration | `t/openhap/integration/`  | real daemon, full protocol flow      | `make integration` |
 
 Module tests follow the unit-test rules in the root `CLAUDE.md` (skip
-gracefully on missing dependencies). Integration tests follow the stricter
-rules in `t/openhap/integration/CLAUDE.md` (never skip, no log parsing).
+gracefully on missing dependencies) and need no citations. Integration tests
+follow the stricter rules in `t/openhap/integration/CLAUDE.md` (never skip, no
+log parsing).
+
+## Conformance tier
+
+One `.t` per normative spec topic file, named after the lowercased stem
+(`spec/HAP-TLV8.md` ↔ `t/conformance/hap-tlv8.t`). Rules:
+
+- Every subtest name starts with a citation; catalog tables are data-driven
+  loops citing `/<row>`; wire examples from the spec are replayed byte-exactly;
+  crypto known-answer vectors live under the algorithm sections.
+- Host-side, `Test::More` + `subtest`, `skip_all` on missing CPAN dependencies.
+- Data tables and vectors live inline — no network, no `external/`.
+- Shared mocks live in `t/lib/` (e.g. `OpenHAP::TestMock::MQTT`), loaded with
+  `use lib "$RealBin/../lib"`.
+- The index files (`HAP.md`, `MQTT.md`) and `IMPLEMENTATIONS.md` get no test
+  file; their few normative facts are covered by topic files.
 
 ## Spec citations
 
@@ -38,8 +55,8 @@ ok($error == 0x02, '[HAP-Pairing §2.6] M4 returns kTLVError_Authentication');
 subtest '[HAP-TLV8 §2] fragmentation' => sub { ... };
 ```
 
-The grep pattern is `\[(HAP|MQTT)[A-Za-z-]* §[0-9][0-9.]*(/[^\]]+)?\]`. One
-test may carry several citations. A citation asserts the section's
+The grep pattern is `\[(HAP|MQTT)[A-Za-z0-9-]* §[0-9][0-9.]*(/[^\]]+)?\]`.
+One test may carry several citations. A citation asserts the section's
 requirement — do not cite a section the test merely mentions.
 
 Coverage of `spec/` and stale-citation detection are computed by

--- a/t/conformance/hap-categories.t
+++ b/t/conformance/hap-categories.t
@@ -1,0 +1,53 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/HAP-Categories.md
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+use File::Temp qw(tempdir);
+
+BEGIN {
+	eval { require Crypt::Ed25519; require JSON::XS; };
+	if ($@) {
+		plan skip_all => 'Required modules not available';
+	}
+}
+
+use_ok('OpenHAP::HAP');
+
+subtest '[HAP-Categories §1] bridge category identifier is 2' => sub {
+	my $hap = OpenHAP::HAP->new(
+		port         => 51827,
+		pin          => '123-45-678',
+		name         => 'Category Bridge',
+		storage_path => tempdir( CLEANUP => 1 ),
+	);
+
+	my $txt = $hap->get_mdns_txt_records;
+	is( $txt->{ci}, 2,
+		'[HAP-Categories §1/Bridge] OpenHAP advertises '
+		    . 'CATEGORY_BRIDGE (2)' );
+};
+
+subtest '[HAP-Categories §3] category advertised in mDNS ci field' => sub {
+	my $hap = OpenHAP::HAP->new(
+		port         => 51828,
+		pin          => '123-45-678',
+		name         => 'Category Bridge',
+		storage_path => tempdir( CLEANUP => 1 ),
+	);
+
+	my $txt = $hap->get_mdns_txt_records;
+	ok( exists $txt->{ci}, 'ci field present in TXT records' );
+	like( $txt->{ci}, qr/^\d+$/, 'ci is a numeric identifier' );
+
+	# The category is a UI hint only; bridged accessories of any
+	# service type still live behind ci=2
+	is( $txt->{ci}, 2, 'bridge category regardless of bridged devices' );
+};
+
+done_testing();

--- a/t/conformance/hap-characteristics.t
+++ b/t/conformance/hap-characteristics.t
@@ -1,0 +1,293 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/HAP-Characteristics.md
+#
+# Data-driven over the characteristics OpenHAP implements; catalog rows
+# are cited as [HAP-Characteristics §5/<Name>] and the UUID table as
+# §6 rows.
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use lib "$RealBin/../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+use_ok('OpenHAP::Characteristic');
+use_ok('OpenHAP::Bridge');
+use_ok('OpenHAP::TestMock::MQTT');
+use_ok('OpenHAP::Tasmota::Heater');
+use_ok('OpenHAP::Tasmota::Sensor');
+use_ok('OpenHAP::Tasmota::Thermostat');
+use_ok('OpenHAP::Tasmota::Lightbulb');
+
+# [HAP-Characteristics §5] catalog rows for the characteristics OpenHAP
+# implements: short UUID, format, spec permissions, spec range, unit
+my %catalog = (
+	Identify => {
+		short  => '14',
+		format => 'bool',
+		perms  => [qw(pw)],
+	},
+	Manufacturer     => { short => '20', format => 'string',
+		perms => [qw(pr)] },
+	Model            => { short => '21', format => 'string',
+		perms => [qw(pr)] },
+	Name             => { short => '23', format => 'string',
+		perms => [qw(pr)] },
+	SerialNumber     => { short => '30', format => 'string',
+		perms => [qw(pr)] },
+	FirmwareRevision => { short => '52', format => 'string',
+		perms => [qw(pr)] },
+	Version          => { short => '37', format => 'string',
+		perms => [qw(pr)] },
+	On => {
+		short  => '25',
+		format => 'bool',
+		perms  => [qw(pr pw ev)],
+	},
+	Brightness => {
+		short  => '8',
+		format => 'int',
+		perms  => [qw(pr pw ev)],
+		range  => [ 0, 100 ],
+		unit   => 'percentage',
+	},
+	Hue => {
+		short  => '13',
+		format => 'float',
+		perms  => [qw(pr pw ev)],
+		range  => [ 0, 360 ],
+		unit   => 'arcdegrees',
+	},
+	Saturation => {
+		short  => '2F',
+		format => 'float',
+		perms  => [qw(pr pw ev)],
+		range  => [ 0, 100 ],
+		unit   => 'percentage',
+	},
+	ColorTemperature => {
+		short  => 'CE',
+		format => 'uint32',
+		perms  => [qw(pr pw ev)],
+		range  => [ 140, 500 ],
+	},
+	CurrentTemperature => {
+		short  => '11',
+		format => 'float',
+		perms  => [qw(pr ev)],
+		range  => [ -273.1, 1000 ],
+		unit   => 'celsius',
+	},
+	TargetTemperature => {
+		short  => '35',
+		format => 'float',
+		perms  => [qw(pr pw ev)],
+		range  => [ 10, 38 ],
+		unit   => 'celsius',
+	},
+	TemperatureDisplayUnits => {
+		short  => '36',
+		format => 'uint8',
+		perms  => [qw(pr pw ev)],
+		range  => [ 0, 1 ],
+	},
+	CurrentHeatingCoolingState => {
+		short  => 'F',
+		format => 'uint8',
+		perms  => [qw(pr ev)],
+		range  => [ 0, 2 ],
+	},
+	TargetHeatingCoolingState => {
+		short  => '33',
+		format => 'uint8',
+		perms  => [qw(pr pw ev)],
+		range  => [ 0, 3 ],
+	},
+	CurrentRelativeHumidity => {
+		short  => '10',
+		format => 'float',
+		perms  => [qw(pr ev)],
+		range  => [ 0, 100 ],
+		unit   => 'percentage',
+	},
+	OutletInUse => {
+		short  => '26',
+		format => 'bool',
+		perms  => [qw(pr ev)],
+	},
+);
+
+subtest '[HAP-Characteristics §6] characteristic UUID table' => sub {
+	for my $name ( sort keys %OpenHAP::Characteristic::CHAR_TYPES ) {
+		my $row = $catalog{$name};
+		ok( $row, "catalog covers implemented type $name" ) or next;
+		my $short = $row->{short};
+		my $full  = sprintf '%08s-0000-1000-8000-0026BB765291',
+		    '0' x ( 8 - length $short ) . $short;
+		is( $OpenHAP::Characteristic::CHAR_TYPES{$name},
+			$full,
+			"[HAP-Characteristics §6/$name] UUID is $full" );
+	}
+};
+
+subtest '[HAP-Characteristics §2] data formats' => sub {
+	my @spec_formats =
+	    qw(bool uint8 uint16 uint32 uint64 int float string tlv8 data);
+	for my $format (@spec_formats) {
+		ok( $OpenHAP::Characteristic::FORMATS{$format},
+			"format $format recognized" );
+	}
+	is( scalar keys %OpenHAP::Characteristic::FORMATS,
+		scalar @spec_formats, 'no formats beyond the spec table' );
+};
+
+subtest '[HAP-Characteristics §3] permissions' => sub {
+	my @spec_perms = qw(pr pw ev aa tw hd wr);
+	for my $perm (@spec_perms) {
+		ok( $OpenHAP::Characteristic::PERMISSIONS{$perm},
+			"permission $perm recognized" );
+	}
+	is( scalar keys %OpenHAP::Characteristic::PERMISSIONS,
+		scalar @spec_perms,
+		'no permissions beyond the spec table' );
+};
+
+subtest '[HAP-Characteristics §1][HAP-Characteristics §7] JSON shape' =>
+    sub {
+	my $value = 75;
+	my $char  = OpenHAP::Characteristic->new(
+		type   => 'Brightness',
+		iid    => 10,
+		format => 'int',
+		perms  => [ 'pr', 'pw', 'ev' ],
+		unit   => 'percentage',
+		value  => \$value,
+		min    => 0,
+		max    => 100,
+		step   => 1,
+	);
+
+	my $json = $char->to_json;
+	is( $json->{iid},      10,           'iid encoded' );
+	is( $json->{type},     '8',          'short type encoded' );
+	is( $json->{format},   'int',        'format encoded' );
+	is( $json->{value},    75,           'value encoded' );
+	is( $json->{minValue}, 0,            'minValue encoded' );
+	is( $json->{maxValue}, 100,          'maxValue encoded' );
+	is( $json->{minStep},  1,            'minStep encoded' );
+	is( $json->{unit},     'percentage', 'unit encoded' );
+	is_deeply( $json->{perms}, [ 'pr', 'pw', 'ev' ], 'perms encoded' );
+
+	# [HAP-Characteristics §8] a write-only characteristic omits value
+	my $write_only = OpenHAP::Characteristic->new(
+		type   => 'Identify',
+		iid    => 2,
+		format => 'bool',
+		perms  => ['pw'],
+	);
+	ok( !exists $write_only->to_json->{value},
+		'[HAP-Characteristics §8] non-readable value omitted' );
+};
+
+# Instantiate every device type and check each characteristic instance
+# against its catalog row
+subtest '[HAP-Characteristics §5] device characteristics match rows' =>
+    sub {
+	my $mqtt        = OpenHAP::TestMock::MQTT->new;
+	my @accessories = (
+		OpenHAP::Bridge->new( name => 'Bridge' ),
+		OpenHAP::Tasmota::Heater->new(
+			aid         => 2,
+			name        => 'Heater',
+			mqtt_topic  => 'h',
+			mqtt_client => $mqtt,
+		),
+		OpenHAP::Tasmota::Sensor->new(
+			aid          => 3,
+			name         => 'Sensor',
+			mqtt_topic   => 's',
+			mqtt_client  => $mqtt,
+			has_humidity => 1,
+		),
+		OpenHAP::Tasmota::Thermostat->new(
+			aid         => 4,
+			name        => 'Thermostat',
+			mqtt_topic  => 't',
+			mqtt_client => $mqtt,
+		),
+		OpenHAP::Tasmota::Lightbulb->new(
+			aid          => 5,
+			name         => 'Light',
+			mqtt_topic   => 'l',
+			mqtt_client  => $mqtt,
+			capabilities =>
+			    OpenHAP::Tasmota::Lightbulb::CAP_DIMMER() |
+			    OpenHAP::Tasmota::Lightbulb::CAP_COLOR() |
+			    OpenHAP::Tasmota::Lightbulb::CAP_CT(),
+		),
+	);
+
+	my %short_to_name =
+	    map { $catalog{$_}{short} => $_ } keys %catalog;
+
+	for my $accessory (@accessories) {
+		for my $service ( $accessory->get_services ) {
+			for my $char ( $service->get_characteristics ) {
+				my $short = $char->to_json->{type};
+				my $name  = $short_to_name{$short};
+				ok( $name,
+					"$accessory->{name}: type $short is "
+					    . 'in the spec catalog' )
+				    or next;
+				check_row( $accessory->{name}, $name,
+					$char );
+			}
+		}
+	}
+};
+
+# check_row($where, $name, $char): assert one characteristic instance
+# against its spec catalog row
+sub check_row ( $where, $name, $char )
+{
+	my $row   = $catalog{$name};
+	my $label = "[HAP-Characteristics §5/$name] $where";
+
+	is( $char->{format}, $row->{format},
+		"$label: format is $row->{format}" );
+
+	my %allowed = map { $_ => 1 } @{ $row->{perms} };
+	my @extra   = grep { !$allowed{$_} } @{ $char->{perms} };
+	is( "@extra", '', "$label: permissions within spec set" );
+
+	if ( $row->{range} ) {
+		my ( $spec_min, $spec_max ) = @{ $row->{range} };
+		if ( defined $char->{min} ) {
+			ok( $char->{min} >= $spec_min,
+				"$label: min within spec range" );
+		}
+		if ( defined $char->{max} ) {
+			ok( $char->{max} <= $spec_max,
+				"$label: max within spec range" );
+		}
+	}
+
+	if ( $row->{unit} && defined $char->{unit} ) {
+		is( $char->{unit}, $row->{unit},
+			"$label: unit is $row->{unit}" );
+	}
+
+	# [HAP-Characteristics §4] any unit used must be a spec unit
+	if ( defined $char->{unit} ) {
+		my %spec_units =
+		    map { $_ => 1 } qw(celsius percentage arcdegrees
+		    lux seconds);
+		ok( $spec_units{ $char->{unit} },
+			"$label: unit is a defined HAP unit" );
+	}
+}
+
+done_testing();

--- a/t/conformance/hap-encryption-exchange.t
+++ b/t/conformance/hap-encryption-exchange.t
@@ -1,0 +1,178 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Session-framing assertions over a real verified in-process session
+# established by OpenHAP::Test::Controller (spec/HAP-Encryption.md).
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+use File::Temp qw(tempdir);
+
+BEGIN {
+	eval {
+		require Math::BigInt;
+		require Crypt::Ed25519;
+		require Crypt::Curve25519;
+		require Crypt::AuthEnc::ChaCha20Poly1305;
+		require JSON::XS;
+	};
+	if ($@) {
+		plan skip_all => 'Crypto dependencies not available';
+	}
+}
+
+use_ok('OpenHAP::HAP');
+use_ok('OpenHAP::HTTP');
+use_ok('OpenHAP::Session');
+use_ok('OpenHAP::Pairing');
+use_ok('OpenHAP::Test::Controller');
+
+my $PIN = '123-45-678';
+
+# Transport that records the raw (encrypted) bytes both directions
+my @wire;
+
+sub make_verified_pair ()
+{
+	OpenHAP::Pairing->clear_pairing_state();
+
+	my $hap = OpenHAP::HAP->new(
+		port         => 51827,
+		pin          => $PIN,
+		name         => 'Frame Bridge',
+		storage_path => tempdir( CLEANUP => 1 ),
+	);
+	$hap->{pairing}->reset_auth_attempts;
+
+	my $session   = OpenHAP::Session->new( socket => 'in-process' );
+	my $transport = sub ($request_bytes) {
+		my $was_encrypted = $session->is_encrypted;
+		push @wire,
+		    {
+			direction => 'c2a',
+			encrypted => $was_encrypted,
+			bytes     => $request_bytes
+		    };
+		my $plain =
+		    $was_encrypted
+		    ? $session->decrypt($request_bytes)
+		    : $request_bytes;
+		return unless defined $plain;
+		my $request  = OpenHAP::HTTP::parse($plain);
+		my $response = $hap->_dispatch( $request, $session );
+		$response = $session->encrypt($response) if $was_encrypted;
+		push @wire,
+		    {
+			direction => 'a2c',
+			encrypted => $was_encrypted,
+			bytes     => $response
+		    };
+		return $response;
+	};
+
+	my $controller = OpenHAP::Test::Controller->new(
+		pin       => $PIN,
+		transport => $transport,
+	);
+
+	ok( $controller->pair_setup,  'pair-setup completes' );
+	ok( $controller->pair_verify, 'pair-verify completes' );
+	@wire = ();
+
+	return ( $controller, $hap, $session );
+}
+
+sub frame_lengths ($bytes)
+{
+	my @lengths;
+	my $pos = 0;
+	while ( $pos + 2 <= length($bytes) ) {
+		my $length = unpack( 'v', substr( $bytes, $pos, 2 ) );
+		push @lengths, $length;
+		$pos += 2 + $length + 16;
+	}
+	return ( \@lengths, $pos == length($bytes) );
+}
+
+subtest '[HAP-Encryption §2][HAP-Encryption §3] frame layout both '
+    . 'directions' => sub {
+	my ( $controller, $hap, $session ) = make_verified_pair();
+
+	my $response = $controller->request( 'GET', '/accessories' );
+	is( $response->{status}, 200, 'encrypted request succeeded' );
+
+	my ($c2a) = grep { $_->{direction} eq 'c2a' } @wire;
+	my ($a2c) = grep { $_->{direction} eq 'a2c' } @wire;
+
+	for my $leg ( [ 'controller-to-accessory', $c2a ],
+		[ 'accessory-to-controller', $a2c ] )
+	{
+		my ( $name, $capture ) = @$leg;
+		ok( $capture->{encrypted}, "$name leg is encrypted" );
+
+		my ( $lengths, $exact ) =
+		    frame_lengths( $capture->{bytes} );
+		ok( $exact,
+			"$name stream is a whole number of frames" );
+		ok( ( !grep { $_ > 1024 } @$lengths ),
+			"$name frames carry at most 1024 bytes" );
+
+		# each frame is 2-byte LE length + ciphertext + 16-byte tag
+		my $expected = 0;
+		$expected += 2 + $_ + 16 for @$lengths;
+		is( length( $capture->{bytes} ),
+			$expected, "$name frame overhead is 18 bytes" );
+	}
+
+	# Plaintext is not visible on the wire
+	unlike( $a2c->{bytes}, qr/"accessories"/,
+		'accessory JSON not visible in the encrypted stream' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Encryption §4][HAP-Encryption §6] counters increment '
+    . 'per frame and direction' => sub {
+	my ( $controller, $hap, $session ) = make_verified_pair();
+
+	$controller->request( 'GET', '/accessories' );
+	$controller->request( 'GET', '/accessories' );
+
+	# Two requests, two responses; the response to /accessories is
+	# larger than 1024 bytes so it spans several frames
+	my @c2a = grep { $_->{direction} eq 'c2a' } @wire;
+	is( scalar @c2a, 2, 'two request transmissions' );
+
+	is( $controller->{encrypt_count},
+		2, 'controller write counter advanced once per frame' );
+	cmp_ok( $controller->{decrypt_count}, '>=', 2,
+		'controller read counter advanced per response frame' );
+	is( $session->{decrypt_count},
+		$controller->{encrypt_count},
+		'accessory read counter mirrors controller writes' );
+	is( $session->{encrypt_count},
+		$controller->{decrypt_count},
+		'accessory write counter mirrors controller reads' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Encryption §9] tampered frame fails the session' => sub {
+	my ( $controller, $hap, $session ) = make_verified_pair();
+
+	# Build a valid encrypted request, then flip a ciphertext bit
+	my $raw = $controller->_build_request( 'GET', '/accessories' );
+	my $encrypted = $controller->_encrypt($raw);
+	substr( $encrypted, 5, 1 ) =
+	    substr( $encrypted, 5, 1 ) ^. "\x01";
+
+	ok( !defined $session->decrypt($encrypted),
+		'accessory rejects the tampered frame' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+done_testing();

--- a/t/conformance/hap-encryption.t
+++ b/t/conformance/hap-encryption.t
@@ -1,0 +1,253 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/HAP-Encryption.md
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+BEGIN {
+	eval { require Crypt::AuthEnc::ChaCha20Poly1305; };
+	if ($@) {
+		plan skip_all => 'CryptX not available';
+	}
+}
+
+use_ok('OpenHAP::Crypto');
+use_ok('OpenHAP::Session');
+
+# Fixed 32-byte keys for deterministic frame tests
+my $key_a2c = pack( 'H*', '11' x 32 );
+my $key_c2a = pack( 'H*', '22' x 32 );
+
+# Accessory-side session: encrypts with a2c, decrypts with c2a
+sub accessory_session ()
+{
+	my $session = OpenHAP::Session->new( socket => 'dummy' );
+	$session->set_encryption( $key_a2c, $key_c2a );
+	return $session;
+}
+
+# Controller-side decrypt of an accessory frame, built from primitives
+sub controller_decrypt ( $frame, $counter )
+{
+	my $aad        = substr( $frame, 0, 2 );
+	my $length     = unpack( 'v', $aad );
+	my $ciphertext = substr( $frame, 2, $length );
+	my $tag        = substr( $frame, 2 + $length, 16 );
+	my $nonce      = pack( 'x[4]Q<', $counter );
+	return OpenHAP::Crypto::chacha20_poly1305_decrypt( $key_a2c, $nonce,
+		$ciphertext, $tag, $aad );
+}
+
+subtest '[HAP-Encryption §2] frame layout on raw bytes' => sub {
+	my $session   = accessory_session();
+	my $plaintext = "HTTP/1.1 200 OK\r\n\r\n";
+	my $frame     = $session->encrypt($plaintext);
+
+	is( length($frame), 2 + length($plaintext) + 16,
+		'frame is 2-byte length + ciphertext + 16-byte tag' );
+	is( unpack( 'v', substr( $frame, 0, 2 ) ),
+		length($plaintext),
+		'length field is little-endian plaintext length' );
+	is( unpack( 'H*', substr( $frame, 0, 2 ) ),
+		'1300',
+		'[HAP-Encryption §8] 19-byte payload length field is 13 00' );
+	isnt( substr( $frame, 2, length($plaintext) ),
+		$plaintext, 'payload bytes are encrypted' );
+};
+
+subtest '[HAP-Encryption §2] max 1024 bytes plaintext per frame' => sub {
+	my $session   = accessory_session();
+	my $plaintext = 'A' x 2500;
+	my $stream    = $session->encrypt($plaintext);
+
+	# 2500 bytes -> frames of 1024, 1024, 452
+	my @lengths;
+	my $pos = 0;
+	while ( $pos < length($stream) ) {
+		my $length = unpack( 'v', substr( $stream, $pos, 2 ) );
+		push @lengths, $length;
+		$pos += 2 + $length + 16;
+	}
+	is_deeply( \@lengths, [ 1024, 1024, 452 ],
+		'[HAP-Encryption §8] 2500 bytes split into 1024 + 1024 + 452'
+	);
+	is( length($stream), 2500 + 3 * 18,
+		'[HAP-Encryption §8] total overhead is 18 bytes per frame' );
+};
+
+subtest '[HAP-Encryption §3] AAD is the length field' => sub {
+	my $session = accessory_session();
+	my $frame   = $session->encrypt('hello');
+
+	# Decrypting with the frame's own AAD succeeds
+	is( controller_decrypt( $frame, 0 ),
+		'hello', 'decrypts with length field as AAD' );
+
+	# Recomputing with a different AAD fails
+	my $length     = unpack( 'v', substr( $frame, 0, 2 ) );
+	my $ciphertext = substr( $frame, 2, $length );
+	my $tag        = substr( $frame, 2 + $length, 16 );
+	my $nonce      = pack( 'x[4]Q<', 0 );
+	my $plaintext =
+	    OpenHAP::Crypto::chacha20_poly1305_decrypt( $key_a2c, $nonce,
+		$ciphertext, $tag, pack( 'v', $length + 1 ) );
+	ok( !defined $plaintext, 'wrong AAD fails authentication' );
+};
+
+subtest '[HAP-Encryption §4] nonce is 4 zero bytes + LE counter' => sub {
+	my $session = accessory_session();
+	my $frame0  = $session->encrypt('first');
+	my $frame1  = $session->encrypt('second');
+
+	# Counter starts at 0 and increments per frame, per direction
+	is( controller_decrypt( $frame0, 0 ),
+		'first', 'first frame uses counter 0' );
+	is( controller_decrypt( $frame1, 1 ),
+		'second', 'second frame uses counter 1' );
+	ok( !defined controller_decrypt( $frame1, 0 ),
+		'frame does not decrypt under the wrong counter' );
+
+	# Direction counters are independent: controller->accessory
+	# counter starts at 0 regardless of accessory->controller traffic
+	my $c2a_nonce = pack( 'x[4]Q<', 0 );
+	my ( $ciphertext, $tag ) =
+	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $key_c2a, $c2a_nonce,
+		'PUT /characteristics', pack( 'v', 20 ) );
+	my $inbound = pack( 'v', 20 ) . $ciphertext . $tag;
+	is( $session->decrypt($inbound),
+		'PUT /characteristics',
+		'[HAP-Encryption §5][HAP-Encryption §6] inbound frame '
+		    . 'decrypts under its own direction counter' );
+
+	# Nonce layout: 12 bytes, first 4 zero, counter little-endian
+	is( unpack( 'H*', pack( 'x[4]Q<', 1 ) ),
+		'000000000100000000000000', 'counter 1 nonce layout' );
+};
+
+subtest '[HAP-Encryption §7] ChaCha20-Poly1305 RFC 8439 vector' => sub {
+	my $key = pack( 'H*',
+		'808182838485868788898a8b8c8d8e8f'
+		    . '909192939495969798999a9b9c9d9e9f' );
+	my $nonce     = pack( 'H*', '070000004041424344454647' );
+	my $aad       = pack( 'H*', '50515253c0c1c2c3c4c5c6c7' );
+	my $plaintext = "Ladies and Gentlemen of the class of '99: "
+	    . 'If I could offer you only one tip for the future, '
+	    . 'sunscreen would be it.';
+
+	my ( $ciphertext, $tag ) =
+	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $key, $nonce,
+		$plaintext, $aad );
+
+	is( unpack( 'H*', $ciphertext ),
+		'd31a8d34648e60db7b86afbc53ef7ec2'
+		    . 'a4aded51296e08fea9e2b5a736ee62d6'
+		    . '3dbea45e8ca9671282fafb69da92728b'
+		    . '1a71de0a9e060b2905d6a5b67ecd3b36'
+		    . '92ddbd7f2d778b8c9803aee328091b58'
+		    . 'fab324e4fad675945585808b4831d7bc'
+		    . '3ff4def08e4b7a9de576d26586cec64b'
+		    . '6116',
+		'RFC 8439 §2.8.2 ciphertext'
+	);
+	is( unpack( 'H*', $tag ),
+		'1ae10b594f09e26a7e902ecbd0600691',
+		'RFC 8439 §2.8.2 auth tag' );
+
+	is(
+		OpenHAP::Crypto::chacha20_poly1305_decrypt(
+			$key, $nonce, $ciphertext, $tag, $aad
+		),
+		$plaintext,
+		'RFC 8439 vector decrypts'
+	);
+};
+
+subtest '[HAP-Encryption §9] error handling' => sub {
+	my $session = accessory_session();
+
+	# Build a valid inbound frame, then tamper with it
+	my $nonce = pack( 'x[4]Q<', 0 );
+	my ( $ciphertext, $tag ) =
+	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $key_c2a, $nonce,
+		'GET /accessories', pack( 'v', 16 ) );
+	my $good = pack( 'v', 16 ) . $ciphertext . $tag;
+
+	# Bad auth tag
+	my $tampered = $good;
+	substr( $tampered, -1, 1 ) =
+	    substr( $tampered, -1, 1 ) ^. "\x01";
+	ok( !defined accessory_session()->decrypt($tampered),
+		'bad auth tag fails decryption' );
+
+	# Truncated frame (incomplete at EOF)
+	my $truncated = substr( $good, 0, length($good) - 4 );
+	ok( !defined accessory_session()->decrypt($truncated),
+		'incomplete frame is an error' );
+
+	# Frame length > 1024
+	my $oversize = pack( 'v', 1025 ) . ( 'X' x ( 1025 + 16 ) );
+	ok( !defined accessory_session()->decrypt($oversize),
+		'frame length over 1024 is an error' );
+
+	# Valid frame still decrypts (control)
+	is( accessory_session()->decrypt($good),
+		'GET /accessories',
+		'[HAP-Encryption §5] control frame decrypts' );
+};
+
+subtest '[HAP-Encryption §1] session key derivation' => sub {
+
+	# Both directions derive from the shared secret with Control-Salt
+	my $shared = pack( 'H*', 'ab' x 32 );
+	my $read_key =
+	    OpenHAP::Crypto::hkdf_sha512( $shared, 'Control-Salt',
+		'Control-Read-Encryption-Key', 32 );
+	my $write_key =
+	    OpenHAP::Crypto::hkdf_sha512( $shared, 'Control-Salt',
+		'Control-Write-Encryption-Key', 32 );
+
+	is( length($read_key),  32, 'AccessoryToControllerKey is 32 bytes' );
+	is( length($write_key), 32, 'ControllerToAccessoryKey is 32 bytes' );
+	isnt( unpack( 'H*', $read_key ),
+		unpack( 'H*', $write_key ),
+		'read and write keys differ' );
+
+	# The accessory session encrypts outbound with the read key
+	my $session = OpenHAP::Session->new( socket => 'dummy' );
+	$session->set_encryption( $read_key, $write_key );
+	my $frame = $session->encrypt('response');
+	my $aad   = substr( $frame, 0, 2 );
+	is(
+		OpenHAP::Crypto::chacha20_poly1305_decrypt(
+			$read_key, pack( 'x[4]Q<', 0 ),
+			substr( $frame, 2, -16 ),
+			substr( $frame, -16 ), $aad
+		),
+		'response',
+		'accessory outgoing data uses Control-Read-Encryption-Key'
+	);
+};
+
+subtest '[HAP-Encryption §10] connection lifecycle' => sub {
+	my $session = OpenHAP::Session->new( socket => 'dummy' );
+
+	# Before pair-verify the session passes data through unencrypted
+	ok( !$session->is_encrypted, 'session starts unencrypted' );
+	is( $session->encrypt('plain'), 'plain',
+		'pre-verify data is not framed' );
+	is( $session->decrypt('plain'), 'plain',
+		'pre-verify inbound data is passed through' );
+
+	# After key setup every byte is framed and encrypted
+	$session->set_encryption( $key_a2c, $key_c2a );
+	ok( $session->is_encrypted, 'session encrypted after key setup' );
+	isnt( $session->encrypt('plain'), 'plain',
+		'post-verify data is encrypted' );
+};
+
+done_testing();

--- a/t/conformance/hap-http.t
+++ b/t/conformance/hap-http.t
@@ -1,0 +1,584 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/HAP-HTTP.md
+#
+# Drives OpenHAP::HAP request dispatch in-process (no sockets); the
+# session's verification state is set directly to model the paired and
+# unpaired cases.
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use lib "$RealBin/../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+use File::Temp qw(tempdir);
+use JSON::PP   ();
+
+BEGIN {
+	eval {
+		require IO::Socket::INET;
+		require Crypt::Ed25519;
+		require JSON::XS;
+		require Crypt::AuthEnc::ChaCha20Poly1305;
+	};
+	if ($@) {
+		plan skip_all => 'Required modules not available';
+	}
+}
+
+use_ok('OpenHAP::HAP');
+use_ok('OpenHAP::HTTP');
+use_ok('OpenHAP::Session');
+use_ok('OpenHAP::TLV');
+use_ok('OpenHAP::Pairing');
+use_ok('OpenHAP::TestMock::MQTT');
+use_ok('OpenHAP::Tasmota::Heater');
+
+# Mock socket that records writes for event delivery tests
+package MockSocket;
+
+sub new ($class) { bless { written => '' }, $class }
+sub connected ($self) { 1 }
+sub syswrite ( $self, $data ) { $self->{written} .= $data; length $data }
+
+package main;
+
+my $json = JSON::PP->new;
+
+sub make_hap ()
+{
+	my $hap = OpenHAP::HAP->new(
+		port         => 51827,
+		pin          => '123-45-678',
+		name         => 'Conformance Bridge',
+		storage_path => tempdir( CLEANUP => 1 ),
+	);
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'Test Heater',
+		mqtt_topic  => 'heater',
+		mqtt_client => $mqtt,
+	);
+	$hap->add_accessory($heater);
+	return $hap;
+}
+
+sub verified_session ( $controller_id = 'test-controller' )
+{
+	my $session = OpenHAP::Session->new( socket => 'dummy' );
+	$session->set_verified($controller_id);
+	return $session;
+}
+
+sub dispatch ( $hap, $method, $path, $body = undef, $session = undef )
+{
+	$session //= verified_session();
+	my $request = {
+		method => $method,
+		path   => $path,
+		body   => $body // '',
+	};
+	my $response = $hap->_dispatch( $request, $session );
+	my ( $head, $resp_body ) = split /\r\n\r\n/, $response, 2;
+	my ($status) = $head =~ m{^HTTP/1\.1 (\d+)};
+	my %headers;
+	for my $line ( split /\r\n/, $head ) {
+		$headers{ lc $1 } = $2 if $line =~ /^([^:]+):\s*(.*)$/;
+	}
+	return ( $status, \%headers, $resp_body // '' );
+}
+
+# Find the aid/iid of a characteristic by short type in /accessories
+sub find_char ( $accessories, $type )
+{
+	for my $acc ( @{ $accessories->{accessories} } ) {
+		for my $svc ( @{ $acc->{services} } ) {
+			for my $char ( @{ $svc->{characteristics} } ) {
+				return ( $acc->{aid}, $char->{iid} )
+				    if $char->{type} eq $type;
+			}
+		}
+	}
+	return;
+}
+
+subtest '[HAP-HTTP §1] endpoints require a verified session' => sub {
+	my $hap        = make_hap();
+	my $unverified = OpenHAP::Session->new( socket => 'dummy' );
+
+	for my $probe (
+		[ 'POST', '/pairings' ],
+		[ 'GET',  '/accessories' ],
+		[ 'GET',  '/characteristics?id=1.1' ],
+		[ 'PUT',  '/characteristics' ],
+		[ 'PUT',  '/prepare' ],
+	    )
+	{
+		my ( $status, undef, undef ) =
+		    dispatch( $hap, @$probe, undef, $unverified );
+		is( $status, 470,
+			"[HAP-HTTP §13.4] @$probe returns 470 "
+			    . 'without pair-verify' );
+	}
+
+	# Pairing endpoints do not require verification
+	my $m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
+	);
+	my ( $status, undef, undef ) =
+	    dispatch( $hap, 'POST', '/pair-setup', $m1, $unverified );
+	is( $status, 200,
+		'[HAP-HTTP §4] POST /pair-setup open to unverified sessions'
+	);
+	OpenHAP::Pairing->clear_pairing_state();
+
+	# Pair-verify is likewise open and answers with TLV
+	my $pv_m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),     pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_PublicKey(), 'X' x 32,
+	);
+	( $status, my $headers, undef ) =
+	    dispatch( $hap, 'POST', '/pair-verify', $pv_m1, $unverified );
+	is( $status, 200,
+		'[HAP-HTTP §5] POST /pair-verify open to unverified sessions'
+	);
+};
+
+subtest '[HAP-HTTP §2] content types' => sub {
+	my $hap = make_hap();
+
+	my $m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
+	);
+	my ( undef, $headers, undef ) =
+	    dispatch( $hap, 'POST', '/pair-setup', $m1,
+		OpenHAP::Session->new( socket => 'dummy' ) );
+	is( $headers->{'content-type'},
+		'application/pairing+tlv8',
+		'pairing endpoints use application/pairing+tlv8' );
+	OpenHAP::Pairing->clear_pairing_state();
+
+	( undef, $headers, undef ) = dispatch( $hap, 'GET', '/accessories' );
+	is( $headers->{'content-type'},
+		'application/hap+json',
+		'accessory endpoints use application/hap+json' );
+};
+
+subtest '[HAP-HTTP §3] POST /identify paired vs unpaired' => sub {
+	my $hap = make_hap();
+	my $unverified = OpenHAP::Session->new( socket => 'dummy' );
+
+	my ( $status, undef, undef ) =
+	    dispatch( $hap, 'POST', '/identify', undef, $unverified );
+	is( $status, 204, 'unpaired identify returns 204 No Content' );
+
+	$hap->{storage}->save_pairing( 'controller', 'X' x 32, 1 );
+	( $status, undef, my $body ) =
+	    dispatch( $hap, 'POST', '/identify', undef, $unverified );
+	is( $status, 400, 'paired identify returns 400' );
+	is( $json->decode($body)->{status},
+		-70401, 'paired identify body is {"status":-70401}' );
+};
+
+subtest '[HAP-HTTP §7] GET /accessories structure' => sub {
+	my $hap = make_hap();
+	my ( $status, undef, $body ) =
+	    dispatch( $hap, 'GET', '/accessories' );
+
+	is( $status, 200, 'returns 200 with body' );
+	my $data = $json->decode($body);
+	ok( ref $data->{accessories} eq 'ARRAY', 'accessories array' );
+
+	my ($bridge) = grep { $_->{aid} == 1 } @{ $data->{accessories} };
+	ok( $bridge, 'bridge accessory has aid 1' );
+
+	my ($heater) = grep { $_->{aid} == 2 } @{ $data->{accessories} };
+	ok( $heater, '[HAP-HTTP §7.1] accessory object has aid and services' );
+	ok( ref $heater->{services} eq 'ARRAY',
+		'[HAP-HTTP §7.1] services is an array' );
+	for my $svc ( @{ $heater->{services} } ) {
+		ok( defined $svc->{iid},
+			'[HAP-HTTP §7.2] service object has iid' );
+		ok( defined $svc->{type},
+			'[HAP-HTTP §7.2] service object has type' );
+		ok( ref $svc->{characteristics} eq 'ARRAY',
+			'[HAP-HTTP §7.2] service has characteristics array' );
+	}
+
+	# [HAP-HTTP §7.3] characteristic objects carry type, iid, perms,
+	# format, and value for readable characteristics
+	my ($char) =
+	    grep { $_->{type} eq '25' }
+	    map  { @{ $_->{characteristics} } } @{ $heater->{services} };
+	ok( $char, 'found On characteristic object' );
+	ok( defined $char->{iid},
+		'[HAP-HTTP §7.3] characteristic has iid' );
+	ok( defined $char->{format},
+		'[HAP-HTTP §7.3] characteristic has format' );
+	ok( ref $char->{perms} eq 'ARRAY',
+		'[HAP-HTTP §7.3] characteristic has perms' );
+	ok( exists $char->{value},
+		'[HAP-HTTP §7.3] readable characteristic has value' );
+};
+
+subtest '[HAP-HTTP §8] GET /characteristics' => sub {
+	my $hap = make_hap();
+	my ( undef, undef, $acc_body ) =
+	    dispatch( $hap, 'GET', '/accessories' );
+	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
+	ok( defined $iid, 'found On characteristic' );
+
+	my ( $status, undef, $body ) =
+	    dispatch( $hap, 'GET', "/characteristics?id=$aid.$iid" );
+	is( $status, 200,
+		'[HAP-HTTP §13.1][HAP-HTTP §16.1] valid read returns 200' );
+	my $data = $json->decode($body);
+	is( $data->{characteristics}[0]{aid}, $aid, 'response has aid' );
+	is( $data->{characteristics}[0]{iid}, $iid, 'response has iid' );
+	ok( exists $data->{characteristics}[0]{value},
+		'[HAP-HTTP §16.1] response carries the value' );
+
+	# meta/perms/type parameters include optional fields
+	( $status, undef, $body ) = dispatch( $hap, 'GET',
+		"/characteristics?id=$aid.$iid&meta=1&perms=1&type=1" );
+	$data = $json->decode($body);
+	ok( exists $data->{characteristics}[0]{format},
+		'meta=1 includes format' );
+	ok( exists $data->{characteristics}[0]{perms},
+		'perms=1 includes permissions' );
+	ok( exists $data->{characteristics}[0]{type},
+		'type=1 includes type' );
+
+	# [HAP-HTTP §12] invalid aid.iid -> -70409, [HAP-HTTP §9] 207
+	( $status, undef, $body ) =
+	    dispatch( $hap, 'GET', "/characteristics?id=999.999" );
+	is( $status, 207, 'invalid id returns 207 Multi-Status' );
+	is( $json->decode($body)->{characteristics}[0]{status},
+		-70409, 'invalid id has status -70409' );
+};
+
+subtest '[HAP-HTTP §9] PUT /characteristics' => sub {
+	my $hap = make_hap();
+	my ( undef, undef, $acc_body ) =
+	    dispatch( $hap, 'GET', '/accessories' );
+	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
+
+	# Successful write returns 204 No Content
+	my $put = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $iid, value => 1 } ] } );
+	my ( $status, undef, $body ) =
+	    dispatch( $hap, 'PUT', '/characteristics', $put );
+	is( $status, 204,
+		'[HAP-HTTP §13.1][HAP-HTTP §16.2] successful write '
+		    . 'returns 204 No Content' );
+	is( $body, '', '204 response has no body' );
+
+	# Write to nonexistent characteristic: 207 with -70409
+	$put = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => 9999, value => 1 } ] } );
+	( $status, undef, $body ) =
+	    dispatch( $hap, 'PUT', '/characteristics', $put );
+	is( $status, 207, 'partial failure returns 207 Multi-Status' );
+	is( $json->decode($body)->{characteristics}[0]{status},
+		-70409, 'unknown iid has status -70409' );
+
+	# Write to a read-only characteristic: -70404
+	my ( undef, $ro_iid ) = find_char( $json->decode($acc_body), '30' );
+	$put = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $ro_iid, value => 'x' } ] } );
+	( $status, undef, $body ) =
+	    dispatch( $hap, 'PUT', '/characteristics', $put );
+	is( $status, 207, 'read-only write returns 207' );
+	is( $json->decode($body)->{characteristics}[0]{status},
+		-70404, 'read-only write has status -70404' );
+
+	# [HAP-HTTP §13.2] malformed JSON returns 400
+	( $status, undef, undef ) =
+	    dispatch( $hap, 'PUT', '/characteristics', 'not json' );
+	is( $status, 400, 'malformed body returns 400 Bad Request' );
+};
+
+subtest '[HAP-HTTP §10] PUT /prepare timed write' => sub {
+	my $hap = make_hap();
+	my $session = verified_session();
+
+	my $prepare = $json->encode( { ttl => 2500, pid => 11122333 } );
+	my ( $status, undef, $body ) =
+	    dispatch( $hap, 'PUT', '/prepare', $prepare, $session );
+	is( $status, 200, 'prepare returns 200' );
+	is( $json->decode($body)->{status}, 0, 'prepare status 0' );
+
+	# Missing ttl/pid -> -70410 invalid value
+	( $status, undef, $body ) =
+	    dispatch( $hap, 'PUT', '/prepare', '{}', $session );
+	is( $status, 400, 'missing ttl/pid rejected' );
+	is( $json->decode($body)->{status},
+		-70410, 'missing ttl/pid has status -70410' );
+
+	# POST also accepted (spec shows POST in the endpoint table)
+	( $status, undef, undef ) =
+	    dispatch( $hap, 'POST', '/prepare', $prepare, $session );
+	is( $status, 200, 'POST /prepare also accepted' );
+};
+
+subtest '[HAP-HTTP §6][HAP-Pairing §7][HAP-Pairing §7.1] add pairing' =>
+    sub {
+	my $hap = make_hap();
+	$hap->{storage}->save_pairing( 'admin-ctrl', 'A' x 32, 1 );
+	$hap->{storage}->save_pairing( 'user-ctrl',  'U' x 32, 0 );
+
+	my $add = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),      pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(),     pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_Identifier(), 'new-ctrl',
+		OpenHAP::Pairing::kTLVType_PublicKey(),  'N' x 32,
+		OpenHAP::Pairing::kTLVType_Permissions(), pack( 'C', 0 ),
+	);
+
+	# Non-admin controller -> 0x02 Authentication
+	my ( $status, undef, $body ) = dispatch( $hap, 'POST', '/pairings',
+		$add, verified_session('user-ctrl') );
+	my %tlv = OpenHAP::TLV::decode($body);
+	is( unpack( 'C', $tlv{ OpenHAP::Pairing::kTLVType_Error() } ),
+		OpenHAP::Pairing::kTLVError_Authentication(),
+		'[HAP-Pairing §7.4] non-admin add rejected with 0x02' );
+
+	# Admin controller -> success M2
+	( $status, undef, $body ) = dispatch( $hap, 'POST', '/pairings',
+		$add, verified_session('admin-ctrl') );
+	%tlv = OpenHAP::TLV::decode($body);
+	is( unpack( 'C', $tlv{ OpenHAP::Pairing::kTLVType_State() } ),
+		2, 'admin add returns M2' );
+	ok( !exists $tlv{ OpenHAP::Pairing::kTLVType_Error() },
+		'admin add succeeds' );
+	ok( exists $hap->{storage}->load_pairings()->{'new-ctrl'},
+		'pairing stored' );
+
+	# Same identifier, different LTPK -> 0x01 Unknown
+	my $conflict = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),      pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(),     pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_Identifier(), 'new-ctrl',
+		OpenHAP::Pairing::kTLVType_PublicKey(),  'Z' x 32,
+		OpenHAP::Pairing::kTLVType_Permissions(), pack( 'C', 1 ),
+	);
+	( $status, undef, $body ) = dispatch( $hap, 'POST', '/pairings',
+		$conflict, verified_session('admin-ctrl') );
+	%tlv = OpenHAP::TLV::decode($body);
+	is( unpack( 'C', $tlv{ OpenHAP::Pairing::kTLVType_Error() } ),
+		OpenHAP::Pairing::kTLVError_Unknown(),
+		'[HAP-Pairing §7.4] existing identifier with different '
+		    . 'LTPK rejected with 0x01' );
+
+	# Same identifier, same LTPK -> permissions updated, success
+	my $update = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),      pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(),     pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_Identifier(), 'new-ctrl',
+		OpenHAP::Pairing::kTLVType_PublicKey(),  'N' x 32,
+		OpenHAP::Pairing::kTLVType_Permissions(), pack( 'C', 1 ),
+	);
+	( $status, undef, $body ) = dispatch( $hap, 'POST', '/pairings',
+		$update, verified_session('admin-ctrl') );
+	%tlv = OpenHAP::TLV::decode($body);
+	ok( !exists $tlv{ OpenHAP::Pairing::kTLVType_Error() },
+		'matching LTPK updates permissions' );
+	is( $hap->{storage}->load_pairings()->{'new-ctrl'}{permissions},
+		1, '[HAP-Pairing §6.1] permissions updated to admin (0x01)' );
+};
+
+subtest '[HAP-Pairing §7.2][HAP-Pairing §7.3] remove and list' => sub {
+	my $hap = make_hap();
+	$hap->{storage}->save_pairing( 'admin-ctrl', 'A' x 32, 1 );
+	$hap->{storage}->save_pairing( 'user-ctrl',  'U' x 32, 0 );
+
+	# List pairings (admin only)
+	my $list = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 5 ),
+	);
+	my ( $status, undef, $body ) = dispatch( $hap, 'POST', '/pairings',
+		$list, verified_session('user-ctrl') );
+	my %tlv = OpenHAP::TLV::decode($body);
+	is( unpack( 'C', $tlv{ OpenHAP::Pairing::kTLVType_Error() } ),
+		OpenHAP::Pairing::kTLVError_Authentication(),
+		'[HAP-Pairing §7.4] non-admin list rejected with 0x02' );
+
+	( $status, undef, $body ) = dispatch( $hap, 'POST', '/pairings',
+		$list, verified_session('admin-ctrl') );
+	like( $body, qr/admin-ctrl/, 'list contains admin identifier' );
+	like( $body, qr/user-ctrl/,  'list contains user identifier' );
+	like( $body, qr/\xFF\x00/,
+		'entries separated by zero-length 0xFF separator' );
+
+	# Remove a pairing that does not exist returns success
+	my $remove_ghost = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),      pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(),     pack( 'C', 4 ),
+		OpenHAP::Pairing::kTLVType_Identifier(), 'ghost-ctrl',
+	);
+	( $status, undef, $body ) = dispatch( $hap, 'POST', '/pairings',
+		$remove_ghost, verified_session('admin-ctrl') );
+	%tlv = OpenHAP::TLV::decode($body);
+	ok( !exists $tlv{ OpenHAP::Pairing::kTLVType_Error() },
+		'removing nonexistent pairing returns success' );
+
+	# Removing the last admin clears all pairings
+	my $remove_admin = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),      pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(),     pack( 'C', 4 ),
+		OpenHAP::Pairing::kTLVType_Identifier(), 'admin-ctrl',
+	);
+	( $status, undef, $body ) = dispatch( $hap, 'POST', '/pairings',
+		$remove_admin, verified_session('admin-ctrl') );
+	%tlv = OpenHAP::TLV::decode($body);
+	ok( !exists $tlv{ OpenHAP::Pairing::kTLVType_Error() },
+		'removing last admin succeeds' );
+	is( scalar keys %{ $hap->{storage}->load_pairings() },
+		0, 'all pairings removed with the last admin' );
+};
+
+subtest '[HAP-HTTP §13][HAP-HTTP §13.2] unknown endpoint returns 404' =>
+    sub {
+	my $hap = make_hap();
+	my ( $status, undef, undef ) =
+	    dispatch( $hap, 'GET', '/no-such-endpoint' );
+	is( $status, 404, 'unknown endpoint returns 404' );
+};
+
+subtest '[HAP-HTTP §15][HAP-HTTP §15.1] JSON value encoding' => sub {
+	my $hap = make_hap();
+	my ( undef, undef, $acc_body ) =
+	    dispatch( $hap, 'GET', '/accessories' );
+	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
+
+	# bool encodes as JSON true/false, not 1/0
+	my ( undef, undef, $body ) =
+	    dispatch( $hap, 'GET', "/characteristics?id=$aid.$iid" );
+	like( $body, qr/"value"\s*:\s*(?:true|false)/,
+		'bool value encodes as JSON boolean' );
+
+	my $put = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $iid, value => 1 } ] } );
+	dispatch( $hap, 'PUT', '/characteristics', $put );
+	( undef, undef, $body ) =
+	    dispatch( $hap, 'GET', "/characteristics?id=$aid.$iid" );
+	like( $body, qr/"value"\s*:\s*true/, 'true after write of 1' );
+
+	# string characteristics encode as JSON strings
+	my ( undef, $name_iid ) = find_char( $json->decode($acc_body), '23' );
+	( undef, undef, $body ) =
+	    dispatch( $hap, 'GET', "/characteristics?id=$aid.$name_iid" );
+	like( $body, qr/"value"\s*:\s*"/, 'string value encodes as string' );
+};
+
+subtest '[HAP-HTTP §15.2] type coercion on write' => sub {
+	my $hap = make_hap();
+	my ( undef, undef, $acc_body ) =
+	    dispatch( $hap, 'GET', '/accessories' );
+	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
+
+	# JSON true and numeric 1 both write a bool characteristic
+	for my $value ( \1, 1 ) {
+		my $put = $json->encode( { characteristics =>
+			    [ { aid => $aid, iid => $iid,
+				    value => $value } ] } );
+		my ( $status, undef, undef ) =
+		    dispatch( $hap, 'PUT', '/characteristics', $put );
+		is( $status, 204, 'bool write coerced and accepted' );
+	}
+};
+
+subtest '[HAP-HTTP §16][HAP-HTTP §16.3] event subscription via ev:true' =>
+    sub {
+	my $hap = make_hap();
+	my ( undef, undef, $acc_body ) =
+	    dispatch( $hap, 'GET', '/accessories' );
+	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
+
+	my $session = verified_session();
+	my $put     = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $iid, ev => \1 } ] } );
+	my ( $status, undef, undef ) =
+	    dispatch( $hap, 'PUT', '/characteristics', $put, $session );
+	is( $status, 204, 'subscription write returns 204' );
+	ok( exists $hap->{event_subscriptions}{"$aid.$iid"}{$session},
+		'session registered for events' );
+
+	# ev on a characteristic without the ev permission -> -70406
+	my ( undef, $ro_iid ) = find_char( $json->decode($acc_body), '30' );
+	$put = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $ro_iid, ev => \1 } ] } );
+	( $status, undef, my $body ) =
+	    dispatch( $hap, 'PUT', '/characteristics', $put, $session );
+	is( $status, 207, 'unsupported subscription returns 207' );
+	is( $json->decode($body)->{characteristics}[0]{status},
+		-70406,
+		'[HAP-HTTP §12] notification-not-supported is -70406' );
+};
+
+subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
+	my $hap = make_hap();
+
+	# Two encrypted sessions with mock sockets; only one subscribes
+	my $key_a = pack( 'H*', '11' x 32 );
+	my $key_b = pack( 'H*', '22' x 32 );
+
+	my $sub_sock = MockSocket->new;
+	my $sub_sess = OpenHAP::Session->new( socket => $sub_sock );
+	$sub_sess->set_verified('subscriber');
+	$sub_sess->set_encryption( $key_a, $key_b );
+
+	my $other_sock = MockSocket->new;
+	my $other_sess = OpenHAP::Session->new( socket => $other_sock );
+	$other_sess->set_verified('bystander');
+	$other_sess->set_encryption( $key_a, $key_b );
+
+	$hap->_register_event_subscription( $sub_sess, 2, 10 );
+	$hap->send_event( 2, 10, 1 );
+
+	ok( length( $sub_sock->{written} ) > 0,
+		'subscribed session receives event' );
+	is( $other_sock->{written}, '',
+		'subscriptions are per-connection: bystander receives nothing'
+	);
+
+	# Decrypt the frame and check the EVENT/1.0 message format
+	my $frame  = $sub_sock->{written};
+	my $aad    = substr( $frame, 0, 2 );
+	my $length = unpack( 'v', $aad );
+	require OpenHAP::Crypto;
+	my $plain = OpenHAP::Crypto::chacha20_poly1305_decrypt(
+		$key_a,
+		pack( 'x[4]Q<', 0 ),
+		substr( $frame, 2, $length ),
+		substr( $frame, 2 + $length, 16 ), $aad
+	);
+	like( $plain, qr{^EVENT/1\.0 200 OK\r\n},
+		'event starts with EVENT/1.0 200 OK' );
+	like( $plain, qr{Content-Type: application/hap\+json\r\n},
+		'event content type is application/hap+json' );
+	my ($event_body) = $plain =~ /\r\n\r\n(.*)$/s;
+	my $data = $json->decode($event_body);
+	is( $data->{characteristics}[0]{aid}, 2, 'event has aid' );
+	is( $data->{characteristics}[0]{iid}, 10, 'event has iid' );
+	is( $data->{characteristics}[0]{value}, 1, 'event has new value' );
+
+	# Unsubscribe stops delivery
+	$sub_sock->{written} = '';
+	$hap->_unregister_event_subscription( $sub_sess, 2, 10 );
+	$hap->send_event( 2, 10, 0 );
+	is( $sub_sock->{written}, '',
+		'unsubscribed session receives nothing' );
+
+	# Event coalescing delay is 250ms
+	is( OpenHAP::HAP::EVENT_COALESCE_DELAY(),
+		0.250, 'coalescing delay is 250ms' );
+};
+
+done_testing();

--- a/t/conformance/hap-mdns.t
+++ b/t/conformance/hap-mdns.t
@@ -1,0 +1,197 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/HAP-mDNS.md
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+use File::Temp qw(tempdir);
+use Digest::SHA qw(sha512);
+use MIME::Base64 qw(encode_base64);
+
+BEGIN {
+	eval { require Crypt::Ed25519; require JSON::XS; };
+	if ($@) {
+		plan skip_all => 'Required modules not available';
+	}
+}
+
+use_ok('OpenHAP::HAP');
+use_ok('OpenHAP::MDNS');
+
+sub make_hap (%extra)
+{
+	return OpenHAP::HAP->new(
+		port         => 51827,
+		pin          => '123-45-678',
+		name         => 'mDNS Bridge',
+		storage_path => tempdir( CLEANUP => 1 ),
+		%extra,
+	);
+}
+
+subtest '[HAP-mDNS §1] service type is hap over tcp' => sub {
+	my $mdns = OpenHAP::MDNS->new(
+		service_name => 'mDNS Bridge',
+		port         => 51827,
+	);
+	ok( defined $mdns, 'MDNS registration wrapper created' );
+	is( $mdns->{service_name}, 'mDNS Bridge', 'service name stored' );
+
+	# The mdnsctl invocation registers the hap/tcp service type;
+	# browsing _hap._tcp is asserted by the mdns integration test
+	is( $mdns->{port}, 51827, 'port carried to registration' );
+};
+
+subtest '[HAP-mDNS §2] required TXT record fields' => sub {
+	my $hap = make_hap();
+	my $txt = $hap->get_mdns_txt_records;
+
+	for my $key (qw(c# ff id md pv s# sf ci)) {
+		ok( exists $txt->{$key},
+			"[HAP-mDNS §2/$key] required field $key present" );
+	}
+	ok( !exists $txt->{sh},
+		'[HAP-mDNS §2/sh] optional sh absent without setup_id' );
+};
+
+subtest '[HAP-mDNS §3] field values' => sub {
+	my $hap = make_hap();
+	my $txt = $hap->get_mdns_txt_records;
+
+	is( $txt->{ff}, 0, '[HAP-mDNS §3.2] feature flags are 0' );
+	is( $txt->{md}, 'mDNS Bridge',
+		'[HAP-mDNS §3.4] model name matches display name' );
+	like( $txt->{'s#'}, qr/^\d+$/, '[HAP-mDNS §3.6] s# is numeric' );
+	cmp_ok( $txt->{'s#'}, '>=', 1,
+		'[HAP-mDNS §3.6] state number starts at 1' );
+};
+
+subtest '[HAP-mDNS §9] complete TXT record' => sub {
+	my $hap = make_hap( setup_id => 'XYZQ' );
+	my $txt = $hap->get_mdns_txt_records;
+
+	# All fields of the complete example are present with sane values
+	like( $txt->{'c#'}, qr/^\d+$/,   'c# numeric' );
+	is( $txt->{ff}, 0, 'ff zero' );
+	like( $txt->{id}, qr/^[0-9A-F:]+$/, 'id MAC-like' );
+	ok( length( $txt->{md} ),  'md present' );
+	ok( length( $txt->{pv} ),  'pv present' );
+	like( $txt->{'s#'}, qr/^\d+$/, 's# numeric' );
+	like( $txt->{sf}, qr/^[01]$/, 'sf is 0 or 1' );
+	like( $txt->{ci}, qr/^\d+$/,  'ci numeric' );
+	ok( length( $txt->{sh} ), 'sh present with setup_id' );
+};
+
+subtest '[HAP-mDNS §10] bridge advertises a single service' => sub {
+
+	# One mDNS service covers the bridge and all bridged accessories;
+	# individual bridged accessories are not advertised separately
+	my $hap  = make_hap();
+	my $mdns = OpenHAP::MDNS->new(
+		service_name => $hap->{name},
+		port         => 51827,
+		txt_records  => $hap->get_mdns_txt_records,
+	);
+	ok( defined $mdns, 'single registration for the bridge' );
+	is( $mdns->{txt_records}{ci}, 2,
+		'advertised category is Bridge for all bridged accessories'
+	);
+};
+
+subtest '[HAP-mDNS §3.1] configuration number' => sub {
+	my $hap = make_hap();
+	my $txt = $hap->get_mdns_txt_records;
+
+	like( $txt->{'c#'}, qr/^\d+$/, 'c# is numeric' );
+	cmp_ok( $txt->{'c#'}, '>=', 1, 'c# starts at 1' );
+
+	# c# increments when the accessory database changes
+	$hap->{storage}->increment_config_number;
+	my $txt2 = $hap->get_mdns_txt_records;
+	is( $txt2->{'c#'}, $txt->{'c#'} + 1,
+		'c# increments on configuration change ([HAP-mDNS §8])' );
+};
+
+subtest '[HAP-mDNS §3.3] device ID format' => sub {
+	my $hap = make_hap();
+	my $id  = $hap->get_device_id;
+
+	like( $id, qr/^[0-9A-F]{2}(:[0-9A-F]{2}){5}$/,
+		'device ID is uppercase MAC-like format' );
+	is( $hap->get_mdns_txt_records->{id},
+		$id, 'TXT id field carries the device ID' );
+};
+
+subtest '[HAP-mDNS §3.5] protocol version' => sub {
+	my $hap = make_hap();
+
+	# pv=1 rather than 1.1: mdnsd uses '.' as the TXT record
+	# delimiter and cannot escape it; HomeKit accepts pv=1
+	is( $hap->get_mdns_txt_records->{pv},
+		'1', 'pv advertised (1, see mdnsd delimiter note)' );
+};
+
+subtest '[HAP-mDNS §3.7] status flags follow pairing state' => sub {
+	my $hap = make_hap();
+
+	is( $hap->get_mdns_txt_records->{sf},
+		1, 'sf=1 (bit 0 set) when not paired' );
+
+	$hap->{storage}->save_pairing( 'controller', 'X' x 32, 1 );
+	is( $hap->get_mdns_txt_records->{sf},
+		0, 'sf=0 once paired ([HAP-mDNS §8] pairing added)' );
+
+	$hap->{storage}->remove_all_pairings;
+	is( $hap->get_mdns_txt_records->{sf},
+		1, 'sf returns to 1 when pairing removed' );
+};
+
+subtest '[HAP-mDNS §3.8] category identifier' => sub {
+	my $hap = make_hap();
+	is( $hap->get_mdns_txt_records->{ci}, 2, 'ci=2 for a bridge' );
+};
+
+subtest '[HAP-mDNS §3.9] setup hash with fixed vector' => sub {
+	my $hap = make_hap( setup_id => 'XYZQ' );
+
+	# Pin the device ID by fixing the LTPK-derived identity
+	$hap->{accessory_ltpk} = pack( 'H*', '00ffaabbccdd' . 'ee' x 26 );
+	is( $hap->get_device_id, '00:FF:AA:BB:CC:DD',
+		'fixed LTPK yields fixed device ID' );
+
+	# setupHash = Base64(SHA512(SetupID + DeviceID.uppercase())[0:4])
+	my $expected = encode_base64(
+		substr( sha512( 'XYZQ' . '00:FF:AA:BB:CC:DD' ), 0, 4 ), '' );
+	my $txt = $hap->get_mdns_txt_records;
+	is( $txt->{sh}, $expected,
+		'sh is Base64 of first 4 SHA-512 bytes over '
+		    . 'SetupID + DeviceID' );
+	is( length($txt->{sh}), 8, '4 hash bytes encode to 8 base64 chars' );
+};
+
+subtest '[HAP-mDNS §4] service instance name' => sub {
+	my $hap = make_hap();
+	is( $hap->get_mdns_txt_records->{md},
+		'mDNS Bridge', 'model name matches the display name' );
+
+	my $mdns = OpenHAP::MDNS->new(
+		service_name => $hap->{name},
+		port         => 51827,
+	);
+	is( $mdns->{service_name}, 'mDNS Bridge',
+		'service advertised under the display name' );
+};
+
+subtest '[HAP-mDNS §6] port' => sub {
+	my $mdns = OpenHAP::MDNS->new( service_name => 'x' );
+	is( $mdns->{port}, 51827, 'default HAP port is 51827' );
+
+	my $custom = OpenHAP::MDNS->new( service_name => 'x', port => 8080 );
+	is( $custom->{port}, 8080, 'any available port can be advertised' );
+};
+
+done_testing();

--- a/t/conformance/hap-pairing-exchange.t
+++ b/t/conformance/hap-pairing-exchange.t
@@ -1,0 +1,205 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Full pair-setup and pair-verify exchanges through
+# OpenHAP::Test::Controller wired in-process to an OpenHAP::HAP
+# instance (spec/HAP-Pairing.md). No crypto is mocked: the accessory
+# ends these tests actually paired.
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+use File::Temp qw(tempdir);
+
+BEGIN {
+	eval {
+		require Math::BigInt;
+		require Crypt::Ed25519;
+		require Crypt::Curve25519;
+		require Crypt::AuthEnc::ChaCha20Poly1305;
+		require JSON::XS;
+	};
+	if ($@) {
+		plan skip_all => 'Crypto dependencies not available';
+	}
+}
+
+use_ok('OpenHAP::HAP');
+use_ok('OpenHAP::HTTP');
+use_ok('OpenHAP::Session');
+use_ok('OpenHAP::Pairing');
+use_ok('OpenHAP::Test::Controller');
+
+my $PIN = '123-45-678';
+
+# Wire a controller to a fresh OpenHAP::HAP instance through an
+# in-process transport: requests are parsed and dispatched directly,
+# with one accessory-side session per controller connection.
+sub make_pair ( %controller_args )
+{
+	OpenHAP::Pairing->clear_pairing_state();
+
+	my $hap = OpenHAP::HAP->new(
+		port         => 51827,
+		pin          => $PIN,
+		name         => 'Exchange Bridge',
+		storage_path => tempdir( CLEANUP => 1 ),
+	);
+	$hap->{pairing}->reset_auth_attempts;
+
+	# Mirror _handle_client: the pair-verify M4 response is sent in
+	# the clear even though dispatch just enabled encryption
+	my $session   = OpenHAP::Session->new( socket => 'in-process' );
+	my $transport = sub ($request_bytes) {
+		my $was_encrypted = $session->is_encrypted;
+		my $plain =
+		    $was_encrypted
+		    ? $session->decrypt($request_bytes)
+		    : $request_bytes;
+		return unless defined $plain;
+		my $request  = OpenHAP::HTTP::parse($plain);
+		my $response = $hap->_dispatch( $request, $session );
+		return $was_encrypted
+		    ? $session->encrypt($response)
+		    : $response;
+	};
+
+	my $controller = OpenHAP::Test::Controller->new(
+		pin       => $PIN,
+		transport => $transport,
+		%controller_args,
+	);
+
+	return ( $controller, $hap, $session );
+}
+
+subtest '[HAP-Pairing §2.2][HAP-Pairing §2.8] full pair-setup M1-M6' =>
+    sub {
+	my ( $controller, $hap ) = make_pair();
+
+	ok( $controller->pair_setup, 'pair-setup completes with real PIN' );
+	is( $controller->last_error, undef, 'no error recorded' );
+
+	ok( defined $controller->{accessory_ltpk},
+		'accessory LTPK stored on the controller' );
+	is( length( $controller->{accessory_ltpk} ),
+		32, 'accessory LTPK is a 32-byte Ed25519 key' );
+
+	# The accessory is actually paired now
+	ok( $hap->is_paired, 'accessory is paired after M6' );
+	my $pairings = $hap->{storage}->load_pairings;
+	ok( exists $pairings->{'openhap-test-ctrl'},
+		'controller identifier persisted' );
+	is( $pairings->{'openhap-test-ctrl'}{permissions},
+		1, 'initial controller is admin' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §2.6][HAP-Pairing §8] wrong PIN rejected' => sub {
+	my ( $controller, $hap ) = make_pair( pin => '876-54-321' );
+
+	ok( !$controller->pair_setup, 'pair-setup fails with wrong PIN' );
+	is( $controller->last_error,
+		OpenHAP::Pairing::kTLVError_Authentication(),
+		'M4 carries kTLVError_Authentication (0x02)' );
+	ok( !$hap->is_paired, 'accessory remains unpaired' );
+	is( OpenHAP::Pairing->get_failed_attempts(),
+		1, 'attempt counter incremented' );
+	is( $hap->{storage}->get_auth_attempts,
+		1, 'attempt counter persisted' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §2.4] already-paired M2 error' => sub {
+	my ( $controller, $hap, $session ) = make_pair();
+	ok( $controller->pair_setup, 'first pairing succeeds' );
+
+	# A second controller on a fresh connection is refused
+	my $session2   = OpenHAP::Session->new( socket => 'in-process-2' );
+	my $transport2 = sub ($request_bytes) {
+		my $request = OpenHAP::HTTP::parse($request_bytes);
+		return $hap->_dispatch( $request, $session2 );
+	};
+	my $second = OpenHAP::Test::Controller->new(
+		pin           => $PIN,
+		transport     => $transport2,
+		controller_id => 'second-ctrl',
+	);
+	ok( !$second->pair_setup, 'second pair-setup refused' );
+	is( $second->last_error,
+		OpenHAP::Pairing::kTLVError_Unavailable(),
+		'M2 carries kTLVError_Unavailable (0x06)' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §3] pair-verify and key derivation' => sub {
+	my ( $controller, $hap, $session ) = make_pair();
+	ok( $controller->pair_setup,  'pair-setup completes' );
+	ok( $controller->pair_verify, 'pair-verify completes' );
+	is( $controller->last_error, undef, 'no error recorded' );
+
+	ok( $controller->is_encrypted, 'controller session encrypted' );
+	ok( $session->is_encrypted,    'accessory session encrypted' );
+	ok( $session->is_verified,     'accessory session verified' );
+	is( $session->controller_id, 'openhap-test-ctrl',
+		'accessory knows the controller identity' );
+
+	# The derived keys interoperate: authenticated request succeeds
+	my $response = $controller->request( 'GET', '/accessories' );
+	ok( defined $response, 'encrypted request round-trips' );
+	is( $response->{status}, 200,
+		'paired GET /accessories returns 200' );
+	like( $response->{body}, qr/"accessories"/,
+		'accessory database returned over the encrypted session' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §7.2] remove-pairing and last-admin behavior' =>
+    sub {
+	my ( $controller, $hap, $session ) = make_pair();
+	ok( $controller->pair_setup,  'pair-setup completes' );
+	ok( $controller->pair_verify, 'pair-verify completes' );
+
+	# Add a second (non-admin) pairing, then list both
+	ok( $controller->add_pairing( 'user-ctrl', 'U' x 32, 0 ),
+		'[HAP-Pairing §7.1] admin adds a second pairing' );
+	my $pairings = $controller->list_pairings;
+	is( scalar @$pairings, 2, '[HAP-Pairing §7.3] two pairings listed' );
+
+	# Removing a pairing that does not exist returns success
+	ok( $controller->remove_pairing('ghost-ctrl'),
+		'removing nonexistent pairing succeeds' );
+
+	# Removing the last admin clears all pairings
+	my $old_ltpk = $hap->{accessory_ltpk};
+	ok( $controller->remove_pairing, 'admin removes itself' );
+	ok( !$hap->is_paired, 'all pairings removed with the last admin' );
+	isnt( $hap->{accessory_ltpk}, $old_ltpk,
+		'accessory identity regenerated after last admin removal' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §2.4] re-pair after remove' => sub {
+	my ( $controller, $hap, $session ) = make_pair();
+	ok( $controller->pair_setup, 'first pairing' );
+
+	# Unpair directly through storage (the encrypted session died
+	# with the identity regeneration in the previous flow)
+	$hap->{storage}->remove_all_pairings;
+	ok( !$hap->is_paired, 'unpaired again' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+	my ( $controller2, $hap2 ) = make_pair();
+	ok( $controller2->pair_setup, 'pair-setup succeeds after unpair' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+done_testing();

--- a/t/conformance/hap-pairing.t
+++ b/t/conformance/hap-pairing.t
@@ -1,0 +1,690 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/HAP-Pairing.md
+#
+# The controller side of pair-setup and pair-verify is scripted inline
+# from the spec formulas (Math::BigInt for SRP, OpenHAP::Crypto
+# primitives for the rest), independent of the accessory-side modules
+# under test.
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+use File::Temp qw(tempdir);
+
+BEGIN {
+	eval {
+		require Math::BigInt;
+		require Digest::SHA;
+		require Crypt::Ed25519;
+		require Crypt::Curve25519;
+		require Crypt::AuthEnc::ChaCha20Poly1305;
+	};
+	if ($@) {
+		plan skip_all => 'Crypto dependencies not available';
+	}
+}
+
+use Digest::SHA qw(sha512);
+
+use_ok('OpenHAP::Crypto');
+use_ok('OpenHAP::SRP');
+use_ok('OpenHAP::Pairing');
+use_ok('OpenHAP::Session');
+use_ok('OpenHAP::Storage');
+use_ok('OpenHAP::TLV');
+
+my $PIN = '123-45-678';
+
+sub b2i ($bytes) { Math::BigInt->from_hex( unpack( 'H*', $bytes ) ) }
+
+sub i2b ( $int, $len = undef )
+{
+	return OpenHAP::SRP::_bigint_to_bytes( $int, $len );
+}
+
+sub make_pairing ( $storage = undef )
+{
+	$storage //= OpenHAP::Storage->new(
+		db_path => tempdir( CLEANUP => 1 ) );
+	my ( $ltsk, $ltpk ) = OpenHAP::Crypto::generate_keypair_ed25519();
+	my $pairing = OpenHAP::Pairing->new(
+		pin            => $PIN,
+		storage        => $storage,
+		accessory_ltsk => $ltsk,
+		accessory_ltpk => $ltpk,
+	);
+	OpenHAP::Pairing->clear_pairing_state();
+	$pairing->reset_auth_attempts;
+	return ( $pairing, $storage, $ltpk );
+}
+
+sub tlv_field ( $response, $type )
+{
+	my %tlv = OpenHAP::TLV::decode($response);
+	return $tlv{$type};
+}
+
+sub error_code ($response)
+{
+	my $error =
+	    tlv_field( $response, OpenHAP::Pairing::kTLVType_Error() );
+	return defined $error ? unpack( 'C', $error ) : undef;
+}
+
+# Client-side SRP per HAP-Pairing.md §2.5, independent of OpenHAP::SRP
+# state. Returns (A_bytes, M1, K).
+sub client_srp ( $salt, $B_bytes, $pin )
+{
+	my $I = 'Pair-Setup';
+	( my $P = $pin ) =~ s/-//g;
+
+	my $N = b2i($OpenHAP::Crypto::N_3072);
+	my $g = Math::BigInt->new(5);
+
+	my $a = b2i( OpenHAP::Crypto::generate_random_bytes(32) );
+	my $A = $g->copy->bmodpow( $a, $N );
+
+	my $u = b2i( sha512( i2b( $A, 384 ) . i2b( b2i($B_bytes), 384 ) ) );
+	my $x = b2i( sha512( $salt . sha512("$I:$P") ) );
+	my $k = b2i( sha512( i2b($N) . i2b( $g, 384 ) ) );
+
+	# S = (B - k*g^x)^(a + u*x) mod N
+	my $gx   = $g->copy->bmodpow( $x, $N );
+	my $base = ( b2i($B_bytes) - ( $k * $gx ) ) % $N;
+	my $S    = $base->bmodpow( $a + $u * $x, $N );
+	my $K    = sha512( i2b($S) );
+
+	# M1 = H(H(N) xor H(g) | H(I) | s | PAD(A) | PAD(B) | K)
+	my $M1 = sha512( ( sha512( i2b($N) ) ^. sha512( i2b($g) ) )
+		. sha512($I)
+		    . $salt
+		    . i2b( $A, 384 )
+		    . i2b( b2i($B_bytes), 384 )
+		    . $K );
+
+	return ( i2b( $A, 384 ), $M1, $K );
+}
+
+# Drive pair-setup M1..M4 against a pairing handler with a given PIN.
+# Returns (m4_response, K, session).
+sub run_m1_to_m4 ( $pairing, $pin )
+{
+	my $session = OpenHAP::Session->new( socket => 'client' );
+
+	my $m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
+	);
+	my $m2 = $pairing->handle_pair_setup( $m1, $session );
+
+	my $salt = tlv_field( $m2, OpenHAP::Pairing::kTLVType_Salt() );
+	my $B = tlv_field( $m2, OpenHAP::Pairing::kTLVType_PublicKey() );
+	return unless defined $salt && defined $B;
+
+	my ( $A, $M1, $K ) = client_srp( $salt, $B, $pin );
+
+	my $m3 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),     pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_PublicKey(), $A,
+		OpenHAP::Pairing::kTLVType_Proof(),     $M1,
+	);
+	my $m4 = $pairing->handle_pair_setup( $m3, $session );
+
+	return ( $m4, $K, $session, $A, $M1 );
+}
+
+subtest '[HAP-Pairing §1] HKDF-SHA-512 known-answer vector' => sub {
+
+	# RFC 5869 test case 1 parameters with SHA-512
+	my $okm = OpenHAP::Crypto::hkdf_sha512(
+		"\x0b" x 22,
+		pack( 'H*', '000102030405060708090a0b0c' ),
+		pack( 'H*', 'f0f1f2f3f4f5f6f7f8f9' ), 42
+	);
+	is( unpack( 'H*', $okm ),
+		'832390086cda71fb47625bb5ceb168e4'
+		    . 'c8e26a1a16ed34d9fc7fe92c14815793'
+		    . '38da362cb8d9f925d7cb',
+		'HKDF-SHA-512 output matches published vector'
+	);
+};
+
+subtest '[HAP-Pairing §1] Ed25519 RFC 8032 known-answer vector' => sub {
+	my $public = pack( 'H*',
+		'd75a980182b10ab7d54bfed3c964073a'
+		    . '0ee172f3daa62325af021a68f707511a' );
+	my $signature = pack( 'H*',
+		'e5564300c360ac729086e2cc806e828a'
+		    . '84877f1eb8e5d974d873e06522490155'
+		    . '5fb8821590a33bacc61e39701cf9b46b'
+		    . 'd25bf5f0595bbe24655141438e7a100b' );
+
+	ok( OpenHAP::Crypto::verify_ed25519( $signature, '', $public ),
+		'RFC 8032 TEST 1 signature verifies' );
+	ok( !OpenHAP::Crypto::verify_ed25519( $signature, 'x', $public ),
+		'RFC 8032 signature fails for different message' );
+
+	# Sign/verify round-trip with a generated keypair
+	my ( $ltsk, $ltpk ) = OpenHAP::Crypto::generate_keypair_ed25519();
+	my $sig = OpenHAP::Crypto::sign_ed25519( 'message', $ltsk, $ltpk );
+	ok( OpenHAP::Crypto::verify_ed25519( $sig, 'message', $ltpk ),
+		'generated keypair round-trips' );
+};
+
+subtest '[HAP-Pairing §1] X25519 RFC 7748 known-answer vector' => sub {
+	my $a = Crypt::Curve25519::curve25519_secret_key(
+		pack( 'H*',
+			'77076d0a7318a57d3c16c17251b26645'
+			    . 'df4c2f87ebc0992ab177fba51db92c2a' ) );
+	my $b = Crypt::Curve25519::curve25519_secret_key(
+		pack( 'H*',
+			'5dab087e624a8a4b79e17f8b83800ee6'
+			    . '6f3bb1292618b6fd1c2f8b27ff88e0eb' ) );
+
+	my $a_pub = Crypt::Curve25519::curve25519_public_key($a);
+	my $b_pub = Crypt::Curve25519::curve25519_public_key($b);
+
+	is( unpack( 'H*', $a_pub ),
+		'8520f0098930a754748b7ddcb43ef75a'
+		    . '0dbf3a0d26381af4eba4a98eaa9b4e6a',
+		'RFC 7748 public key for a' );
+	is( unpack( 'H*', $b_pub ),
+		'de9edb7d7b7dc1b4d35b61c2ece43537'
+		    . '3f8343c85b78674dadfc7e146f882b4f',
+		'RFC 7748 public key for b' );
+	is(
+		unpack( 'H*',
+			OpenHAP::Crypto::derive_shared_secret( $a, $b_pub ) ),
+		'4a5d9d5ba4ce2de1728e3bf480350f25'
+		    . 'e07e21c947d19e3376f09b3c1e161742',
+		'RFC 7748 shared secret'
+	);
+	is(
+		unpack( 'H*',
+			OpenHAP::Crypto::derive_shared_secret( $b, $a_pub ) ),
+		'4a5d9d5ba4ce2de1728e3bf480350f25'
+		    . 'e07e21c947d19e3376f09b3c1e161742',
+		'shared secret agrees from both sides'
+	);
+};
+
+subtest '[HAP-Pairing §2.2] SRP-6a group parameters' => sub {
+
+	# RFC 5054 3072-bit prime, transcribed from the spec text
+	my $rfc5054_3072 =
+	      'FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD1'
+	    . '29024E088A67CC74020BBEA63B139B22514A08798E3404DD'
+	    . 'EF9519B3CD3A431B302B0A6DF25F14374FE1356D6D51C245'
+	    . 'E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED'
+	    . 'EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE45B3D'
+	    . 'C2007CB8A163BF0598DA48361C55D39A69163FA8FD24CF5F'
+	    . '83655D23DCA3AD961C62F356208552BB9ED529077096966D'
+	    . '670C354E4ABC9804F1746C08CA18217C32905E462E36CE3B'
+	    . 'E39E772C180E86039B2783A2EC07A28FB5C55DF06F4C52C9'
+	    . 'DE2BCBF6955817183995497CEA956AE515D2261898FA0510'
+	    . '15728E5A8AAAC42DAD33170D04507A33A85521ABDF1CBA64'
+	    . 'ECFB850458DBEF0A8AEA71575D060C7DB3970F85A6E1E4C7'
+	    . 'ABF5AE8CDB0933D71E8C94E04A25619DCEE3D2261AD2EE6B'
+	    . 'F12FFA06D98A0864D87602733EC86A64521F2B18177B200C'
+	    . 'BBE117577A615D6C770988C0BAD946E208E24FA074E5AB31'
+	    . '43DB5BFCE0FD108E4B82D120A93AD2CAFFFFFFFFFFFFFFFF';
+
+	is( uc( unpack( 'H*', $OpenHAP::Crypto::N_3072 ) ),
+		$rfc5054_3072, 'N is the RFC 5054 3072-bit prime' );
+	is( length($OpenHAP::Crypto::N_3072), 384, 'N is 384 bytes' );
+	is( $OpenHAP::Crypto::g, 5, 'g is 5' );
+
+	my $srp = OpenHAP::SRP->new( password => $PIN );
+	is( $srp->{username}, 'Pair-Setup', 'I is "Pair-Setup"' );
+	is( $srp->{password}, '12345678',
+		'P is the 8-digit setup code without dashes' );
+
+	# x = H(s | H(I ":" P)) and v = g^x mod N with a fixed salt
+	my $salt = pack( 'H*', '00' x 15 . '01' );
+	my $v    = $srp->compute_verifier($salt);
+	my $x    = b2i( sha512( $salt . sha512('Pair-Setup:12345678') ) );
+	my $expected_v =
+	    Math::BigInt->new(5)
+	    ->bmodpow( $x, b2i($OpenHAP::Crypto::N_3072) );
+	ok( $v == $expected_v, 'verifier v = g^x mod N' );
+};
+
+subtest '[HAP-Pairing §2][HAP-Pairing §2.1] pair setup state machine' =>
+    sub {
+	my ($pairing) = make_pairing();
+	my $session = OpenHAP::Session->new( socket => 'client' );
+
+	# Invalid state value is rejected
+	my $bogus = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 99 ),
+	);
+	is( error_code( $pairing->handle_pair_setup( $bogus, $session ) ),
+		OpenHAP::Pairing::kTLVError_Unknown(),
+		'invalid state rejected with kTLVError_Unknown' );
+
+	# M3 without a preceding M1 is rejected
+	my $m3 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),     pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_PublicKey(), 'A' x 384,
+		OpenHAP::Pairing::kTLVType_Proof(),     'P' x 64,
+	);
+	is( error_code( $pairing->handle_pair_setup( $m3, $session ) ),
+		OpenHAP::Pairing::kTLVError_Unknown(),
+		'M3 before M1 rejected' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §3.1] pair verify state machine' => sub {
+	my ($pairing) = make_pairing();
+	my $session = OpenHAP::Session->new( socket => 'client' );
+
+	# Invalid state value is rejected
+	my $bogus = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 99 ),
+	);
+	is( error_code( $pairing->handle_pair_verify( $bogus, $session ) ),
+		OpenHAP::Pairing::kTLVError_Unknown(),
+		'invalid state rejected with kTLVError_Unknown' );
+
+	# M3 without a preceding M1 is rejected
+	my $m3 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_EncryptedData(), 'X' x 32,
+	);
+	is( error_code( $pairing->handle_pair_verify( $m3, $session ) ),
+		OpenHAP::Pairing::kTLVError_Unknown(),
+		'verify M3 before M1 rejected' );
+};
+
+subtest '[HAP-Pairing §2.3][HAP-Pairing §2.4] M1 -> M2 shape' => sub {
+	my ($pairing) = make_pairing();
+	my $session = OpenHAP::Session->new( socket => 'client' );
+
+	my $m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
+	);
+	my $m2 = $pairing->handle_pair_setup( $m1, $session );
+
+	is( unpack( 'C',
+		    tlv_field( $m2, OpenHAP::Pairing::kTLVType_State() ) ),
+		2, 'M2 has State 0x02' );
+	is( length( tlv_field( $m2, OpenHAP::Pairing::kTLVType_Salt() ) ),
+		16, 'M2 salt is 16 random bytes' );
+	is(
+		length( tlv_field(
+			$m2, OpenHAP::Pairing::kTLVType_PublicKey() ) ),
+		384,
+		'M2 public key B is 384 bytes'
+	);
+	ok( !defined error_code($m2), 'M2 success carries no Error TLV' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §2.4] M2 error responses' => sub {
+
+	# Already paired -> 0x06 Unavailable
+	my ( $pairing, $storage ) = make_pairing();
+	$storage->save_pairing( 'controller', 'X' x 32, 1 );
+	my $m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
+	);
+	my $session = OpenHAP::Session->new( socket => 'c1' );
+	is( error_code( $pairing->handle_pair_setup( $m1, $session ) ),
+		OpenHAP::Pairing::kTLVError_Unavailable(),
+		'already paired returns 0x06 Unavailable' );
+	OpenHAP::Pairing->clear_pairing_state();
+
+	# Another pairing in progress -> 0x07 Busy
+	my ($pairing2) = make_pairing();
+	my $s1 = OpenHAP::Session->new( socket => 'c2' );
+	my $s2 = OpenHAP::Session->new( socket => 'c3' );
+	$pairing2->handle_pair_setup( $m1, $s1 );
+	is( error_code( $pairing2->handle_pair_setup( $m1, $s2 ) ),
+		OpenHAP::Pairing::kTLVError_Busy(),
+		'concurrent pairing returns 0x07 Busy' );
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §2.5][HAP-Pairing §2.6] M3 -> M4 SRP proof' => sub {
+
+	# Correct PIN: M4 returns a verifiable server proof M2
+	my ($pairing) = make_pairing();
+	my ( $m4, $K, $session, $A, $M1 ) = run_m1_to_m4( $pairing, $PIN );
+
+	is( unpack( 'C',
+		    tlv_field( $m4, OpenHAP::Pairing::kTLVType_State() ) ),
+		4, 'M4 has State 0x04' );
+	ok( !defined error_code($m4), 'correct proof accepted' );
+
+	my $proof = tlv_field( $m4, OpenHAP::Pairing::kTLVType_Proof() );
+	is( length($proof), 64, 'M4 proof is 64 bytes (SHA-512)' );
+
+	# M2 = H(PAD(A) | M1 | K), verified client-side
+	is( unpack( 'H*', $proof ),
+		unpack( 'H*', sha512( $A . $M1 . $K ) ),
+		'server proof M2 = H(A | M1 | K) verifies' );
+	OpenHAP::Pairing->clear_pairing_state();
+
+	# Wrong PIN: M4 returns 0x02 Authentication
+	my ($pairing2) = make_pairing();
+	my ($m4_bad) = run_m1_to_m4( $pairing2, '876-54-321' );
+	is( error_code($m4_bad),
+		OpenHAP::Pairing::kTLVError_Authentication(),
+		'wrong setup code returns 0x02 Authentication in M4' );
+	is( OpenHAP::Pairing->get_failed_attempts(),
+		1, 'failed proof increments attempt counter' );
+	OpenHAP::Pairing->clear_pairing_state();
+
+	# A mod N == 0: rejected before proof verification
+	my ($pairing3) = make_pairing();
+	my $s = OpenHAP::Session->new( socket => 'client' );
+	my $m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
+	);
+	$pairing3->handle_pair_setup( $m1, $s );
+	my $m3 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),     pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_PublicKey(), "\x00" x 384,
+		OpenHAP::Pairing::kTLVType_Proof(),     'X' x 64,
+	);
+	is( error_code( $pairing3->handle_pair_setup( $m3, $s ) ),
+		OpenHAP::Pairing::kTLVError_Authentication(),
+		'A mod N == 0 rejected with 0x02' );
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §2.7][HAP-Pairing §2.8] M5 -> M6 exchange' => sub {
+	my ( $pairing, $storage, $accessory_ltpk ) = make_pairing();
+	my ( $m4, $K, $session ) = run_m1_to_m4( $pairing, $PIN );
+	ok( !defined error_code($m4), 'SRP phase succeeded' );
+
+	# [HAP-Pairing §4/Pair Setup Encryption] session encryption key
+	my $encrypt_key = OpenHAP::Crypto::hkdf_sha512( $K,
+		'Pair-Setup-Encrypt-Salt', 'Pair-Setup-Encrypt-Info', 32 );
+
+	# Controller long-term identity and signature
+	# [HAP-Pairing §4/Controller Signature]
+	my ( $ios_ltsk, $ios_ltpk ) =
+	    OpenHAP::Crypto::generate_keypair_ed25519();
+	my $ios_id = 'ios-controller-1';
+	my $ios_x  = OpenHAP::Crypto::hkdf_sha512(
+		$K,
+		'Pair-Setup-Controller-Sign-Salt',
+		'Pair-Setup-Controller-Sign-Info', 32
+	);
+	my $ios_signature =
+	    OpenHAP::Crypto::sign_ed25519( $ios_x . $ios_id . $ios_ltpk,
+		$ios_ltsk, $ios_ltpk );
+
+	my $inner = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_Identifier(), $ios_id,
+		OpenHAP::Pairing::kTLVType_PublicKey(),  $ios_ltpk,
+		OpenHAP::Pairing::kTLVType_Signature(),  $ios_signature,
+	);
+
+	# [HAP-Pairing §5/M5] nonce PS-Msg05
+	is( unpack( 'H*', pack('x[4]') . 'PS-Msg05' ),
+		'0000000050532d4d73673035', 'M5 nonce is PS-Msg05' );
+	my ( $encrypted, $tag ) =
+	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $encrypt_key,
+		pack('x[4]') . 'PS-Msg05', $inner );
+
+	my $m5 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 5 ),
+		OpenHAP::Pairing::kTLVType_EncryptedData(),
+		$encrypted . $tag,
+	);
+	my $m6 = $pairing->handle_pair_setup( $m5, $session );
+
+	is( unpack( 'C',
+		    tlv_field( $m6, OpenHAP::Pairing::kTLVType_State() ) ),
+		6, 'M6 has State 0x06' );
+	ok( !defined error_code($m6), 'M5 accepted' );
+
+	# Pairing persisted with admin permissions
+	my $pairings = $storage->load_pairings();
+	ok( exists $pairings->{$ios_id},
+		'[HAP-Pairing §6] controller pairing persisted' );
+	is( $pairings->{$ios_id}{ltpk},
+		$ios_ltpk,
+		'[HAP-Pairing §6.2] pairing ID, LTPK and permissions stored'
+	);
+	is( $pairings->{$ios_id}{permissions},
+		1,
+		'[HAP-Pairing §6.1] initial pairing has admin permissions' );
+
+	# Decrypt M6 with nonce PS-Msg06 ([HAP-Pairing §5/M6])
+	my $m6_data =
+	    tlv_field( $m6, OpenHAP::Pairing::kTLVType_EncryptedData() );
+	my $m6_tag = substr( $m6_data, -16, 16, '' );
+	my $m6_plain =
+	    OpenHAP::Crypto::chacha20_poly1305_decrypt( $encrypt_key,
+		pack('x[4]') . 'PS-Msg06', $m6_data, $m6_tag );
+	ok( defined $m6_plain, 'M6 sub-TLV decrypts with PS-Msg06 nonce' );
+
+	# Verify accessory signature ([HAP-Pairing §4/Accessory Signature])
+	my %m6_inner = OpenHAP::TLV::decode($m6_plain);
+	my $acc_id =
+	    $m6_inner{ OpenHAP::Pairing::kTLVType_Identifier() };
+	my $acc_ltpk =
+	    $m6_inner{ OpenHAP::Pairing::kTLVType_PublicKey() };
+	my $acc_sig =
+	    $m6_inner{ OpenHAP::Pairing::kTLVType_Signature() };
+
+	is( $acc_ltpk, $accessory_ltpk, 'M6 carries accessory LTPK' );
+	like( $acc_id, qr/^[0-9A-F]{2}(:[0-9A-F]{2}){5}$/,
+		'accessory pairing ID is MAC-like' );
+
+	my $acc_x = OpenHAP::Crypto::hkdf_sha512(
+		$K,
+		'Pair-Setup-Accessory-Sign-Salt',
+		'Pair-Setup-Accessory-Sign-Info', 32
+	);
+	ok(
+		OpenHAP::Crypto::verify_ed25519(
+			$acc_sig, $acc_x . $acc_id . $acc_ltpk, $acc_ltpk
+		),
+		'accessory signature verifies'
+	);
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+subtest '[HAP-Pairing §3] pair-verify handshake' => sub {
+
+	# Pair first so the accessory knows the controller LTPK
+	my ( $pairing, $storage, $accessory_ltpk ) = make_pairing();
+	my ( $ios_ltsk, $ios_ltpk ) =
+	    OpenHAP::Crypto::generate_keypair_ed25519();
+	my $ios_id = 'ios-controller-1';
+	$storage->save_pairing( $ios_id, $ios_ltpk, 1 );
+
+	my $session = OpenHAP::Session->new( socket => 'client' );
+
+	# [HAP-Pairing §3.2] M1: controller ephemeral public key
+	my ( $ios_secret, $ios_public ) =
+	    OpenHAP::Crypto::generate_keypair_x25519();
+	my $m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),     pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_PublicKey(), $ios_public,
+	);
+	my $m2 = $pairing->handle_pair_verify( $m1, $session );
+
+	# [HAP-Pairing §3.3] M2: accessory public key + encrypted proof
+	is( unpack( 'C',
+		    tlv_field( $m2, OpenHAP::Pairing::kTLVType_State() ) ),
+		2, 'M2 has State 0x02' );
+	my $acc_public =
+	    tlv_field( $m2, OpenHAP::Pairing::kTLVType_PublicKey() );
+	is( length($acc_public), 32,
+		'M2 carries 32-byte Curve25519 public key' );
+
+	my $shared =
+	    OpenHAP::Crypto::derive_shared_secret( $ios_secret,
+		$acc_public );
+
+	# [HAP-Pairing §4/Pair Verify Encryption] + [HAP-Pairing §5/PV M2]
+	my $pv_key = OpenHAP::Crypto::hkdf_sha512( $shared,
+		'Pair-Verify-Encrypt-Salt', 'Pair-Verify-Encrypt-Info', 32 );
+	my $m2_data =
+	    tlv_field( $m2, OpenHAP::Pairing::kTLVType_EncryptedData() );
+	my $m2_tag = substr( $m2_data, -16, 16, '' );
+	my $m2_plain =
+	    OpenHAP::Crypto::chacha20_poly1305_decrypt( $pv_key,
+		pack('x[4]') . 'PV-Msg02', $m2_data, $m2_tag );
+	ok( defined $m2_plain, 'M2 sub-TLV decrypts with PV-Msg02 nonce' );
+
+	my %m2_inner = OpenHAP::TLV::decode($m2_plain);
+	my $acc_id = $m2_inner{ OpenHAP::Pairing::kTLVType_Identifier() };
+	my $acc_sig = $m2_inner{ OpenHAP::Pairing::kTLVType_Signature() };
+	ok(
+		OpenHAP::Crypto::verify_ed25519(
+			$acc_sig, $acc_public . $acc_id . $ios_public,
+			$accessory_ltpk
+		),
+		'accessory signature over AccessoryInfo verifies'
+	);
+
+	# [HAP-Pairing §3.4] M3: controller proof
+	my $ios_sig = OpenHAP::Crypto::sign_ed25519(
+		$ios_public . $ios_id . $acc_public,
+		$ios_ltsk, $ios_ltpk );
+	my $m3_inner = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_Identifier(), $ios_id,
+		OpenHAP::Pairing::kTLVType_Signature(),  $ios_sig,
+	);
+	my ( $m3_encrypted, $m3_tag ) =
+	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $pv_key,
+		pack('x[4]') . 'PV-Msg03', $m3_inner );
+	my $m3 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_EncryptedData(),
+		$m3_encrypted . $m3_tag,
+	);
+	my $m4 = $pairing->handle_pair_verify( $m3, $session );
+
+	# [HAP-Pairing §3.5] M4: success, session becomes encrypted
+	is( unpack( 'C',
+		    tlv_field( $m4, OpenHAP::Pairing::kTLVType_State() ) ),
+		4, 'M4 has State 0x04' );
+	ok( !defined error_code($m4), 'pair-verify succeeded' );
+	ok( $session->is_verified,  'session marked verified' );
+	ok( $session->is_encrypted, 'session encryption enabled' );
+
+	# [HAP-Pairing §4/Session Read Key][HAP-Pairing §4/Session Write Key]
+	# Accessory encrypts with the Read key, decrypts with the Write key
+	my $read_key =
+	    OpenHAP::Crypto::hkdf_sha512( $shared, 'Control-Salt',
+		'Control-Read-Encryption-Key', 32 );
+	my $frame = $session->encrypt('event data');
+	my $aad   = substr( $frame, 0, 2 );
+	my $plain = OpenHAP::Crypto::chacha20_poly1305_decrypt(
+		$read_key,
+		pack( 'x[4]Q<', 0 ),
+		substr( $frame, 2, -16 ),
+		substr( $frame, -16 ), $aad
+	);
+	is( $plain, 'event data',
+		'accessory-to-controller key is Control-Read-Encryption-Key'
+	);
+
+	# Unknown controller is rejected with 0x02
+	my $session2 = OpenHAP::Session->new( socket => 'client2' );
+	my ( $pairing2, $storage2 ) = make_pairing();
+	my $m2_2 = $pairing2->handle_pair_verify( $m1, $session2 );
+	my $acc_public2 =
+	    tlv_field( $m2_2, OpenHAP::Pairing::kTLVType_PublicKey() );
+	my $shared2 =
+	    OpenHAP::Crypto::derive_shared_secret( $ios_secret,
+		$acc_public2 );
+	my $pv_key2 = OpenHAP::Crypto::hkdf_sha512( $shared2,
+		'Pair-Verify-Encrypt-Salt', 'Pair-Verify-Encrypt-Info', 32 );
+	my $ios_sig2 = OpenHAP::Crypto::sign_ed25519(
+		$ios_public . $ios_id . $acc_public2,
+		$ios_ltsk, $ios_ltpk );
+	my $m3_inner2 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_Identifier(), $ios_id,
+		OpenHAP::Pairing::kTLVType_Signature(),  $ios_sig2,
+	);
+	my ( $enc2, $tag2 ) =
+	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $pv_key2,
+		pack('x[4]') . 'PV-Msg03', $m3_inner2 );
+	my $m3_2 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 3 ),
+		OpenHAP::Pairing::kTLVType_EncryptedData(), $enc2 . $tag2,
+	);
+	is( error_code( $pairing2->handle_pair_verify( $m3_2, $session2 ) ),
+		OpenHAP::Pairing::kTLVError_Authentication(),
+		'[HAP-Pairing §3.5] unknown controller rejected with 0x02' );
+};
+
+subtest '[HAP-Pairing §8] authentication attempt limits' => sub {
+	my $storage =
+	    OpenHAP::Storage->new( db_path => tempdir( CLEANUP => 1 ) );
+	my ( $pairing, undef, undef ) = make_pairing($storage);
+
+	# Limit is 100 attempts; at the limit M1 returns 0x05 MaxTries
+	is( OpenHAP::Pairing::MAX_AUTH_ATTEMPTS(),
+		100, 'maximum unsuccessful attempts is 100' );
+
+	$OpenHAP::Pairing::failed_auth_attempts = 100;
+	my $session = OpenHAP::Session->new( socket => 'client' );
+	my $m1      = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
+	);
+	is( error_code( $pairing->handle_pair_setup( $m1, $session ) ),
+		OpenHAP::Pairing::kTLVError_MaxTries(),
+		'M1 at the limit returns 0x05 MaxTries' );
+
+	# Counter is stored persistently and survives restart
+	my ($pairing2) = run_failed_attempt($storage);
+	is( $storage->get_auth_attempts, 1, 'failed attempt persisted' );
+
+	my $revived = OpenHAP::Pairing->new(
+		pin            => $PIN,
+		storage        => $storage,
+		accessory_ltsk => 'x' x 64,
+		accessory_ltpk => 'y' x 32,
+	);
+	is( OpenHAP::Pairing->get_failed_attempts(),
+		1, 'attempt counter restored from storage on restart' );
+
+	# Reset only after a successful SRP proof verification
+	my ( $pairing3, undef, undef ) = make_pairing($storage);
+	my ($m4) = run_m1_to_m4( $pairing3, $PIN );
+	ok( !defined error_code($m4), 'successful SRP proof' );
+	is( OpenHAP::Pairing->get_failed_attempts(),
+		0, 'counter reset after successful SRP proof' );
+	is( $storage->get_auth_attempts, 0, 'reset persisted' );
+
+	OpenHAP::Pairing->clear_pairing_state();
+};
+
+# Run a single failed pairing attempt (wrong PIN) against $storage
+sub run_failed_attempt ($storage)
+{
+	OpenHAP::Pairing->clear_pairing_state();
+	my ( $ltsk, $ltpk ) = OpenHAP::Crypto::generate_keypair_ed25519();
+	my $pairing = OpenHAP::Pairing->new(
+		pin            => $PIN,
+		storage        => $storage,
+		accessory_ltsk => $ltsk,
+		accessory_ltpk => $ltpk,
+	);
+	$pairing->reset_auth_attempts;
+	run_m1_to_m4( $pairing, '876-54-321' );
+	OpenHAP::Pairing->clear_pairing_state();
+	return $pairing;
+}
+
+done_testing();

--- a/t/conformance/hap-services.t
+++ b/t/conformance/hap-services.t
@@ -1,0 +1,261 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/HAP-Services.md
+#
+# Data-driven over the services OpenHAP implements; catalog rows are
+# cited as [HAP-Services §4/<Name>] and the UUID table as §6 rows.
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use lib "$RealBin/../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+use_ok('OpenHAP::Service');
+use_ok('OpenHAP::Characteristic');
+use_ok('OpenHAP::Bridge');
+use_ok('OpenHAP::TestMock::MQTT');
+use_ok('OpenHAP::Tasmota::Heater');
+use_ok('OpenHAP::Tasmota::Sensor');
+use_ok('OpenHAP::Tasmota::Thermostat');
+use_ok('OpenHAP::Tasmota::Lightbulb');
+
+# [HAP-Services §6] UUID table rows for every service OpenHAP defines
+my %uuid_table = (
+	AccessoryInformation => '3E',
+	ProtocolInformation  => 'A2',
+	Thermostat           => '4A',
+	Switch               => '49',
+	TemperatureSensor    => '8A',
+	HumiditySensor       => '82',
+	Outlet               => '47',
+	Lightbulb            => '43',
+);
+
+subtest '[HAP-Services §6] service UUID table' => sub {
+	for my $name ( sort keys %uuid_table ) {
+		my $short = $uuid_table{$name};
+		my $full  = sprintf '%08s-0000-1000-8000-0026BB765291',
+		    '0' x ( 8 - length $short ) . $short;
+		is( $OpenHAP::Service::SERVICE_TYPES{$name},
+			$full, "[HAP-Services §6/$name] UUID is $full" );
+	}
+};
+
+subtest '[HAP-Services §2] UUID short form in JSON' => sub {
+	my $service = OpenHAP::Service->new( type => 'Lightbulb', iid => 10 );
+	is( $service->to_json->{type}, '43',
+		'Apple service UUID shortened to hex prefix' );
+
+	my $custom = OpenHAP::Service->new(
+		type => '12345678-1234-1234-1234-123456789012',
+		iid  => 11,
+	);
+	is( $custom->to_json->{type},
+		'12345678-1234-1234-1234-123456789012',
+		'custom UUID preserved in full' );
+};
+
+# Collect the short types of the characteristics present on a service
+sub service_char_types ($service)
+{
+	my %types;
+	for my $char ( $service->get_characteristics ) {
+		$types{ $char->to_json->{type} } = 1;
+	}
+	return \%types;
+}
+
+sub find_service ( $accessory, $short_type )
+{
+	for my $service ( $accessory->get_services ) {
+		return $service
+		    if $service->to_json->{type} eq $short_type;
+	}
+	return;
+}
+
+subtest '[HAP-Services §3] AccessoryInformation on every accessory' =>
+    sub {
+	my $mqtt        = OpenHAP::TestMock::MQTT->new;
+	my @accessories = (
+		OpenHAP::Bridge->new( name => 'Bridge' ),
+		OpenHAP::Tasmota::Heater->new(
+			aid         => 2,
+			name        => 'Heater',
+			mqtt_topic  => 'h',
+			mqtt_client => $mqtt,
+		),
+	);
+
+	for my $accessory (@accessories) {
+		my $info = find_service( $accessory, '3E' );
+		ok( $info, "$accessory->{name} has AccessoryInformation" );
+		is( ( $accessory->get_services )[0], $info,
+			'AccessoryInformation is the first service' );
+
+		my $types = service_char_types($info);
+		for my $required (
+			[ Identify         => '14' ],
+			[ Manufacturer     => '20' ],
+			[ Model            => '21' ],
+			[ Name             => '23' ],
+			[ SerialNumber     => '30' ],
+			[ FirmwareRevision => '52' ],
+		    )
+		{
+			my ( $name, $short ) = @$required;
+			ok( $types->{$short},
+				"required characteristic $name ($short)" );
+		}
+	}
+};
+
+subtest '[HAP-Services §3] ProtocolInformation on the bridge only' => sub {
+	my $bridge = OpenHAP::Bridge->new( name => 'Bridge' );
+	my $protocol = find_service( $bridge, 'A2' );
+	ok( $protocol, 'bridge carries ProtocolInformation' );
+
+	my $types = service_char_types($protocol);
+	ok( $types->{'37'}, 'required characteristic Version (37)' );
+
+	my $version =
+	    $protocol->get_characteristic_by_type('Version');
+	is( $version->get_value, '1.1.0', 'Version reports HAP 1.1.0' );
+
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'Heater',
+		mqtt_topic  => 'h',
+		mqtt_client => $mqtt,
+	);
+	ok( !find_service( $heater, 'A2' ),
+		'bridged accessories do not carry ProtocolInformation' );
+};
+
+subtest '[HAP-Services §4] required characteristics per service' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+
+	# [HAP-Services §4/Switch] required: On
+	my $heater = OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'Heater',
+		mqtt_topic  => 'h',
+		mqtt_client => $mqtt,
+	);
+	my $switch = find_service( $heater, '49' );
+	ok( $switch, 'Heater exposes a Switch service' );
+	ok( service_char_types($switch)->{'25'},
+		'[HAP-Services §4/Switch] required characteristic On' );
+
+	# [HAP-Services §4/TemperatureSensor] required: CurrentTemperature
+	my $sensor = OpenHAP::Tasmota::Sensor->new(
+		aid         => 3,
+		name        => 'Sensor',
+		mqtt_topic  => 's',
+		mqtt_client => $mqtt,
+	);
+	my $temp = find_service( $sensor, '8A' );
+	ok( $temp, 'Sensor exposes a TemperatureSensor service' );
+	ok( service_char_types($temp)->{'11'},
+		'[HAP-Services §4/TemperatureSensor] CurrentTemperature' );
+
+	# [HAP-Services §4/HumiditySensor] required: CurrentRelativeHumidity
+	my $humidity_sensor = OpenHAP::Tasmota::Sensor->new(
+		aid          => 4,
+		name         => 'Humidity',
+		mqtt_topic   => 'hs',
+		mqtt_client  => $mqtt,
+		has_humidity => 1,
+	);
+	my $humidity = find_service( $humidity_sensor, '82' );
+	ok( $humidity, 'humidity Sensor exposes a HumiditySensor service' );
+	ok( service_char_types($humidity)->{'10'},
+		'[HAP-Services §4/HumiditySensor] CurrentRelativeHumidity' );
+
+	# [HAP-Services §4/Thermostat] five required characteristics
+	my $thermostat_dev = OpenHAP::Tasmota::Thermostat->new(
+		aid         => 5,
+		name        => 'Thermostat',
+		mqtt_topic  => 't',
+		mqtt_client => $mqtt,
+	);
+	my $thermostat = find_service( $thermostat_dev, '4A' );
+	ok( $thermostat, 'Thermostat exposes a Thermostat service' );
+	my $types = service_char_types($thermostat);
+	for my $required (
+		[ CurrentHeatingCoolingState => 'F' ],
+		[ TargetHeatingCoolingState  => '33' ],
+		[ CurrentTemperature         => '11' ],
+		[ TargetTemperature          => '35' ],
+		[ TemperatureDisplayUnits    => '36' ],
+	    )
+	{
+		my ( $name, $short ) = @$required;
+		ok( $types->{$short},
+			"[HAP-Services §4/Thermostat] required $name" );
+	}
+
+	# [HAP-Services §4/LightBulb] required: On
+	my $light_dev = OpenHAP::Tasmota::Lightbulb->new(
+		aid          => 6,
+		name         => 'Light',
+		mqtt_topic   => 'l',
+		mqtt_client  => $mqtt,
+		capabilities => OpenHAP::Tasmota::Lightbulb::CAP_DIMMER(),
+	);
+	my $light = find_service( $light_dev, '43' );
+	ok( $light, 'Lightbulb exposes a LightBulb service' );
+	ok( service_char_types($light)->{'25'},
+		'[HAP-Services §4/LightBulb] required characteristic On' );
+	ok( service_char_types($light)->{'8'},
+		'[HAP-Services §4/LightBulb] optional Brightness present '
+		    . 'for dimmer' );
+};
+
+subtest '[HAP-Services §1][HAP-Services §7] service JSON structure' =>
+    sub {
+	my $service = OpenHAP::Service->new(
+		type    => 'Switch',
+		iid     => 10,
+		hidden  => 1,
+		primary => 1,
+	);
+	$service->add_characteristic(
+		OpenHAP::Characteristic->new(
+			type   => 'On',
+			iid    => 11,
+			format => 'bool',
+			perms  => [ 'pr', 'pw' ],
+			value  => 0,
+		) );
+
+	my $json = $service->to_json;
+	is( $json->{iid},  10,   'service has instance ID' );
+	is( $json->{type}, '49', 'service has type UUID' );
+	is( ref $json->{characteristics},
+		'ARRAY', 'service carries characteristic objects' );
+	is( scalar @{ $json->{characteristics} },
+		1, 'characteristics array populated' );
+	is( ${ $json->{primary} }, 1, 'primary flag encoded' );
+	is( ${ $json->{hidden} },  1, 'hidden flag encoded' );
+};
+
+subtest '[HAP-Services §5] primary service marking' => sub {
+	my $service = OpenHAP::Service->new(
+		type    => 'Switch',
+		iid     => 10,
+		primary => 1,
+	);
+	my $json = $service->to_json;
+	is( ${ $json->{primary} }, 1, 'primary service marked in JSON' );
+
+	my $plain = OpenHAP::Service->new( type => 'Switch', iid => 11 );
+	ok( !exists $plain->to_json->{primary},
+		'non-primary service omits the flag' );
+};
+
+done_testing();

--- a/t/conformance/hap-tlv8.t
+++ b/t/conformance/hap-tlv8.t
@@ -1,0 +1,238 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/HAP-TLV8.md
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+use_ok('OpenHAP::TLV');
+use_ok('OpenHAP::Pairing');
+
+subtest '[HAP-TLV8 §1] basic record structure' => sub {
+	my $encoded = OpenHAP::TLV::encode( 0x06, "\x01" );
+	is( length($encoded), 3, 'record is type + length + value' );
+	is( unpack( 'H*', $encoded ), '060101',
+		'type, length and value bytes in order' );
+
+	my $empty = OpenHAP::TLV::encode( 0x0A, '' );
+	is( unpack( 'H*', $empty ), '0a00', 'zero-length value encodes' );
+};
+
+subtest '[HAP-TLV8 §2] fragmentation of long values' => sub {
+	my $value   = 'X' x 500;
+	my $encoded = OpenHAP::TLV::encode( 0x03, $value );
+
+	# 500 bytes -> 255 + 245: 2 records with 2-byte headers each
+	is( length($encoded), 500 + 4, 'two records for 500 bytes' );
+
+	# First fragment must be exactly 255 bytes
+	my ( $t1, $l1 ) = unpack( 'CC', substr( $encoded, 0, 2 ) );
+	is( $t1, 0x03, 'first fragment has value type' );
+	is( $l1, 255,  'non-final fragment is exactly 255 bytes' );
+
+	my ( $t2, $l2 ) = unpack( 'CC', substr( $encoded, 257, 2 ) );
+	is( $t2, 0x03, 'second fragment has same type' );
+	is( $l2, 245,  'final fragment carries the remainder' );
+
+	# Decoder concatenates same-type records
+	my %decoded = OpenHAP::TLV::decode($encoded);
+	is( $decoded{0x03}, $value, 'fragments concatenated on decode' );
+};
+
+subtest '[HAP-TLV8 §8][HAP-TLV8 §8.2] 384-byte SRP key splits FF/81' =>
+    sub {
+	my $key     = 'K' x 384;
+	my $encoded = OpenHAP::TLV::encode( 0x03, $key );
+
+	is( length($encoded), 384 + 4, '384 bytes need two records' );
+	is( unpack( 'C', substr( $encoded, 1, 1 ) ),
+		0xFF, 'first fragment length byte is FF (255)' );
+	is( unpack( 'C', substr( $encoded, 257 + 1, 1 ) ),
+		0x81, 'second fragment length byte is 81 (129)' );
+
+	my %decoded = OpenHAP::TLV::decode($encoded);
+	is( length( $decoded{0x03} ), 384, 'round-trips to 384 bytes' );
+};
+
+subtest '[HAP-TLV8 §3] separators between list items' => sub {
+	my $encoded = OpenHAP::TLV::encode_separator();
+	is( unpack( 'H*', $encoded ), 'ff00',
+		'separator is type 0xFF with zero length' );
+	is( OpenHAP::TLV::kTLVType_Separator(), 0xFF, 'separator type 0xFF' );
+};
+
+subtest '[HAP-TLV8 §4] value encodings' => sub {
+
+	# [HAP-TLV8 §4.1] integers are little-endian, minimum bytes
+	is( unpack( 'H*', OpenHAP::TLV::encode( 0x0B, pack( 'C', 1 ) ) ),
+		'0b0101', '[HAP-TLV8 §4.1] integer 1 encodes as 01' );
+	is( unpack( 'H*', OpenHAP::TLV::encode( 0x0B, pack( 'v', 256 ) ) ),
+		'0b020001',
+		'[HAP-TLV8 §4.1] integer 256 encodes as 00 01 (LE)' );
+	is( unpack( 'H*', OpenHAP::TLV::encode( 0x0B, pack( 'V', 65536 ) ) ),
+		'0b0400000100',
+		'[HAP-TLV8 §4.1] integer 65536 encodes as 00 00 01 00 (LE)' );
+
+	# [HAP-TLV8 §4.2] strings without null terminator
+	is( unpack( 'H*', OpenHAP::TLV::encode( 0x01, 'Hello' ) ),
+		'010548656c6c6f',
+		'[HAP-TLV8 §4.2] UTF-8 bytes, no null terminator' );
+
+	# [HAP-TLV8 §4.3] binary data round-trips raw
+	my $binary  = pack( 'H*', '00ff10deadbeef' );
+	my %decoded =
+	    OpenHAP::TLV::decode( OpenHAP::TLV::encode( 0x05, $binary ) );
+	is( unpack( 'H*', $decoded{0x05} ),
+		'00ff10deadbeef',
+		'[HAP-TLV8 §4.3] raw bytes preserved' );
+
+	# [HAP-TLV8 §4.4] a TLV value can be a nested TLV structure
+	my $inner = OpenHAP::TLV::encode( 0x01, 'id', 0x0A, 'sig' );
+	my %outer =
+	    OpenHAP::TLV::decode( OpenHAP::TLV::encode( 0x05, $inner ) );
+	my %nested = OpenHAP::TLV::decode( $outer{0x05} );
+	is( $nested{0x01}, 'id',
+		'[HAP-TLV8 §4.4] nested TLV decodes from sub-TLV value' );
+	is( $nested{0x0A}, 'sig', '[HAP-TLV8 §4.4] all nested fields kept' );
+};
+
+subtest '[HAP-TLV8 §5] pairing TLV type codes' => sub {
+	my %types = (
+		Method        => 0x00,
+		Identifier    => 0x01,
+		Salt          => 0x02,
+		PublicKey     => 0x03,
+		Proof         => 0x04,
+		EncryptedData => 0x05,
+		State         => 0x06,
+		Error         => 0x07,
+		RetryDelay    => 0x08,
+		Certificate   => 0x09,
+		Signature     => 0x0A,
+		Permissions   => 0x0B,
+		FragmentData  => 0x0C,
+		FragmentLast  => 0x0D,
+		SessionID     => 0x0E,
+		Flags         => 0x13,
+		Separator     => 0xFF,
+	);
+	for my $name ( sort keys %types ) {
+		my $constant = OpenHAP::Pairing->can("kTLVType_$name");
+		ok( $constant, "kTLVType_$name defined" );
+		is( $constant->(), $types{$name},
+			sprintf( '[HAP-TLV8 §5/%s] kTLVType_%s is 0x%02X',
+				$name, $name, $types{$name} ) );
+	}
+};
+
+subtest '[HAP-TLV8 §7] pairing error codes' => sub {
+	my %errors = (
+		Unknown        => 0x01,
+		Authentication => 0x02,
+		Backoff        => 0x03,
+		MaxPeers       => 0x04,
+		MaxTries       => 0x05,
+		Unavailable    => 0x06,
+		Busy           => 0x07,
+	);
+	for my $name ( sort keys %errors ) {
+		my $constant = OpenHAP::Pairing->can("kTLVError_$name");
+		ok( $constant, "kTLVError_$name defined" );
+		is( $constant->(), $errors{$name},
+			sprintf( '[HAP-TLV8 §7/%s] kTLVError_%s is 0x%02X',
+				$name, $name, $errors{$name} ) );
+	}
+};
+
+subtest '[HAP-TLV8 §8.1] pair setup M1 wire bytes' => sub {
+	my $m1 = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
+		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
+	);
+	is( unpack( 'H*', $m1 ), '060101000100',
+		'M1 request is 06 01 01 00 01 00' );
+
+	my %decoded = OpenHAP::TLV::decode( pack( 'H*', '060101000100' ) );
+	is( unpack( 'C', $decoded{0x06} ), 1, 'spec bytes decode State=M1' );
+	is( unpack( 'C', $decoded{0x00} ), 0,
+		'spec bytes decode Method=PairSetup' );
+};
+
+subtest '[HAP-TLV8 §8.3] error response wire bytes' => sub {
+	my $error = OpenHAP::TLV::encode(
+		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 2 ),
+		OpenHAP::Pairing::kTLVType_Error(),
+		pack( 'C', OpenHAP::Pairing::kTLVError_Authentication() ),
+	);
+	is( unpack( 'H*', $error ), '060102070102',
+		'M2 authentication error is 06 01 02 07 01 02' );
+};
+
+subtest '[HAP-TLV8 §9] base64 encoding in JSON' => sub {
+	require MIME::Base64;
+
+	# The spec example: "BgEBAAEA" decodes to the M1 request bytes
+	my $decoded = MIME::Base64::decode_base64('BgEBAAEA');
+	is( unpack( 'H*', $decoded ), '060101000100',
+		'spec base64 example decodes to M1 bytes' );
+
+	my %tlv = OpenHAP::TLV::decode($decoded);
+	is( unpack( 'C', $tlv{0x06} ), 1, 'decoded TLV carries State=M1' );
+
+	is( MIME::Base64::encode_base64( pack( 'H*', '060101000100' ), '' ),
+		'BgEBAAEA', 'M1 bytes encode back to the spec base64' );
+};
+
+subtest '[HAP-TLV8 §10] parser rules with hostile buffers' => sub {
+
+	# Rule 1: unknown types are preserved, not fatal
+	my %decoded =
+	    OpenHAP::TLV::decode( pack( 'H*', '060101' . 'aa0142' ) );
+	is( unpack( 'C', $decoded{0x06} ), 1, 'known type decoded' );
+	is( $decoded{0xAA}, 'B', 'unknown type tolerated by parser' );
+
+	# Rule 3: consecutive same types concatenate
+	%decoded = OpenHAP::TLV::decode( pack( 'H*', '01024142' . '010243'
+		    . '44' ) );
+	is( $decoded{0x01}, 'ABCD', 'consecutive same types concatenate' );
+
+	# Rule 4: zero-length values are valid
+	%decoded = OpenHAP::TLV::decode( pack( 'H*', 'ff00' ) );
+	ok( exists $decoded{0xFF}, 'zero-length value is valid' );
+	is( $decoded{0xFF}, '', 'zero-length value is empty string' );
+
+	# Malformed: length runs past end of buffer
+	my @result = OpenHAP::TLV::decode( pack( 'H*', '06ff0102' ) );
+	is( scalar @result, 0, 'length past end of buffer is rejected' );
+
+	# Malformed: truncated record header (type without length)
+	@result = OpenHAP::TLV::decode( pack( 'H*', '06010106' ) );
+	is( scalar @result, 0, 'truncated record header is rejected' );
+
+	# Malformed input to pair-setup returns an error TLV, not a crash
+	require OpenHAP::Session;
+	require OpenHAP::Storage;
+	require File::Temp;
+	my $storage =
+	    OpenHAP::Storage->new(
+		db_path => File::Temp::tempdir( CLEANUP => 1 ) );
+	my $pairing = OpenHAP::Pairing->new(
+		pin            => '123-45-678',
+		storage        => $storage,
+		accessory_ltsk => 'x' x 64,
+		accessory_ltpk => 'y' x 32,
+	);
+	my $session  = OpenHAP::Session->new( socket => 'dummy' );
+	my $response =
+	    $pairing->handle_pair_setup( pack( 'H*', '06ff0102' ), $session );
+	my %resp = OpenHAP::TLV::decode($response);
+	is( unpack( 'C', $resp{ OpenHAP::Pairing::kTLVType_Error() } ),
+		OpenHAP::Pairing::kTLVError_Unknown(),
+		'malformed pair-setup body answered with kTLVError_Unknown' );
+};
+
+done_testing();

--- a/t/conformance/mqtt-control.t
+++ b/t/conformance/mqtt-control.t
@@ -1,0 +1,271 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/MQTT-Control.md
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use lib "$RealBin/../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+use_ok('OpenHAP::TestMock::MQTT');
+use_ok('OpenHAP::Tasmota::Heater');
+use_ok('OpenHAP::Tasmota::Thermostat');
+use_ok('OpenHAP::Tasmota::Sensor');
+use_ok('OpenHAP::Tasmota::Lightbulb');
+
+sub make_heater ( $mqtt, %extra )
+{
+	return OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'Heater',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+		%extra,
+	);
+}
+
+sub make_light ( $mqtt, $capabilities )
+{
+	return OpenHAP::Tasmota::Lightbulb->new(
+		aid          => 2,
+		name         => 'Light',
+		mqtt_topic   => 'light',
+		mqtt_client  => $mqtt,
+		capabilities => $capabilities,
+	);
+}
+
+my $CAP_DIMMER = OpenHAP::Tasmota::Lightbulb::CAP_DIMMER();
+my $CAP_COLOR  = OpenHAP::Tasmota::Lightbulb::CAP_COLOR();
+my $CAP_CT     = OpenHAP::Tasmota::Lightbulb::CAP_CT();
+
+sub last_published ($mqtt)
+{
+	my @published = $mqtt->get_published;
+	return $published[-1];
+}
+
+subtest '[MQTT-Control §1] power control payloads' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = make_heater($mqtt);
+
+	$mqtt->clear_published;
+	$heater->set_power(1);
+	is( last_published($mqtt)->{topic},
+		'cmnd/device/Power', 'Power command topic' );
+	is( last_published($mqtt)->{payload}, 'ON', 'ON turns relay on' );
+
+	$mqtt->clear_published;
+	$heater->set_power(0);
+	is( last_published($mqtt)->{payload}, 'OFF', 'OFF turns relay off' );
+
+	$mqtt->clear_published;
+	$heater->toggle_power;
+	is( last_published($mqtt)->{payload},
+		'TOGGLE', 'TOGGLE toggles state' );
+
+	$mqtt->clear_published;
+	$heater->blink(1);
+	is( last_published($mqtt)->{payload},
+		'BLINK', 'BLINK starts blinking' );
+
+	$mqtt->clear_published;
+	$heater->blink(0);
+	is( last_published($mqtt)->{payload},
+		'BLINKOFF', 'BLINKOFF stops blinking' );
+};
+
+subtest '[MQTT-Control §1] multi-relay and SetOption26' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+
+	my $plain = make_heater($mqtt);
+	is( $plain->_get_power_key,   'POWER', 'single relay uses POWER' );
+	is( $plain->_get_power_topic, 'cmnd/device/Power',
+		'single relay topic has no index' );
+
+	my $relay2 = make_heater( $mqtt, aid => 3, relay_index => 2 );
+	is( $relay2->_get_power_key, 'POWER2',
+		'relay 2 uses POWER2 state key' );
+	is( $relay2->_get_power_topic, 'cmnd/device/Power2',
+		'relay 2 commands Power2' );
+
+	my $so26 = make_heater( $mqtt, aid => 4, setoption26 => 1 );
+	is( $so26->_get_power_key, 'POWER1',
+		'SetOption26 uses POWER1 even for a single relay' );
+
+	# FullTopic composes with relay index
+	my $custom = OpenHAP::Tasmota::Base->new(
+		aid         => 5,
+		name        => 'Custom',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+		relay_index => 2,
+		fulltopic   => 'home/%topic%/%prefix%/',
+	);
+	is( $custom->_get_power_topic, 'home/device/cmnd/Power2',
+		'FullTopic + relay_index builds correct topic' );
+};
+
+subtest '[MQTT-Control §2] dimmer control' => sub {
+	my $mqtt  = OpenHAP::TestMock::MQTT->new;
+	my $light = make_light( $mqtt, $CAP_DIMMER );
+	$light->subscribe_mqtt;
+
+	$mqtt->clear_published;
+	$light->_set_brightness(75);
+	is( last_published($mqtt)->{topic},
+		'cmnd/light/Dimmer', 'Dimmer command topic' );
+	is( last_published($mqtt)->{payload},
+		'75', 'brightness percentage 0..100' );
+
+	for my $step (
+		[ '+', 'increase by DimmerStep' ],
+		[ '-', 'decrease by DimmerStep' ],
+	    )
+	{
+		$mqtt->clear_published;
+		$light->dimmer_step( $step->[0] );
+		is( last_published($mqtt)->{payload},
+			$step->[0], "dimmer step $step->[1]" );
+	}
+
+	$mqtt->clear_published;
+	$light->dimmer_min;
+	is( last_published($mqtt)->{payload}, '<', '< decreases to 1' );
+
+	$mqtt->clear_published;
+	$light->dimmer_max;
+	is( last_published($mqtt)->{payload}, '>', '> increases to 100' );
+};
+
+subtest '[MQTT-Control §3][MQTT-Control §3.1] HSBColor control' => sub {
+	my $mqtt  = OpenHAP::TestMock::MQTT->new;
+	my $light = make_light( $mqtt, $CAP_DIMMER | $CAP_COLOR );
+	$light->subscribe_mqtt;
+
+	$mqtt->clear_published;
+	$light->_set_hue(240);
+	is( last_published($mqtt)->{topic},
+		'cmnd/light/HSBColor1', 'HSBColor1 sets hue only' );
+	is( last_published($mqtt)->{payload}, '240', 'hue 0..360' );
+
+	$mqtt->clear_published;
+	$light->_set_saturation(80);
+	is( last_published($mqtt)->{topic},
+		'cmnd/light/HSBColor2', 'HSBColor2 sets saturation only' );
+	is( last_published($mqtt)->{payload}, '80', 'saturation 0..100' );
+
+	$mqtt->clear_published;
+	$light->set_color( 120, 100, 50 );
+	is( last_published($mqtt)->{topic},
+		'cmnd/light/HSBColor', 'HSBColor sets all three' );
+	is( last_published($mqtt)->{payload},
+		'120,100,50', 'payload is <hue>,<sat>,<bri>' );
+};
+
+subtest '[MQTT-Control §3.2] Color RGB formats' => sub {
+	my $mqtt  = OpenHAP::TestMock::MQTT->new;
+	my $light = make_light( $mqtt, $CAP_COLOR );
+	$light->subscribe_mqtt;
+
+	# Hex color format (SetOption17 0, default)
+	$mqtt->simulate_message( 'stat/light/RESULT', '{"Color":"FF0000"}' );
+	is( $light->{hue}, 0, 'hex color red parsed (hue 0)' );
+
+	# Decimal color format (SetOption17 1)
+	$mqtt->simulate_message( 'stat/light/RESULT', '{"Color":"0,255,0"}' );
+	is( $light->{hue}, 120, 'decimal color green parsed (hue 120)' );
+
+	$mqtt->simulate_message( 'stat/light/RESULT', '{"Color":"0,0,255"}' );
+	is( $light->{hue}, 240, 'decimal color blue parsed (hue 240)' );
+
+	# RGB -> HSB conversion per the spec value ranges
+	my ( $h, $s, $b ) = $light->_rgb_to_hsb( 255, 0, 0 );
+	is_deeply( [ $h, $s, $b ], [ 0, 100, 100 ],
+		'pure red is 0,100,100' );
+	( $h, $s, $b ) = $light->_rgb_to_hsb( 255, 255, 255 );
+	is_deeply( [ $s, $b ], [ 0, 100 ], 'white has no saturation' );
+	( $h, $s, $b ) = $light->_rgb_to_hsb( 128, 128, 128 );
+	is_deeply( [ $s, $b ], [ 0, 50 ], '50% gray at half brightness' );
+};
+
+subtest '[MQTT-Control §4] color temperature range' => sub {
+	my $mqtt  = OpenHAP::TestMock::MQTT->new;
+	my $light = make_light( $mqtt, $CAP_CT );
+	$light->subscribe_mqtt;
+
+	$mqtt->clear_published;
+	$light->_set_ct(300);
+	is( last_published($mqtt)->{topic}, 'cmnd/light/CT',
+		'CT command topic' );
+	is( last_published($mqtt)->{payload}, '300', 'CT in mireds' );
+
+	# Range is 153..500 mireds
+	$mqtt->clear_published;
+	$light->_set_ct(100);
+	is( last_published($mqtt)->{payload},
+		'153', 'CT clamped to 153 (cold end)' );
+
+	$mqtt->simulate_message( 'stat/light/RESULT', '{"CT":600}' );
+	is( $light->{ct}, 500, 'reported CT clamped to 500 (warm end)' );
+};
+
+subtest '[MQTT-Control §5] status queries' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+
+	# Thermostats query sensor information (Status 10) on subscribe
+	my $thermostat = OpenHAP::Tasmota::Thermostat->new(
+		aid         => 2,
+		name        => 'Thermostat',
+		mqtt_topic  => 'thermostat',
+		mqtt_client => $mqtt,
+	);
+	$thermostat->subscribe_mqtt;
+	ok(
+		( grep {
+			$_->{topic} eq 'cmnd/thermostat/Status'
+			    && $_->{payload} eq '10'
+		} $mqtt->get_published ),
+		'Status 10 (sensor information) queried on subscribe'
+	);
+
+	# STATUS8 (legacy sensor) responses are handled
+	$mqtt->simulate_message( 'stat/thermostat/STATUS8',
+		'{"StatusSNS":{"DS18B20":{"Temperature":23},"TempUnit":"C"}}'
+	);
+	is( $thermostat->{current_temp}, 23,
+		'STATUS8 response updates temperature' );
+
+	# STATUS10 responses are handled
+	my $sensor = OpenHAP::Tasmota::Sensor->new(
+		aid         => 3,
+		name        => 'Sensor',
+		mqtt_topic  => 'sensor',
+		mqtt_client => $mqtt,
+	);
+	$sensor->subscribe_mqtt;
+	ok( ( grep { $_ eq 'stat/sensor/STATUS10' }
+		    $mqtt->get_subscriptions ),
+		'subscribed to STATUS10 responses' );
+	$mqtt->simulate_message( 'stat/sensor/STATUS10',
+		'{"StatusSNS":{"DS18B20":{"Temperature":26},"TempUnit":"C"}}'
+	);
+	is( $sensor->{current_temp}, 26,
+		'STATUS10 response updates temperature' );
+
+	# STATUS11 (full state) responses are handled
+	my $heater = make_heater($mqtt);
+	$heater->subscribe_mqtt;
+	ok( ( grep { $_ eq 'stat/device/STATUS11' }
+		    $mqtt->get_subscriptions ),
+		'subscribed to STATUS11 responses' );
+	$mqtt->simulate_message( 'stat/device/STATUS11',
+		'{"StatusSTS":{"POWER":"ON","Uptime":"1T00:00:00"}}' );
+	is( $heater->{power_state}, 1,
+		'STATUS11 response updates power state' );
+};
+
+done_testing();

--- a/t/conformance/mqtt-sensors.t
+++ b/t/conformance/mqtt-sensors.t
@@ -1,0 +1,140 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/MQTT-Sensors.md
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use lib "$RealBin/../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+use_ok('OpenHAP::TestMock::MQTT');
+use_ok('OpenHAP::Tasmota::Sensor');
+use_ok('OpenHAP::Tasmota::Base');
+
+sub make_sensor ( $mqtt, %extra )
+{
+	my $sensor = OpenHAP::Tasmota::Sensor->new(
+		aid         => 2,
+		name        => 'Sensor',
+		mqtt_topic  => 'sensor',
+		mqtt_client => $mqtt,
+		%extra,
+	);
+	$sensor->subscribe_mqtt;
+	return $sensor;
+}
+
+subtest '[MQTT-Sensors §1] SENSOR message structure' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $sensor = make_sensor($mqtt);
+
+	ok( ( grep { $_ eq 'tele/sensor/SENSOR' }
+		    $mqtt->get_subscriptions ),
+		'[MQTT-Sensors §5.2] subscribed to tele/+/SENSOR' );
+
+	$mqtt->simulate_message( 'tele/sensor/SENSOR',
+		'{"Time":"2024-01-01T00:00:00",'
+		    . '"DS18B20":{"Temperature":25.5},"TempUnit":"C"}' );
+	is( $sensor->{current_temp}, 25.5,
+		'per-sensor object parsed from SENSOR message' );
+};
+
+subtest '[MQTT-Sensors §2] common sensor types' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $sensor = make_sensor($mqtt);
+
+	$mqtt->simulate_message( 'tele/sensor/SENSOR',
+		'{"DS18B20":{"Temperature":21},"TempUnit":"C"}' );
+	is( $sensor->{sensor_type}, 'DS18B20',
+		'[MQTT-Sensors §2/DS18B20] type auto-detected' );
+
+	my $dht = make_sensor(
+		OpenHAP::TestMock::MQTT->new,
+		aid          => 3,
+		name         => 'DHT',
+		has_humidity => 1,
+	);
+	$dht->{mqtt_client}->simulate_message( 'tele/sensor/SENSOR',
+		'{"DHT22":{"Temperature":22.5,"Humidity":65},"TempUnit":"C"}'
+	);
+	is( $dht->{sensor_type}, 'DHT22',
+		'[MQTT-Sensors §2/DHT11] DHT-family type auto-detected' );
+};
+
+subtest '[MQTT-Sensors §3] temperature sensors' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $sensor = make_sensor($mqtt);
+
+	# TempUnit C is passed through
+	$mqtt->simulate_message( 'tele/sensor/SENSOR',
+		'{"DS18B20":{"Temperature":25},"TempUnit":"C"}' );
+	is( $sensor->{current_temp}, 25, 'Celsius reading passed through' );
+
+	# TempUnit F is converted before use in HomeKit
+	$mqtt->simulate_message( 'tele/sensor/SENSOR',
+		'{"DS18B20":{"Temperature":77},"TempUnit":"F"}' );
+	ok( abs( $sensor->{current_temp} - 25 ) < 0.1,
+		'TempUnit F converted to Celsius (77F = 25C)' );
+
+	# The conversion helper handles the boundary case
+	my $base = OpenHAP::Tasmota::Base->new(
+		aid         => 9,
+		name        => 'Conv',
+		mqtt_topic  => 'conv',
+		mqtt_client => $mqtt,
+	);
+	$base->{temp_unit} = 'F';
+	ok( abs( $base->convert_temperature(32) ) < 0.1, '32F = 0C' );
+
+	# Multiple sensors report under indexed keys
+	my $indexed = make_sensor(
+		OpenHAP::TestMock::MQTT->new,
+		aid          => 4,
+		name         => 'Indexed',
+		sensor_type  => 'DS18B20',
+		sensor_index => 2,
+	);
+	$indexed->{mqtt_client}->simulate_message( 'tele/sensor/SENSOR',
+		'{"DS18B20-1":{"Temperature":20},'
+		    . '"DS18B20-2":{"Temperature":25},"TempUnit":"C"}' );
+	is( $indexed->{current_temp}, 25,
+		'indexed sensor DS18B20-2 selected' );
+
+	# Sensor Id field is tracked
+	$mqtt->simulate_message( 'tele/sensor/SENSOR',
+		'{"DS18B20":{"Id":"01131B123456","Temperature":22.5},'
+		    . '"TempUnit":"C"}' );
+	is( $sensor->{sensor_id}, '01131B123456', 'sensor Id tracked' );
+};
+
+subtest '[MQTT-Sensors §4] humidity sensors' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $sensor = make_sensor( $mqtt, has_humidity => 1 );
+
+	$mqtt->simulate_message( 'tele/sensor/SENSOR',
+		'{"DHT22":{"Temperature":22.5,"Humidity":65},"TempUnit":"C"}'
+	);
+	is( $sensor->{current_temp},     22.5, 'temperature from DHT22' );
+	is( $sensor->{current_humidity}, 65,   'humidity from DHT22' );
+};
+
+subtest '[MQTT-Sensors §5][MQTT-Sensors §5.1] TelePeriod forces telemetry' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+	my $base = OpenHAP::Tasmota::Base->new(
+		aid         => 2,
+		name        => 'Tele',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+	);
+
+	$mqtt->clear_published;
+	$base->force_telemetry;
+	ok( ( grep { $_->{topic} eq 'cmnd/device/TelePeriod' }
+		    $mqtt->get_published ),
+		'TelePeriod command forces a telemetry report' );
+};
+
+done_testing();

--- a/t/conformance/mqtt-state.t
+++ b/t/conformance/mqtt-state.t
@@ -1,0 +1,147 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/MQTT-State.md
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use lib "$RealBin/../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+use_ok('OpenHAP::TestMock::MQTT');
+use_ok('OpenHAP::Tasmota::Heater');
+use_ok('OpenHAP::Tasmota::Lightbulb');
+
+sub make_heater ($mqtt)
+{
+	my $heater = OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'Heater',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+	);
+	$heater->subscribe_mqtt;
+	return $heater;
+}
+
+sub make_light ($mqtt)
+{
+	my $light = OpenHAP::Tasmota::Lightbulb->new(
+		aid          => 2,
+		name         => 'Light',
+		mqtt_topic   => 'light',
+		mqtt_client  => $mqtt,
+		capabilities => OpenHAP::Tasmota::Lightbulb::CAP_DIMMER()
+		    | OpenHAP::Tasmota::Lightbulb::CAP_COLOR()
+		    | OpenHAP::Tasmota::Lightbulb::CAP_CT(),
+	);
+	$light->subscribe_mqtt;
+	return $light;
+}
+
+subtest '[MQTT-State §1] immediate state on stat/' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = make_heater($mqtt);
+
+	ok( ( grep { $_ eq 'stat/device/RESULT' }
+		    $mqtt->get_subscriptions ),
+		'subscribed to stat/+/RESULT' );
+
+	# Plain text POWER response on its own stat topic
+	$mqtt->simulate_message( 'stat/device/POWER', 'ON' );
+	is( $heater->{power_state}, 1, 'plain POWER ON parsed' );
+
+	$mqtt->simulate_message( 'stat/device/POWER', 'OFF' );
+	is( $heater->{power_state}, 0, 'plain POWER OFF parsed' );
+};
+
+subtest '[MQTT-State §2] periodic telemetry on tele/' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = make_heater($mqtt);
+
+	ok( ( grep { $_ eq 'tele/device/STATE' }
+		    $mqtt->get_subscriptions ),
+		'subscribed to tele/+/STATE' );
+};
+
+subtest '[MQTT-State §3] STATE message structure' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = make_heater($mqtt);
+
+	# STATE carries POWER plus device fields
+	$mqtt->simulate_message( 'tele/device/STATE',
+		'{"Time":"2024-01-01T00:00:00","Uptime":"1T00:00:00",'
+		    . '"POWER":"ON","Wifi":{"RSSI":70}}' );
+	is( $heater->{power_state}, 1, 'STATE POWER field parsed' );
+
+	# Lightbulb STATE carries Dimmer/HSBColor/CT
+	my $light = make_light($mqtt);
+	$mqtt->simulate_message( 'tele/light/STATE',
+		'{"POWER":"ON","Dimmer":60,"HSBColor":"90,100,60","CT":400}'
+	);
+	is( $light->{power_state}, 1,  'STATE POWER for light' );
+	is( $light->{brightness},  60, 'STATE Dimmer field parsed' );
+};
+
+subtest '[MQTT-State §4] RESULT message structure' => sub {
+	my $mqtt  = OpenHAP::TestMock::MQTT->new;
+	my $light = make_light($mqtt);
+
+	$mqtt->simulate_message( 'stat/light/RESULT', '{"POWER":"ON"}' );
+	is( $light->{power_state}, 1, 'RESULT POWER parsed' );
+
+	$mqtt->simulate_message( 'stat/light/RESULT', '{"Dimmer":75}' );
+	is( $light->{brightness}, 75, 'RESULT Dimmer parsed' );
+
+	$mqtt->simulate_message( 'stat/light/RESULT',
+		'{"HSBColor":"180,50,80"}' );
+	is( $light->{hue},        180, 'RESULT HSBColor hue parsed' );
+	is( $light->{saturation}, 50,  'RESULT HSBColor saturation parsed' );
+	is( $light->{brightness}, 80,  'RESULT HSBColor brightness parsed' );
+
+	$mqtt->simulate_message( 'stat/light/RESULT', '{"CT":250}' );
+	is( $light->{ct}, 250, 'RESULT CT parsed' );
+
+	# Indexed POWER key for multi-relay devices
+	my $relay2 = OpenHAP::Tasmota::Heater->new(
+		aid         => 3,
+		name        => 'Relay 2',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+		relay_index => 2,
+	);
+	$relay2->subscribe_mqtt;
+	$mqtt->simulate_message( 'stat/device/RESULT', '{"POWER2":"ON"}' );
+	is( $relay2->{power_state}, 1, 'RESULT POWER2 routed to relay 2' );
+};
+
+subtest '[MQTT-State §5][MQTT-State §5.1] status command reconciliation' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = make_heater($mqtt);
+
+	# Status 11 responses reconcile the device state
+	$mqtt->simulate_message( 'stat/device/STATUS11',
+		'{"StatusSTS":{"POWER":"ON"}}' );
+	is( $heater->{power_state}, 1,
+		'STATUS11 reconciles power state' );
+};
+
+subtest '[MQTT-State §5.2] reconnection strategy' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = make_heater($mqtt);
+
+	# On LWT Online, subscriptions exist and the state is re-queried
+	$mqtt->clear_published;
+	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );
+	ok(
+		( grep {
+			$_->{topic} eq 'cmnd/device/Status'
+			    && $_->{payload} eq '11'
+		} $mqtt->get_published ),
+		'Status 11 queried when device comes online'
+	);
+};
+
+done_testing();

--- a/t/conformance/mqtt-transport.t
+++ b/t/conformance/mqtt-transport.t
@@ -1,0 +1,216 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Conformance tests for spec/MQTT-Transport.md
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use lib "$RealBin/../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+use_ok('OpenHAP::TestMock::MQTT');
+use_ok('OpenHAP::Tasmota::Base');
+use_ok('OpenHAP::Tasmota::Heater');
+use_ok('OpenHAP::Tasmota::Lightbulb');
+
+use constant AVAILABILITY_ONLINE  => 1;
+use constant AVAILABILITY_OFFLINE => 2;
+
+sub make_base ( $mqtt, %extra )
+{
+	return OpenHAP::Tasmota::Base->new(
+		aid         => 2,
+		name        => 'Transport Test',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+		%extra,
+	);
+}
+
+subtest '[MQTT-Transport §1][MQTT-Transport §1.1] topic prefixes' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+	my $base = make_base($mqtt);
+	$base->subscribe_mqtt;
+
+	my @subs = $mqtt->get_subscriptions;
+	ok( ( grep {m{^tele/}} @subs ), 'subscribes under tele/ prefix' );
+	ok( ( grep {m{^stat/}} @subs ), 'subscribes under stat/ prefix' );
+	ok( !( grep {m{^cmnd/}} @subs ),
+		'does not subscribe to cmnd/ (device-inbound prefix)' );
+
+	$mqtt->clear_published;
+	$base->force_telemetry;
+	my @published = $mqtt->get_published;
+	ok( ( grep { $_->{topic} =~ m{^cmnd/} } @published ),
+		'commands published under cmnd/ prefix' );
+};
+
+subtest '[MQTT-Transport §1.2] FullTopic pattern' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+
+	# Default pattern: %prefix%/%topic%/
+	my $default = make_base($mqtt);
+	is( $default->_build_topic( 'cmnd', 'Power' ),
+		'cmnd/device/Power', 'default FullTopic %prefix%/%topic%/' );
+
+	# Custom pattern: %topic% before %prefix%
+	my $custom = make_base( $mqtt,
+		fulltopic => 'tasmota/%topic%/%prefix%/' );
+	is( $custom->_build_topic( 'cmnd', 'Power' ),
+		'tasmota/device/cmnd/Power',
+		'custom FullTopic reorders tokens' );
+	is( $custom->_build_topic( 'stat', 'RESULT' ),
+		'tasmota/device/stat/RESULT', 'custom stat topic' );
+	is( $custom->_build_topic( 'tele', 'STATE' ),
+		'tasmota/device/tele/STATE', 'custom tele topic' );
+};
+
+subtest '[MQTT-Transport §1.3] topic tokens' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+	my $base = make_base( $mqtt, fulltopic => 'home/%topic%/%prefix%/' );
+
+	# %topic% replaced by device topic, %prefix% by cmnd/stat/tele
+	my $built = $base->_build_topic( 'tele', 'SENSOR' );
+	like( $built, qr{home/device/tele/SENSOR},
+		'%topic% and %prefix% tokens substituted' );
+};
+
+subtest '[MQTT-Transport §1.4] LWT special topic' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+	my $base = make_base($mqtt);
+	$base->subscribe_mqtt;
+
+	ok( ( grep { $_ eq 'tele/device/LWT' } $mqtt->get_subscriptions ),
+		'subscribed to tele/+/LWT' );
+
+	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );
+	is( $base->{availability}, AVAILABILITY_ONLINE,
+		'LWT Online marks device available' );
+	ok( $base->is_online, 'is_online after LWT Online' );
+};
+
+subtest '[MQTT-Transport §2][MQTT-Transport §2.1] command topic and payload' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'Heater',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+	);
+
+	$mqtt->clear_published;
+	$heater->set_power(1);
+	my ($cmd) = $mqtt->get_published;
+	is( $cmd->{topic}, 'cmnd/device/Power',
+		'command sent to cmnd/%topic%/<Command>' );
+	is( $cmd->{payload}, 'ON', 'payload carries the command value' );
+};
+
+subtest '[MQTT-Transport §2.3] query pattern' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+	my $base = make_base($mqtt);
+	$base->subscribe_mqtt;
+
+	# On LWT Online the device state is queried with Status 11
+	$mqtt->clear_published;
+	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );
+	ok(
+		( grep {
+			$_->{topic} eq 'cmnd/device/Status'
+			    && $_->{payload} eq '11'
+		} $mqtt->get_published ),
+		'state queried via cmnd Status 11'
+	);
+};
+
+subtest '[MQTT-Transport §2.4] bidirectional flow' => sub {
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'Heater',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+	);
+	$heater->subscribe_mqtt;
+
+	# Command out on cmnd/, state back in on stat/
+	$mqtt->clear_published;
+	$heater->set_power(1);
+	ok( ( grep { $_->{topic} =~ m{^cmnd/} } $mqtt->get_published ),
+		'HAP write flows out on cmnd/' );
+
+	$mqtt->simulate_message( 'stat/device/RESULT', '{"POWER":"OFF"}' );
+	is( $heater->{power_state}, 0,
+		'[MQTT-Transport §2.2] device state flows back in on stat/' );
+};
+
+subtest '[MQTT-Transport §3][MQTT-Transport §3.1][MQTT-Transport §3.2] MQTT-related SetOptions' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+
+	# SO26: indexed POWER1 even for a single relay
+	my $so26 = OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'SO26 Heater',
+		mqtt_topic  => 'device',
+		mqtt_client => $mqtt,
+		setoption26 => 1,
+	);
+	is( $so26->_get_power_key, 'POWER1',
+		'SetOption26 uses POWER1 for a single relay' );
+	is( $so26->_get_power_topic, 'cmnd/device/Power1',
+		'SetOption26 command topic indexed' );
+
+	# SO4: responses on command-named topics instead of RESULT
+	my $light = OpenHAP::Tasmota::Lightbulb->new(
+		aid          => 3,
+		name         => 'SO4 Light',
+		mqtt_topic   => 'light',
+		mqtt_client  => $mqtt,
+		capabilities => OpenHAP::Tasmota::Lightbulb::CAP_DIMMER()
+		    | OpenHAP::Tasmota::Lightbulb::CAP_COLOR()
+		    | OpenHAP::Tasmota::Lightbulb::CAP_CT(),
+	);
+	$light->subscribe_mqtt;
+	my @subs = $mqtt->get_subscriptions;
+	for my $topic (qw(DIMMER HSBCOLOR CT)) {
+		ok( ( grep { $_ eq "stat/light/$topic" } @subs ),
+			"SetOption4: subscribed to stat/+/$topic" );
+	}
+};
+
+subtest '[MQTT-Transport §4][MQTT-Transport §4.2] LWT Online/Offline handling' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+	my $base = make_base($mqtt);
+	$base->subscribe_mqtt;
+
+	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );
+	is( $base->{availability}, AVAILABILITY_ONLINE,
+		'LWT Online sets availability' );
+
+	$mqtt->simulate_message( 'tele/device/LWT', 'Offline' );
+	is( $base->{availability}, AVAILABILITY_OFFLINE,
+		'LWT Offline sets availability' );
+	ok( !$base->is_online, 'device reported unavailable' );
+};
+
+subtest '[MQTT-Transport §5][MQTT-Transport §5.2] reconnection state refresh' => sub {
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
+	my $base = make_base($mqtt);
+	$base->subscribe_mqtt;
+
+	# After an Offline/Online cycle the state is re-queried
+	$mqtt->simulate_message( 'tele/device/LWT', 'Offline' );
+	$mqtt->clear_published;
+	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );
+	ok(
+		( grep {
+			$_->{topic} eq 'cmnd/device/Status'
+			    && $_->{payload} eq '11'
+		} $mqtt->get_published ),
+		'Status 11 re-queried after reconnect'
+	);
+};
+
+done_testing();

--- a/t/fugulib/log.t
+++ b/t/fugulib/log.t
@@ -19,10 +19,15 @@ use_ok('FuguLib::Log');
 	my $log = FuguLib::Log->new( mode => 'quiet' );
 	ok( defined $log, 'Created quiet logger' );
 
-	# These should not produce output
-	$log->debug('test');
-	$log->info('test');
-	ok( 1, 'Quiet logger produces no output' );
+	# Capture STDERR to prove quiet mode produces no output
+	my $stderr = '';
+	{
+		local *STDERR;
+		open STDERR, '>', \$stderr or die "Cannot capture STDERR: $!";
+		$log->debug('test');
+		$log->info('test');
+	}
+	is( $stderr, '', 'Quiet logger produces no output' );
 }
 
 # Test 3: Level filtering
@@ -49,12 +54,24 @@ use_ok('FuguLib::Log');
 
 # Test 5: Change log level
 {
-	my $log = FuguLib::Log->new( mode => 'quiet', level => 'error' );
-	$log->set_level('debug');
+	my $log = FuguLib::Log->new( mode => 'stderr', level => 'error' );
 
-	# Just verify no errors
-	$log->debug('now visible');
-	ok( 1, 'set_level works' );
+	my $stderr = '';
+	{
+		local *STDERR;
+		open STDERR, '>', \$stderr or die "Cannot capture STDERR: $!";
+		$log->debug('suppressed at error level');
+	}
+	is( $stderr, '', 'debug suppressed before set_level' );
+
+	$log->set_level('debug');
+	$stderr = '';
+	{
+		local *STDERR;
+		open STDERR, '>', \$stderr or die "Cannot capture STDERR: $!";
+		$log->debug('now visible');
+	}
+	like( $stderr, qr/now visible/, 'set_level enables debug output' );
 }
 
 # Test 6: Default values

--- a/t/fugulib/process.t
+++ b/t/fugulib/process.t
@@ -5,10 +5,9 @@ use Test::More;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../lib";
 
-use_ok('FuguLib::Process');
+use File::Temp qw(tempdir);
 
-# Test 1: Module loads
-ok( 1, 'FuguLib::Process loaded' );
+use_ok('FuguLib::Process');
 
 # Test 2: Basic spawn and terminate
 {
@@ -162,11 +161,9 @@ SKIP: {
 }
 
 # Test 13: I/O redirection
-SKIP: {
-	skip 'Requires writable /tmp', 1 unless -w '/tmp';
-
-	my $outfile = "/tmp/fugulib-process-test-$$.txt";
-	unlink $outfile if -f $outfile;
+{
+	my $tmpdir  = tempdir( CLEANUP => 1 );
+	my $outfile = "$tmpdir/fugulib-process-test.txt";
 
 	my $result = FuguLib::Process->spawn_command(
 		cmd         => [ 'echo', 'test output' ],
@@ -179,11 +176,11 @@ SKIP: {
 
 	ok( -f $outfile, 'Output file created' );
 	if ( -f $outfile ) {
-		open my $fh, '<', $outfile;
+		open my $fh, '<', $outfile
+		    or do { fail("Cannot read $outfile: $!"); };
 		my $content = <$fh>;
 		close $fh;
 		like( $content, qr/test output/, 'Output redirected correctly' );
-		unlink $outfile;
 	}
 }
 

--- a/t/lib/OpenHAP/TestMock/MQTT.pm
+++ b/t/lib/OpenHAP/TestMock/MQTT.pm
@@ -1,0 +1,86 @@
+# ex:ts=8 sw=4:
+# $OpenBSD$
+#
+# Copyright (c) 2026 Dick Olsson <hi@ekkis.net>
+#
+# Permission to use, copy, modify, and distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+use v5.36;
+
+# Mock MQTT client for host-side tests. Records subscriptions and
+# publishes, and delivers simulated messages to matching subscription
+# callbacks, including + and # wildcard patterns.
+
+package OpenHAP::TestMock::MQTT;
+
+sub new ($class)
+{
+	bless {
+		subscriptions => {},
+		published     => [],
+		connected     => 1,
+	}, $class;
+}
+
+sub is_connected ($self) { $self->{connected} }
+
+sub subscribe ( $self, $topic, $callback )
+{
+	$self->{subscriptions}{$topic} = $callback;
+}
+
+sub unsubscribe ( $self, $topic )
+{
+	delete $self->{subscriptions}{$topic};
+}
+
+sub publish ( $self, $topic, $payload )
+{
+	push @{ $self->{published} }, { topic => $topic, payload => $payload };
+}
+
+sub get_subscriptions ($self) { keys %{ $self->{subscriptions} } }
+
+sub get_published ($self) { @{ $self->{published} } }
+
+sub clear_published ($self) { $self->{published} = [] }
+
+sub simulate_message ( $self, $topic, $payload )
+{
+	for my $pattern ( keys %{ $self->{subscriptions} } ) {
+		if ( _topic_matches( $pattern, $topic ) ) {
+			$self->{subscriptions}{$pattern}->( $topic, $payload );
+		}
+	}
+}
+
+sub _topic_matches ( $pattern, $topic )
+{
+	return 1 if $pattern eq $topic;
+	return 0 unless $pattern =~ m{[+#]};
+
+	my @pattern_parts = split m{/}, $pattern;
+	my @topic_parts   = split m{/}, $topic;
+
+	for my $i ( 0 .. $#pattern_parts ) {
+		my $p = $pattern_parts[$i];
+		return 1 if $p eq '#';
+		return 0 if $i > $#topic_parts;
+		next     if $p eq '+';
+		return 0 if $p ne $topic_parts[$i];
+	}
+
+	return @topic_parts == @pattern_parts;
+}
+
+1;

--- a/t/openhap/characteristic.t
+++ b/t/openhap/characteristic.t
@@ -129,9 +129,11 @@ use_ok('OpenHAP::Characteristic');
     ok(exists $json->{iid}, 'JSON has iid');
     ok(exists $json->{format}, 'JSON has format');
     ok(exists $json->{perms}, 'JSON has perms');
-    
-    # These may or may not be included depending on implementation
-    ok(1, 'JSON structure validated');
+    is($json->{value}, 21.5, 'JSON value dereferences scalar ref');
+    is($json->{unit}, 'celsius', 'JSON has unit');
+    is($json->{minValue}, -40, 'JSON has minValue');
+    is($json->{maxValue}, 100, 'JSON has maxValue');
+    is($json->{minStep}, 0.1, 'JSON has minStep');
 }
 
 # Test JSON with boolean value

--- a/t/openhap/config.t
+++ b/t/openhap/config.t
@@ -5,11 +5,13 @@ use FindBin qw($RealBin);
 use lib "$RealBin/../lib";
 use FuguLib::Log;
 $OpenHAP::logger = FuguLib::Log->new(mode => 'quiet', ident => 'test');
+use File::Temp qw(tempdir);
 
 use_ok('OpenHAP::Config');
 
 # Create temporary config file
-my $config_file = "/tmp/openhap_test_$$.conf";
+my $temp_dir    = tempdir(CLEANUP => 1);
+my $config_file = "$temp_dir/openhap_test.conf";
 open my $fh, '>', $config_file or die "Cannot create test config: $!";
 print $fh <<'EOF';
 # Test configuration
@@ -44,8 +46,5 @@ is($devices[0]{topic}, 'tasmota_test', 'Device topic correct');
 
 # Test default value
 is($config->get('nonexistent', 'default'), 'default', 'Default value returned');
-
-# Cleanup
-unlink $config_file;
 
 done_testing();

--- a/t/openhap/daemon.t
+++ b/t/openhap/daemon.t
@@ -80,29 +80,30 @@ use File::Temp qw(tempdir);
 	is(ref $txt, 'HASH', 'Returns a hash reference');
 
 	# Verify required HAP fields exist
-	ok(exists $txt->{'c#'}, "Contains 'c#' (config number)");
-	ok(exists $txt->{'ff'}, "Contains 'ff' (feature flags)");
-	ok(exists $txt->{'id'}, "Contains 'id' (device ID)");
-	ok(exists $txt->{'md'}, "Contains 'md' (model name)");
-	ok(exists $txt->{'pv'}, "Contains 'pv' (protocol version)");
-	ok(exists $txt->{'s#'}, "Contains 's#' (state number)");
-	ok(exists $txt->{'sf'}, "Contains 'sf' (status flags)");
-	ok(exists $txt->{'ci'}, "Contains 'ci' (category identifier)");
+	ok(exists $txt->{'c#'}, "[HAP-mDNS §2] contains 'c#' (config number)");
+	ok(exists $txt->{'ff'}, "[HAP-mDNS §2] contains 'ff' (feature flags)");
+	ok(exists $txt->{'id'}, "[HAP-mDNS §2] contains 'id' (device ID)");
+	ok(exists $txt->{'md'}, "[HAP-mDNS §2] contains 'md' (model name)");
+	ok(exists $txt->{'pv'}, "[HAP-mDNS §2] contains 'pv' (protocol version)");
+	ok(exists $txt->{'s#'}, "[HAP-mDNS §2] contains 's#' (state number)");
+	ok(exists $txt->{'sf'}, "[HAP-mDNS §2] contains 'sf' (status flags)");
+	ok(exists $txt->{'ci'}, "[HAP-mDNS §2] contains 'ci' (category identifier)");
 
 	# Verify values
-	is($txt->{'ff'}, 0, 'Feature flags is 0');
-	is($txt->{'pv'}, '1', 'Protocol version is 1');
-	is($txt->{'s#'}, 1, 'State number is 1');
-	is($txt->{'ci'}, 2, 'Category identifier is 2 (bridge)');
-	is($txt->{'md'}, 'Test MDNS Bridge', 'Model name matches HAP name');
+	is($txt->{'ff'}, 0, '[HAP-mDNS §3.2] feature flags is 0');
+	is($txt->{'pv'}, '1', '[HAP-mDNS §3.5] protocol version is 1');
+	is($txt->{'s#'}, 1, '[HAP-mDNS §3.6] state number is 1');
+	is($txt->{'ci'}, 2, '[HAP-mDNS §3.8] category identifier is 2 (bridge)');
+	is($txt->{'md'}, 'Test MDNS Bridge',
+		'[HAP-mDNS §3.4] model name matches HAP name');
 	ok($txt->{'sf'} == 0 || $txt->{'sf'} == 1,
-		'Status flags is 0 (paired) or 1 (unpaired)');
-	# Check device ID format (XX:XX:XX:XX:XX:XX) - MUST be uppercase per HAP spec
+		'[HAP-mDNS §3.7] status flags is 0 (paired) or 1 (unpaired)');
+	# Check device ID format (XX:XX:XX:XX:XX:XX)
 	ok($txt->{'id'} =~ /^[0-9A-F]{2}(:[0-9A-F]{2}){5}$/,
-		'Device ID is in uppercase XX:XX:XX:XX:XX:XX format');
+		'[HAP-mDNS §3.3] device ID is in uppercase XX:XX:XX:XX:XX:XX format');
 	# Verify device ID is specifically uppercase (not lowercase)
 	ok($txt->{'id'} !~ /[a-f]/,
-		'Device ID contains no lowercase hex characters');
+		'[HAP-mDNS §3.3] device ID contains no lowercase hex characters');
 }
 
 # Test 5: Setup hash in mDNS TXT records
@@ -123,10 +124,11 @@ use File::Temp qw(tempdir);
 	my $txt = $hap->get_mdns_txt_records();
 
 	# Verify setup hash exists when setup_id is provided
-	ok(exists $txt->{'sh'}, "Contains 'sh' (setup hash) when setup_id provided");
+	ok(exists $txt->{'sh'},
+		"[HAP-mDNS §3.9] contains 'sh' (setup hash) when setup_id provided");
 	# Setup hash should be 4 bytes base64 encoded = ~6 characters
 	ok(length($txt->{'sh'}) >= 4 && length($txt->{'sh'}) <= 8,
-		'Setup hash has reasonable length for base64-encoded 4 bytes');
+		'[HAP-mDNS §3.9] setup hash length matches base64-encoded 4 bytes');
 }
 
 # Test 6: No setup hash without setup_id
@@ -167,7 +169,8 @@ use File::Temp qw(tempdir);
 
 	# Unpaired state
 	my $txt_unpaired = $hap->get_mdns_txt_records();
-	is($txt_unpaired->{'sf'}, 1, 'Status flag is 1 when unpaired');
+	is($txt_unpaired->{'sf'}, 1,
+		'[HAP-mDNS §3.7] status flag is 1 when unpaired');
 
 	# Add a pairing using Storage directly
 	my $storage = OpenHAP::Storage->new(db_path => $tmpdir);
@@ -176,7 +179,8 @@ use File::Temp qw(tempdir);
 
 	# Check status flag after pairing
 	my $txt_paired = $hap->get_mdns_txt_records();
-	is($txt_paired->{'sf'}, 0, 'Status flag is 0 when paired');
+	is($txt_paired->{'sf'}, 0,
+		'[HAP-mDNS §3.7] status flag is 0 when paired');
 }
 
 done_testing();

--- a/t/openhap/daemon.t
+++ b/t/openhap/daemon.t
@@ -8,7 +8,8 @@ use FuguLib::Log;
 $OpenHAP::logger = FuguLib::Log->new(mode => 'quiet', ident => 'test');
 use File::Temp qw(tempdir);
 
-# Test daemon mode functionality
+# Test daemon mode functionality. mDNS TXT record content is covered by
+# the spec-cited tests in t/conformance/hap-mdns.t.
 
 # Test 1: MQTT connection with timeout
 {
@@ -58,129 +59,6 @@ use File::Temp qw(tempdir);
 	# Should have private resubscribe method
 	ok($hap->can('_mqtt_resubscribe_accessories'),
 	    'HAP has _mqtt_resubscribe_accessories method');
-}
-
-# Test 4: HAP get_mdns_txt_records returns correct structure
-{
-	use OpenHAP::HAP;
-
-	my $tmpdir = tempdir(CLEANUP => 1);
-
-	my $hap = OpenHAP::HAP->new(
-		port         => 51829,
-		pin          => '123-45-678',
-		name         => 'Test MDNS Bridge',
-		storage_path => $tmpdir,
-	);
-
-	my $txt = $hap->get_mdns_txt_records();
-
-	# Verify structure
-	ok(defined $txt, 'get_mdns_txt_records returns defined value');
-	is(ref $txt, 'HASH', 'Returns a hash reference');
-
-	# Verify required HAP fields exist
-	ok(exists $txt->{'c#'}, "[HAP-mDNS §2] contains 'c#' (config number)");
-	ok(exists $txt->{'ff'}, "[HAP-mDNS §2] contains 'ff' (feature flags)");
-	ok(exists $txt->{'id'}, "[HAP-mDNS §2] contains 'id' (device ID)");
-	ok(exists $txt->{'md'}, "[HAP-mDNS §2] contains 'md' (model name)");
-	ok(exists $txt->{'pv'}, "[HAP-mDNS §2] contains 'pv' (protocol version)");
-	ok(exists $txt->{'s#'}, "[HAP-mDNS §2] contains 's#' (state number)");
-	ok(exists $txt->{'sf'}, "[HAP-mDNS §2] contains 'sf' (status flags)");
-	ok(exists $txt->{'ci'}, "[HAP-mDNS §2] contains 'ci' (category identifier)");
-
-	# Verify values
-	is($txt->{'ff'}, 0, '[HAP-mDNS §3.2] feature flags is 0');
-	is($txt->{'pv'}, '1', '[HAP-mDNS §3.5] protocol version is 1');
-	is($txt->{'s#'}, 1, '[HAP-mDNS §3.6] state number is 1');
-	is($txt->{'ci'}, 2, '[HAP-mDNS §3.8] category identifier is 2 (bridge)');
-	is($txt->{'md'}, 'Test MDNS Bridge',
-		'[HAP-mDNS §3.4] model name matches HAP name');
-	ok($txt->{'sf'} == 0 || $txt->{'sf'} == 1,
-		'[HAP-mDNS §3.7] status flags is 0 (paired) or 1 (unpaired)');
-	# Check device ID format (XX:XX:XX:XX:XX:XX)
-	ok($txt->{'id'} =~ /^[0-9A-F]{2}(:[0-9A-F]{2}){5}$/,
-		'[HAP-mDNS §3.3] device ID is in uppercase XX:XX:XX:XX:XX:XX format');
-	# Verify device ID is specifically uppercase (not lowercase)
-	ok($txt->{'id'} !~ /[a-f]/,
-		'[HAP-mDNS §3.3] device ID contains no lowercase hex characters');
-}
-
-# Test 5: Setup hash in mDNS TXT records
-{
-	use OpenHAP::HAP;
-
-	my $tmpdir = tempdir(CLEANUP => 1);
-
-	# Create HAP with setup_id
-	my $hap = OpenHAP::HAP->new(
-		port         => 51831,
-		pin          => '123-45-678',
-		name         => 'Setup Hash Test',
-		storage_path => $tmpdir,
-		setup_id     => 'XYZQ',  # 4-character setup ID
-	);
-
-	my $txt = $hap->get_mdns_txt_records();
-
-	# Verify setup hash exists when setup_id is provided
-	ok(exists $txt->{'sh'},
-		"[HAP-mDNS §3.9] contains 'sh' (setup hash) when setup_id provided");
-	# Setup hash should be 4 bytes base64 encoded = ~6 characters
-	ok(length($txt->{'sh'}) >= 4 && length($txt->{'sh'}) <= 8,
-		'[HAP-mDNS §3.9] setup hash length matches base64-encoded 4 bytes');
-}
-
-# Test 6: No setup hash without setup_id
-{
-	use OpenHAP::HAP;
-
-	my $tmpdir = tempdir(CLEANUP => 1);
-
-	# Create HAP without setup_id
-	my $hap = OpenHAP::HAP->new(
-		port         => 51832,
-		pin          => '123-45-678',
-		name         => 'No Setup ID Test',
-		storage_path => $tmpdir,
-		# no setup_id
-	);
-
-	my $txt = $hap->get_mdns_txt_records();
-
-	# Verify setup hash is NOT present without setup_id
-	ok(!exists $txt->{'sh'} || !defined $txt->{'sh'},
-		"No 'sh' (setup hash) when setup_id not provided");
-}
-
-# Test 7: Status flag changes with pairing state
-{
-	use OpenHAP::HAP;
-	use OpenHAP::Storage;
-
-	my $tmpdir = tempdir(CLEANUP => 1);
-
-	my $hap = OpenHAP::HAP->new(
-		port         => 51830,
-		pin          => '123-45-678',
-		name         => 'Pairing Test',
-		storage_path => $tmpdir,
-	);
-
-	# Unpaired state
-	my $txt_unpaired = $hap->get_mdns_txt_records();
-	is($txt_unpaired->{'sf'}, 1,
-		'[HAP-mDNS §3.7] status flag is 1 when unpaired');
-
-	# Add a pairing using Storage directly
-	my $storage = OpenHAP::Storage->new(db_path => $tmpdir);
-	my $dummy_ltpk = chr(0) x 32;  # 32 zero bytes
-	$storage->save_pairing('test-controller', $dummy_ltpk, 1);
-
-	# Check status flag after pairing
-	my $txt_paired = $hap->get_mdns_txt_records();
-	is($txt_paired->{'sf'}, 0,
-		'[HAP-mDNS §3.7] status flag is 0 when paired');
 }
 
 done_testing();

--- a/t/openhap/device-loading.t
+++ b/t/openhap/device-loading.t
@@ -7,92 +7,198 @@ use lib "$RealBin/../../lib";
 use FuguLib::Log;
 $OpenHAP::logger = FuguLib::Log->new(mode => 'quiet', ident => 'test');
 
-# Test device loading validation and robustness
+# Test device loading through OpenHAP::DeviceLoader with a mock config,
+# mock MQTT client and a recording HAP stand-in.
 
-plan tests => 8;
+use_ok('OpenHAP::DeviceLoader');
 
-# Test 1: Config has get_devices method
+package MockConfig;
+
+sub new ( $class, @devices )
 {
-	use OpenHAP::Config;
-
-	my $config = OpenHAP::Config->new(file => '/nonexistent');
-	ok($config->can('get_devices'), 'Config has get_devices method');
+	bless { devices => \@devices }, $class;
 }
 
-# Test 2: MQTT has is_connected method
-{
-	use OpenHAP::MQTT;
+sub get_devices ($self) { @{ $self->{devices} } }
 
-	my $mqtt = OpenHAP::MQTT->new(host => '127.0.0.1', port => 1883);
-	ok($mqtt->can('is_connected'), 'MQTT has is_connected method');
+package MockMQTT;
+
+sub new ( $class, %args )
+{
+	bless {
+		connected     => $args{connected} // 1,
+		subscriptions => {},
+		published     => [],
+	}, $class;
 }
 
-# Test 3: Device field validation - missing name
+sub is_connected ($self) { $self->{connected} }
+
+sub subscribe ( $self, $topic, $callback )
 {
-	my $device = {
+	$self->{subscriptions}{$topic} = $callback;
+}
+
+sub publish ( $self, $topic, $payload )
+{
+	push @{ $self->{published} }, { topic => $topic, payload => $payload };
+}
+
+package MockHAP;
+
+sub new ($class) { bless { accessories => [] }, $class }
+
+sub add_accessory ( $self, $accessory )
+{
+	push @{ $self->{accessories} }, $accessory;
+}
+
+package main;
+
+# Valid device is loaded and added to the bridge
+{
+	my $config = MockConfig->new( {
+		type    => 'tasmota',
+		subtype => 'thermostat',
+		name    => 'Bedroom Thermostat',
+		topic   => 'tasmota_bedroom',
+		id      => 'TEST001',
+	} );
+	my $mqtt   = MockMQTT->new;
+	my $hap    = MockHAP->new;
+	my $loader = OpenHAP::DeviceLoader->new;
+
+	my $count = $loader->load_devices( $config, $hap, $mqtt );
+	is( $count, 1, 'One device loaded' );
+
+	my @loaded = $loader->get_devices;
+	is( scalar @loaded, 1, 'Loader tracks loaded device' );
+	isa_ok( $loaded[0], 'OpenHAP::Tasmota::Thermostat' );
+	is( $loaded[0]{aid}, 2, 'First device gets AID 2 (bridge is AID 1)' );
+	is( scalar @{ $hap->{accessories} }, 1, 'Accessory added to bridge' );
+	ok( scalar keys %{ $mqtt->{subscriptions} } > 0,
+		'Device subscribed to MQTT topics' );
+}
+
+# Device missing name is rejected
+{
+	my $config = MockConfig->new( {
 		type    => 'tasmota',
 		subtype => 'thermostat',
 		topic   => 'test/topic',
 		id      => 'TEST001',
-	};
+	} );
+	my $loader = OpenHAP::DeviceLoader->new;
 
-	# Should validate name exists
-	ok(!defined $device->{name} || $device->{name} eq '',
-	    'Device without name should be caught');
+	my $count =
+	    $loader->load_devices( $config, MockHAP->new, MockMQTT->new );
+	is( $count, 0, 'Device without name is skipped' );
 }
 
-# Test 4: Device field validation - missing topic
+# Device missing topic is rejected
 {
-	my $device = {
+	my $config = MockConfig->new( {
 		type    => 'tasmota',
 		subtype => 'thermostat',
 		name    => 'Test Device',
 		id      => 'TEST001',
-	};
+	} );
+	my $loader = OpenHAP::DeviceLoader->new;
 
-	ok(!defined $device->{topic} || $device->{topic} eq '',
-	    'Device without topic should be caught');
+	my $count =
+	    $loader->load_devices( $config, MockHAP->new, MockMQTT->new );
+	is( $count, 0, 'Device without topic is skipped' );
 }
 
-# Test 5: Device field validation - missing id (should use topic as fallback)
+# Device missing id falls back to topic as serial
 {
-	my $device = {
+	my $config = MockConfig->new( {
 		type    => 'tasmota',
-		subtype => 'thermostat',
-		name    => 'Test Device',
-		topic   => 'test/topic',
-	};
+		subtype => 'heater',
+		name    => 'Test Heater',
+		topic   => 'test_heater',
+	} );
+	my $loader = OpenHAP::DeviceLoader->new;
 
-	ok(!defined $device->{id} || $device->{id} eq '',
-	    'Device without id should be handled');
+	my $count =
+	    $loader->load_devices( $config, MockHAP->new, MockMQTT->new );
+	is( $count, 1, 'Device without id still loads' );
+
+	my ($device) = $loader->get_devices;
+	is( $device->{serial}, 'test_heater', 'Topic used as serial fallback' );
 }
 
-# Test 6: Device type validation - wrong type
+# Unsupported device type is skipped
 {
-	my $device = {
+	my $config = MockConfig->new( {
 		type    => 'zigbee',
 		subtype => 'sensor',
 		name    => 'Test Device',
 		topic   => 'test/topic',
 		id      => 'TEST001',
-	};
+	} );
+	my $loader = OpenHAP::DeviceLoader->new;
 
-	ok($device->{type} ne 'tasmota' || $device->{subtype} ne 'thermostat',
-	    'Wrong device type should be skipped');
+	my $count =
+	    $loader->load_devices( $config, MockHAP->new, MockMQTT->new );
+	is( $count, 0, 'Unsupported device type is skipped' );
 }
 
-# Test 7: Thermostat module exists and is loadable
+# MQTT subscription deferred when broker not connected
 {
-	eval { require OpenHAP::Tasmota::Thermostat; };
-	ok(!$@, 'Thermostat module loads without error');
+	my $config = MockConfig->new( {
+		type    => 'tasmota',
+		subtype => 'sensor',
+		name    => 'Test Sensor',
+		topic   => 'test_sensor',
+		id      => 'SENS01',
+	} );
+	my $mqtt   = MockMQTT->new( connected => 0 );
+	my $loader = OpenHAP::DeviceLoader->new;
+
+	my $count = $loader->load_devices( $config, MockHAP->new, $mqtt );
+	is( $count, 1, 'Device loads while MQTT disconnected' );
+	is( scalar keys %{ $mqtt->{subscriptions} },
+		0, 'Subscription deferred while disconnected' );
 }
 
-# Test 8: Thermostat has subscribe_mqtt method
+# Mixed configuration: AIDs assigned sequentially, invalid entries skipped
 {
-	use OpenHAP::Tasmota::Thermostat;
+	my $config = MockConfig->new(
+		{
+			type    => 'tasmota',
+			subtype => 'lightbulb',
+			name    => 'Light One',
+			topic   => 'light1',
+			id      => 'L1',
+		},
+		{
+			type    => 'tasmota',
+			subtype => 'unsupported',
+			name    => 'Bogus',
+			topic   => 'bogus',
+			id      => 'B1',
+		},
+		{
+			type    => 'tasmota',
+			subtype => 'sensor',
+			name    => 'Sensor One',
+			topic   => 'sensor1',
+			id      => 'S1',
+		},
+	);
+	my $hap    = MockHAP->new;
+	my $loader = OpenHAP::DeviceLoader->new;
 
-	ok(OpenHAP::Tasmota::Thermostat->can('subscribe_mqtt'),
-	    'Thermostat has subscribe_mqtt method');
+	my $count = $loader->load_devices( $config, $hap, MockMQTT->new );
+	is( $count, 2, 'Two of three devices loaded' );
+
+	my @loaded = $loader->get_devices;
+	isa_ok( $loaded[0], 'OpenHAP::Tasmota::Lightbulb' );
+	isa_ok( $loaded[1], 'OpenHAP::Tasmota::Sensor' );
+	is( $loaded[0]{aid}, 2, 'First device AID 2' );
+	is( $loaded[1]{aid}, 3,
+		'Second device AID 3 (skipped device consumes no AID)' );
 }
 
 done_testing();

--- a/t/openhap/hap.t
+++ b/t/openhap/hap.t
@@ -72,27 +72,7 @@ use_ok('OpenHAP::Pairing');
     like($device_id, qr/^[0-9A-F]{2}(:[0-9A-F]{2}){5}$/, 'Device ID is MAC format');
 }
 
-# Test get_mdns_txt_records()
-{
-    my $temp_dir = tempdir(CLEANUP => 1);
-    my $hap = OpenHAP::HAP->new(
-        port         => 51830,
-        pin          => '123-45-678',
-        storage_path => $temp_dir,
-    );
-
-    my $records = $hap->get_mdns_txt_records();
-    ok(defined $records, 'mDNS records generated');
-    ok(exists $records->{'c#'}, 'c# record exists');
-    ok(exists $records->{'id'}, 'id record exists');
-    ok(exists $records->{'sf'}, 'sf record exists');
-    is($records->{'sf'}, 1, 'sf=1 when not paired');
-
-    # Add pairing and check sf changes
-    $hap->{storage}->save_pairing('test-controller', 'X' x 32, 1);
-    $records = $hap->get_mdns_txt_records();
-    is($records->{'sf'}, 0, 'sf=0 when paired');
-}
+# mDNS TXT record content is covered by t/conformance/hap-mdns.t
 
 # Test event queue initialization ([HAP-HTTP §14] event notifications)
 {

--- a/t/openhap/hap.t
+++ b/t/openhap/hap.t
@@ -112,6 +112,83 @@ use_ok('OpenHAP::Pairing');
     is($stored_ltpk, $new_ltpk, 'New LTPK persisted to storage');
 }
 
+# Test config number tracking ([HAP-mDNS §3.1] c# increments on change)
+{
+    my $temp_dir = tempdir(CLEANUP => 1);
+    my %args = (
+        port         => 51834,
+        pin          => '123-45-678',
+        storage_path => $temp_dir,
+    );
+
+    my $hap = OpenHAP::HAP->new(%args);
+    is($hap->update_config_number, 1,
+        '[HAP-mDNS §3.1] first run keeps c# at 1');
+    is($hap->update_config_number, 1,
+        'unchanged database keeps c# stable');
+
+    # Restart with the same database: c# unchanged
+    my $hap2 = OpenHAP::HAP->new(%args);
+    is($hap2->update_config_number, 1,
+        '[HAP-mDNS §8] c# persisted across restart');
+
+    # Restart with an added accessory: c# increments
+    require OpenHAP::Tasmota::Heater;
+    require OpenHAP::TestMock::MQTT;
+    my $hap3 = OpenHAP::HAP->new(%args);
+    $hap3->add_accessory(
+        OpenHAP::Tasmota::Heater->new(
+            aid         => 2,
+            name        => 'New Heater',
+            mqtt_topic  => 'heater',
+            mqtt_client => OpenHAP::TestMock::MQTT->new,
+        ));
+    is($hap3->update_config_number, 2,
+        '[HAP-mDNS §3.1] c# increments when a device is added');
+    is($hap3->get_mdns_txt_records->{'c#'}, 2, 'TXT c# reflects change');
+}
+
+# Test mDNS re-advertisement on pairing change ([HAP-mDNS §8])
+{
+    package MockMDNS;
+
+    sub new($class) { bless { updates => [] }, $class }
+
+    sub update_txt_records($self, $records)
+    {
+        push @{ $self->{updates} }, $records;
+        return 1;
+    }
+
+    package main;
+
+    my $temp_dir = tempdir(CLEANUP => 1);
+    my $hap = OpenHAP::HAP->new(
+        port         => 51835,
+        pin          => '123-45-678',
+        storage_path => $temp_dir,
+    );
+    my $mdns = MockMDNS->new;
+    $hap->set_mdns($mdns);
+
+    # No change: no re-advertisement
+    $hap->_refresh_mdns;
+    is(scalar @{ $mdns->{updates} }, 0, 'no update without state change');
+
+    # Pairing added: sf flips to 0 and the TXT record is re-advertised
+    $hap->{storage}->save_pairing('controller', 'X' x 32, 1);
+    $hap->_refresh_mdns;
+    is(scalar @{ $mdns->{updates} }, 1,
+        '[HAP-mDNS §8] TXT re-advertised when pairing added');
+    is($mdns->{updates}[0]{sf}, 0, 'advertised sf=0 once paired');
+
+    # Pairing removed: re-advertised again with sf=1
+    $hap->{storage}->remove_all_pairings;
+    $hap->_refresh_mdns;
+    is($mdns->{updates}[1]{sf}, 1,
+        '[HAP-mDNS §8] advertised sf=1 when pairing removed');
+}
+
 # Test IMMEDIATE_EVENT_TYPES constant ([HAP-HTTP §14] event coalescing)
 {
     # Constants are defined in the package, access via method

--- a/t/openhap/hap.t
+++ b/t/openhap/hap.t
@@ -94,7 +94,7 @@ use_ok('OpenHAP::Pairing');
     is($records->{'sf'}, 0, 'sf=0 when paired');
 }
 
-# Test event queue initialization (Finding 10)
+# Test event queue initialization ([HAP-HTTP §14] event notifications)
 {
     my $temp_dir = tempdir(CLEANUP => 1);
     my $hap = OpenHAP::HAP->new(
@@ -103,12 +103,12 @@ use_ok('OpenHAP::Pairing');
         storage_path => $temp_dir,
     );
 
-    ok(exists $hap->{event_queue}, 'Event queue exists');
+    ok(exists $hap->{event_queue}, '[HAP-HTTP §14] event queue exists');
     ok(ref $hap->{event_queue} eq 'HASH', 'Event queue is a hash');
     ok(!defined $hap->{event_flush_scheduled}, 'No flush scheduled initially');
 }
 
-# Test identity regeneration (Finding 8)
+# Test identity regeneration
 {
     my $temp_dir = tempdir(CLEANUP => 1);
     my $hap = OpenHAP::HAP->new(
@@ -132,7 +132,7 @@ use_ok('OpenHAP::Pairing');
     is($stored_ltpk, $new_ltpk, 'New LTPK persisted to storage');
 }
 
-# Test IMMEDIATE_EVENT_TYPES constant (Finding 10)
+# Test IMMEDIATE_EVENT_TYPES constant ([HAP-HTTP §14] event coalescing)
 {
     # Constants are defined in the package, access via method
     my $temp_dir = tempdir(CLEANUP => 1);
@@ -143,7 +143,7 @@ use_ok('OpenHAP::Pairing');
     );
 
     # Test that queue_event method exists (uses the constants internally)
-    ok($hap->can('queue_event'), 'queue_event method exists');
+    ok($hap->can('queue_event'), '[HAP-HTTP §14] queue_event method exists');
     ok($hap->can('flush_events'), 'flush_events method exists');
     ok($hap->can('send_event'), 'send_event method exists');
 }

--- a/t/openhap/integration/CLAUDE.md
+++ b/t/openhap/integration/CLAUDE.md
@@ -47,6 +47,14 @@ $env->teardown;
 done_testing();
 ```
 
+## Paired behavior
+
+Testing anything behind pair-verify (authenticated endpoints, events,
+encrypted framing) goes through `OpenHAP::Test::Controller` (API in
+`lib/OpenHAP/Test/Controller.pod`): complete `pair_setup`/`pair_verify`
+in setup, use `request`/`next_event`, and `remove_pairing` in teardown so
+the shared daemon is never left paired between files.
+
 ## References
 
 - Running and debugging the suite: `integration-tests` skill

--- a/t/openhap/integration/CLAUDE.md
+++ b/t/openhap/integration/CLAUDE.md
@@ -49,21 +49,21 @@ done_testing();
 
 ## Paired behavior
 
-Testing anything behind pair-verify (authenticated endpoints, events,
-encrypted framing) goes through `OpenHAP::Test::Controller` (API in
-`lib/OpenHAP/Test/Controller.pod`): complete `pair_setup`/`pair_verify`
-in setup, use `request`/`next_event`, and `remove_pairing` in teardown so
-the shared daemon is never left paired between files.
+Testing anything behind pair-verify (authenticated endpoints, events, encrypted
+framing) goes through `OpenHAP::Test::Controller` (API in
+`lib/OpenHAP/Test/Controller.pod`): complete `pair_setup`/`pair_verify` in
+setup, use `request`/`next_event`, and `remove_pairing` in teardown so the
+shared daemon is never left paired between files.
 
 ## Ordering and state
 
-- `scripts/integration.sh` runs the files as an explicit ordered list
-  with `environment.t` always first.
-- Files own their pairing lifecycle: call `$env->ensure_unpaired` in
-  setup, pair via the controller if needed, and unpair in teardown. The
-  shared daemon is never left paired between files.
-- `lib/OpenHAP/Test/` and `t/lib/` ship to the VM alongside the tests;
-  `prove` runs with `-It/lib`.
+- `scripts/integration.sh` runs the files as an explicit ordered list with
+  `environment.t` always first.
+- Files own their pairing lifecycle: call `$env->ensure_unpaired` in setup, pair
+  via the controller if needed, and unpair in teardown. The shared daemon is
+  never left paired between files.
+- `lib/OpenHAP/Test/` and `t/lib/` ship to the VM alongside the tests; `prove`
+  runs with `-It/lib`.
 
 ## References
 

--- a/t/openhap/integration/CLAUDE.md
+++ b/t/openhap/integration/CLAUDE.md
@@ -55,6 +55,16 @@ encrypted framing) goes through `OpenHAP::Test::Controller` (API in
 in setup, use `request`/`next_event`, and `remove_pairing` in teardown so
 the shared daemon is never left paired between files.
 
+## Ordering and state
+
+- `scripts/integration.sh` runs the files as an explicit ordered list
+  with `environment.t` always first.
+- Files own their pairing lifecycle: call `$env->ensure_unpaired` in
+  setup, pair via the controller if needed, and unpair in teardown. The
+  shared daemon is never left paired between files.
+- `lib/OpenHAP/Test/` and `t/lib/` ship to the VM alongside the tests;
+  `prove` runs with `-It/lib`.
+
 ## References
 
 - Running and debugging the suite: `integration-tests` skill

--- a/t/openhap/integration/accessories.t
+++ b/t/openhap/integration/accessories.t
@@ -1,14 +1,13 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Integration test: Accessory and characteristic management
+# Integration test: Accessory endpoints gate on pairing state
 
 use v5.36;
-use Test::More tests => 10;
+use Test::More tests => 8;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../../lib";
 
 use OpenHAP::Test::Integration;
-use JSON::PP qw(decode_json);
 
 my $env = OpenHAP::Test::Integration->new;
 $env->setup;
@@ -26,87 +25,47 @@ my @device_topics = $env->get_device_topics;
 is($config_count // 0, scalar @device_topics,
    'device count matches configuration');
 
-# Test 3: /accessories endpoint structure (may be 470 if unpaired)
+# The daemon starts unpaired (integration files own their pairing
+# lifecycle), so the data-plane endpoints must be gated with HTTP 470.
+# Paired access is covered by t/openhap/integration/characteristics.t.
+
+# Test 3: GET /accessories requires pairing
 my $response = $env->http_request('GET', '/accessories');
-my ($status, $headers, $body) = 
-	OpenHAP::Test::Integration::parse_http_response($response);
+my ($status) = OpenHAP::Test::Integration::parse_http_response($response);
+is($status, 470,
+   '[HAP-HTTP §7] GET /accessories returns 470 when unpaired');
 
-if ($status == 200) {
-	# Verify JSON structure
-	my $accessories;
-	eval { $accessories = decode_json($body); };
-	ok(!$@ && ref $accessories eq 'HASH' && exists $accessories->{accessories},
-	   '/accessories returns valid HAP JSON');
-} else {
-	ok($status == 470, '/accessories requires pairing (status 470)');
-}
-
-# Test 4: Bridge accessory exists (AID 1)
-if ($status == 200) {
-	my $accessories = eval { decode_json($body); };
-	my $has_bridge = 0;
-	if (ref $accessories->{accessories} eq 'ARRAY') {
-		for my $acc (@{$accessories->{accessories}}) {
-			$has_bridge = 1 if $acc->{aid} == 1;
-		}
-	}
-	ok($has_bridge, 'bridge accessory (AID=1) exists');
-} else {
-	ok(1, 'bridge accessory test requires pairing');
-}
-
-# Test 5: Configured devices have accessory IDs
-if ($status == 200 && @device_topics) {
-	my $accessories = eval { decode_json($body); };
-	my $device_count_in_json = 0;
-	if (ref $accessories->{accessories} eq 'ARRAY') {
-		$device_count_in_json = grep { $_->{aid} > 1 } 
-			@{$accessories->{accessories}};
-	}
-	is($device_count_in_json, scalar @device_topics,
-	   'all devices have accessory IDs');
-} else {
-	ok(1, 'device accessory test requires pairing');
-}
-
-# Test 6: /characteristics endpoint responds
+# Test 4: GET /characteristics requires pairing
 $response = $env->http_request('GET', '/characteristics?id=1.10,1.20');
 ($status) = OpenHAP::Test::Integration::parse_http_response($response);
-ok($status == 470 || $status == 200 || $status == 404,
-   '/characteristics endpoint responds');
+is($status, 470,
+   '[HAP-HTTP §8] GET /characteristics returns 470 when unpaired');
 
-# Test 7: Characteristic format is valid (if paired)
-if ($status == 200) {
-	(undef, undef, $body) = 
-		OpenHAP::Test::Integration::parse_http_response($response);
-	my $chars = eval { decode_json($body); };
-	ok(!$@ && ref $chars eq 'HASH',
-	   'characteristics return valid JSON');
-} else {
-	ok(1, 'characteristic test requires pairing');
-}
-
-# Test 8: Multiple characteristic queries work
+# Test 5: Repeated characteristic queries stay gated and responsive
 my $multiple_ok = 1;
 for my $aid (1..3) {
 	$response = $env->http_request('GET', "/characteristics?id=$aid.10");
 	($status) = OpenHAP::Test::Integration::parse_http_response($response);
-	$multiple_ok = 0 unless defined $status;
+	$multiple_ok = 0 unless defined $status && $status == 470;
 }
-ok($multiple_ok, 'multiple characteristic queries work');
+ok($multiple_ok, 'repeated unpaired characteristic queries return 470');
 
-# Test 9: PUT to characteristics is processed
+# Test 6: PUT to characteristics requires pairing
 $response = $env->http_request('PUT', '/characteristics',
 	'{"characteristics":[{"aid":1,"iid":10,"value":1}]}',
 	{'Content-Type' => 'application/hap+json'});
 ($status) = OpenHAP::Test::Integration::parse_http_response($response);
-ok($status == 470 || $status == 204 || $status == 400,
-   'PUT to characteristics processed');
+is($status, 470,
+   '[HAP-HTTP §9] PUT /characteristics returns 470 when unpaired');
 
-# Test 10: Invalid characteristic request handled
+# Test 7: Invalid characteristic id is still gated when unpaired
 $response = $env->http_request('GET', '/characteristics?id=999.999');
 ($status) = OpenHAP::Test::Integration::parse_http_response($response);
-ok($status == 470 || $status == 404 || $status == 400,
-   'invalid characteristic request handled');
+is($status, 470,
+   'invalid characteristic request returns 470 when unpaired');
+
+# Test 8: Daemon responsive after gated requests
+$response = $env->http_request('GET', '/accessories');
+ok(defined $response, 'daemon responsive after gated requests');
 
 $env->teardown;

--- a/t/openhap/integration/characteristics.t
+++ b/t/openhap/integration/characteristics.t
@@ -1,0 +1,110 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Integration test: authenticated accessory data plane over a paired,
+# encrypted session.
+
+use v5.36;
+use Test::More tests => 16;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../../lib";
+
+use OpenHAP::Test::Integration;
+use JSON::PP qw(decode_json encode_json);
+
+my $env = OpenHAP::Test::Integration->new;
+$env->setup;
+$env->ensure_unpaired or die "Cannot reset pairing state\n";
+
+my $controller = $env->get_controller;
+$controller->pair_setup
+    or die 'pair-setup failed: ' . ( $controller->last_error // '?' ) . "\n";
+$controller->pair_verify
+    or die 'pair-verify failed: ' . ( $controller->last_error // '?' ) . "\n";
+
+# Test 1: Paired GET /accessories returns the accessory database
+my $result = $controller->request('GET', '/accessories');
+is($result->{status}, 200, '[HAP-HTTP §7] paired GET /accessories is 200');
+
+my $database = decode_json($result->{body});
+ok(ref $database->{accessories} eq 'ARRAY',
+   '[HAP-HTTP §7] accessories array present');
+
+# Test 2: Bridge accessory has aid 1
+my ($bridge) = grep { $_->{aid} == 1 } @{ $database->{accessories} };
+ok($bridge, '[HAP §3.1] bridge accessory has aid 1');
+
+# Test 3: All configured devices appear with aid > 1
+my @device_topics = $env->get_device_topics;
+my @bridged = grep { $_->{aid} > 1 } @{ $database->{accessories} };
+is(scalar @bridged, scalar @device_topics,
+   'all configured devices have accessory objects');
+
+# Find a readable/writable bool characteristic (On, type 25)
+my ($aid, $iid);
+OUTER: for my $accessory (@bridged) {
+	for my $service (@{ $accessory->{services} }) {
+		for my $char (@{ $service->{characteristics} }) {
+			if ($char->{type} eq '25') {
+				($aid, $iid) = ($accessory->{aid}, $char->{iid});
+				last OUTER;
+			}
+		}
+	}
+}
+ok(defined $iid, 'found an On characteristic to exercise') or do {
+	$env->teardown;
+	die "No On characteristic found in the accessory database\n";
+};
+
+# Test 4: GET /characteristics with real values
+$result = $controller->request('GET', "/characteristics?id=$aid.$iid");
+is($result->{status}, 200,
+   '[HAP-HTTP §8] paired characteristic read returns 200');
+my $read = decode_json($result->{body});
+is($read->{characteristics}[0]{aid}, $aid, 'response aid matches');
+ok(exists $read->{characteristics}[0]{value}, 'value present');
+
+# Test 5: PUT /characteristics succeeds with 204
+$result = $controller->request('PUT', '/characteristics',
+	encode_json({ characteristics =>
+		[ { aid => $aid, iid => $iid, value => \1 } ] }),
+	{ 'Content-Type' => 'application/hap+json' });
+is($result->{status}, 204,
+   '[HAP-HTTP §9] successful write returns 204 No Content');
+
+# Test 6: The written value reads back
+$result = $controller->request('GET', "/characteristics?id=$aid.$iid");
+like($result->{body}, qr/"value"\s*:\s*true/,
+   '[HAP-HTTP §8] written value reads back as true');
+
+# Test 7: Invalid iid yields 207 with HAP status -70409
+$result = $controller->request('GET', '/characteristics?id=999.999');
+is($result->{status}, 207,
+   '[HAP-HTTP §9] invalid id returns 207 Multi-Status');
+is(decode_json($result->{body})->{characteristics}[0]{status}, -70409,
+   '[HAP-HTTP §12] invalid iid has HAP status -70409');
+
+# Test 8: Timed write via /prepare with a pid
+$result = $controller->request('PUT', '/prepare',
+	encode_json({ ttl => 2500, pid => 424242 }),
+	{ 'Content-Type' => 'application/hap+json' });
+is($result->{status}, 200, '[HAP-HTTP §10] /prepare accepted');
+is(decode_json($result->{body})->{status}, 0, '/prepare status 0');
+
+# Test 9: Mixed write is answered with 207 and per-item status
+$result = $controller->request('PUT', '/characteristics',
+	encode_json({ characteristics => [
+		{ aid => $aid, iid => $iid,  value => \0 },
+		{ aid => $aid, iid => 9999, value => \0 },
+	] }),
+	{ 'Content-Type' => 'application/hap+json' });
+is($result->{status}, 207,
+   '[HAP-HTTP §9] partial failure returns 207');
+my @statuses =
+    map { $_->{status} } @{ decode_json($result->{body})->{characteristics} };
+is_deeply([ sort { $a <=> $b } @statuses ], [ -70409, 0 ],
+   'per-item status codes reported');
+
+# Teardown: unpair so the next file starts clean
+$controller->remove_pairing;
+$env->teardown;

--- a/t/openhap/integration/configuration.t
+++ b/t/openhap/integration/configuration.t
@@ -3,11 +3,12 @@
 # Integration test: Configuration loading and validation
 
 use v5.36;
-use Test::More tests => 11;
+use Test::More tests => 10;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../../lib";
 
 use OpenHAP::Test::Integration;
+use Time::HiRes qw(sleep);
 
 my $env = OpenHAP::Test::Integration->new;
 $env->setup;
@@ -40,27 +41,18 @@ ok(defined $hap_port, 'configuration has hap_port');
 ok($hap_port =~ /^\d+$/ && $hap_port >= 1024 && $hap_port <= 65535,
    'hap_port is valid');
 
-# Test 7: Device configuration can be parsed
+# Test 7: Device count reported by hapctl matches parsed configuration
+my ($reported_count) = $check_output =~ /Configured devices:\s*(\d+)/;
 my @device_topics = $env->get_device_topics;
-ok(1, 'device configuration parsed');
+is($reported_count, scalar @device_topics,
+   'hapctl device count matches parsed device topics');
 
-# Test 8: Invalid configuration handling
-my $temp_config = "/tmp/openhapd-invalid-$$.conf";
-open my $tmp, '>', $temp_config or die "Cannot create temp config";
-print $tmp "invalid_syntax_no_equals\n";
-close $tmp;
-
-my $invalid_result = system("openhapd -n -c $temp_config 2>/dev/null");
-unlink $temp_config;
-# Config parser may be lenient, so just verify command runs
-ok(1, 'invalid configuration handling tested');
-
-# Test 9: Daemon still running
+# Test 8: Daemon still running
 sleep 0.5;
 my $running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
 ok($running, 'daemon still running');
 
-# Test 11: Can restart daemon (reload may not be supported)
+# Test 9: Can restart daemon (reload may not be supported)
 system('rcctl restart openhapd >/dev/null 2>&1');
 sleep 1;
 $running = system('rcctl check openhapd >/dev/null 2>&1') == 0;

--- a/t/openhap/integration/events.t
+++ b/t/openhap/integration/events.t
@@ -1,0 +1,88 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Integration test: EVENT/1.0 notifications over paired sessions.
+
+use v5.36;
+use Test::More tests => 8;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../../lib";
+
+use OpenHAP::Test::Integration;
+use JSON::PP qw(decode_json encode_json);
+
+my $env = OpenHAP::Test::Integration->new;
+$env->setup;
+$env->ensure_unpaired or die "Cannot reset pairing state\n";
+
+# Subscriber controller: pairs, verifies, subscribes
+my $subscriber = $env->get_controller;
+$subscriber->pair_setup
+    or die 'pair-setup failed: ' . ( $subscriber->last_error // '?' ) . "\n";
+$subscriber->pair_verify
+    or die 'pair-verify failed: ' . ( $subscriber->last_error // '?' ) . "\n";
+
+# Locate an event-capable writable characteristic (On, type 25)
+my $result   = $subscriber->request('GET', '/accessories');
+my $database = decode_json($result->{body});
+my ($aid, $iid);
+OUTER: for my $accessory (@{ $database->{accessories} }) {
+	next unless $accessory->{aid} > 1;
+	for my $service (@{ $accessory->{services} }) {
+		for my $char (@{ $service->{characteristics} }) {
+			my $perms = $char->{perms} // [];
+			if ($char->{type} eq '25'
+				&& grep { $_ eq 'ev' } @$perms) {
+				($aid, $iid) = ($accessory->{aid}, $char->{iid});
+				last OUTER;
+			}
+		}
+	}
+}
+ok(defined $iid, 'found an event-capable On characteristic') or do {
+	$env->teardown;
+	die "No event-capable characteristic found\n";
+};
+
+# Test 1: Subscribe with ev:true
+$result = $subscriber->request('PUT', '/characteristics',
+	encode_json({ characteristics =>
+		[ { aid => $aid, iid => $iid, ev => \1 } ] }),
+	{ 'Content-Type' => 'application/hap+json' });
+is($result->{status}, 204, '[HAP-HTTP §14] subscription accepted');
+
+# Second controller on its own connection: added as a pairing by the
+# admin, then verified; it does NOT subscribe
+my $bystander = $env->get_controller(controller_id => 'bystander-ctrl');
+$subscriber->add_pairing('bystander-ctrl', $bystander->{ltpk}, 1)
+    or die 'add_pairing failed: ' . ( $subscriber->last_error // '?' ) . "\n";
+$bystander->{accessory_ltpk} = $subscriber->{accessory_ltpk};
+ok($bystander->pair_verify, 'second controller verifies its own session')
+    or diag('pair_verify error: ' . ($bystander->last_error // 'none'));
+
+# Test 2: A write from the second controller triggers an event to the
+# subscriber with the new value
+$result = $bystander->request('PUT', '/characteristics',
+	encode_json({ characteristics =>
+		[ { aid => $aid, iid => $iid, value => \1 } ] }),
+	{ 'Content-Type' => 'application/hap+json' });
+is($result->{status}, 204, 'value changed from the second connection');
+
+my $event = $subscriber->next_event(5);
+ok(defined $event, '[HAP-HTTP §14] EVENT/1.0 message received');
+is($event->{headers}{'content-type'}, 'application/hap+json',
+   '[HAP-HTTP §14] event content type');
+my $payload = decode_json($event->{body});
+my ($change) = grep { $_->{aid} == $aid && $_->{iid} == $iid }
+    @{ $payload->{characteristics} };
+ok($change, '[HAP-HTTP §14] event carries the changed characteristic');
+
+# Test 3: Subscriptions are per-connection - the unsubscribed
+# controller receives nothing
+my $stray = $bystander->next_event(2);
+ok(!defined $stray,
+   '[HAP-HTTP §14] unsubscribed connection receives no events');
+
+# Teardown: unpair everything so the next file starts clean
+$subscriber->remove_pairing('bystander-ctrl');
+$subscriber->remove_pairing;
+$env->teardown;

--- a/t/openhap/integration/hapctl.t
+++ b/t/openhap/integration/hapctl.t
@@ -66,11 +66,11 @@ my $unknown_output = `$hapctl unknown_command_xyz 2>&1`;
 my $unknown_rejected = $? != 0 || $unknown_output =~ /(Unknown|invalid)/i;
 ok($unknown_rejected, 'unknown commands rejected');
 
-# Test 12: hapctl handles missing config file
-my $invalid_config = '/nonexistent/openhapd-test-$$.conf';
-my $invalid_output = `$hapctl -c $invalid_config status 2>&1`;
-# May handle gracefully or error - both OK, just shouldn't crash
-ok(1, 'handles missing config file');
+# Test 12: hapctl survives a missing config file without crashing
+my $invalid_config = "/nonexistent/openhapd-test-$$.conf";
+my $invalid_exit = system("$hapctl -c $invalid_config status >/dev/null 2>&1");
+ok($invalid_exit != -1 && ($invalid_exit & 127) == 0,
+   'missing config file does not crash hapctl (no signal, command ran)');
 
 # Test 13: Multiple hapctl invocations work
 my $multi_ok = 1;
@@ -87,20 +87,16 @@ system("$hapctl -c $config_file devices >/dev/null 2>&1");
 my $after = system('rcctl check openhapd >/dev/null 2>&1');
 is($before, $after, 'hapctl doesn\'t interfere with daemon');
 
-# Test 15: hapctl check detects invalid configuration
-my $temp_config = "/tmp/openhapd-bad-$$.conf";
-if (open my $tmp, '>', $temp_config) {
-	print $tmp "hap_name = \n";  # Invalid: missing value
-	print $tmp "invalid_key = value\n";
-	close $tmp;
-	
-	my $bad_result = system("$hapctl -c $temp_config check 2>/dev/null");
-	unlink $temp_config;
-	
-	# Should fail or warn about invalid config
-	ok($bad_result != 0 || 1, 'detects invalid configuration');
-} else {
-	fail('could not create temp config');
-}
+# Test 15: hapctl check reports zero devices for an empty configuration
+my $temp_config = "/tmp/openhapd-empty-$$.conf";
+open my $tmp, '>', $temp_config
+    or die "Cannot create temp config: $!\n";
+print $tmp "hap_name = \"Empty Bridge\"\n";
+close $tmp;
+
+my $empty_output = `$hapctl -c $temp_config check 2>&1`;
+unlink $temp_config;
+like($empty_output, qr/Configured devices:\s*0/,
+   'check reports zero devices for device-less configuration');
 
 $env->teardown;

--- a/t/openhap/integration/mdns-cleanup.t
+++ b/t/openhap/integration/mdns-cleanup.t
@@ -13,6 +13,19 @@ use Time::HiRes qw(sleep);
 my $env = OpenHAP::Test::Integration->new;
 $env->setup;
 
+# mdnsd must be running for openhapd to spawn mdnsctl publishers
+unless (system('rcctl check mdnsd >/dev/null 2>&1') == 0) {
+	system('rcctl enable mdnsd >/dev/null 2>&1');
+	system('rcctl start mdnsd >/dev/null 2>&1');
+	sleep 1;
+}
+die "mdnsd required for mDNS cleanup tests\n"
+    unless system('rcctl check mdnsd >/dev/null 2>&1') == 0;
+
+# Restart openhapd so it registers with the running mdnsd
+system('rcctl restart openhapd >/dev/null 2>&1');
+sleep 2;
+
 # Test 1: Daemon is running initially
 my $running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
 ok($running, 'daemon is running');
@@ -20,41 +33,33 @@ ok($running, 'daemon is running');
 # Test 2: mdnsctl process exists while daemon is running
 sleep 1;    # Allow mdnsctl to start
 my $mdnsctl_count = count_mdnsctl_processes();
+ok($mdnsctl_count > 0,
+   "mdnsctl process running while daemon active ($mdnsctl_count found)");
 
-# Skip remaining tests if mdnsctl is not running (mdnsd may not be available)
-SKIP: {
-	unless ($mdnsctl_count > 0) {
-		ok(1, 'mdnsctl processes not found (mdnsd may not be available)');
-		skip 'mdnsd/mdnsctl not available, skipping cleanup tests', 4;
+# Test 3: Note the mdnsctl PID(s) for later comparison
+my @initial_pids = get_mdnsctl_pids();
+ok(@initial_pids > 0, 'captured mdnsctl PID(s)');
+
+# Test 4: Stop the daemon
+system('rcctl stop openhapd >/dev/null 2>&1');
+sleep 2;    # Allow cleanup to complete
+
+my $stopped = system('rcctl check openhapd >/dev/null 2>&1') != 0;
+ok($stopped, 'daemon stopped successfully');
+
+# Test 5: mdnsctl process should be terminated
+$mdnsctl_count = count_mdnsctl_processes();
+is($mdnsctl_count, 0, 'mdnsctl process terminated after daemon stop');
+
+# Test 6: Verify the specific PIDs are gone
+my $orphans_remaining = 0;
+for my $pid (@initial_pids) {
+	if (kill(0, $pid)) {
+		$orphans_remaining++;
 	}
-
-	ok($mdnsctl_count > 0, "mdnsctl process running while daemon active ($mdnsctl_count found)");
-
-	# Test 3: Note the mdnsctl PID(s) for later comparison
-	my @initial_pids = get_mdnsctl_pids();
-	ok(@initial_pids > 0, 'captured mdnsctl PID(s)');
-
-	# Test 4: Stop the daemon
-	system('rcctl stop openhapd >/dev/null 2>&1');
-	sleep 2;    # Allow cleanup to complete
-
-	my $stopped = system('rcctl check openhapd >/dev/null 2>&1') != 0;
-	ok($stopped, 'daemon stopped successfully');
-
-	# Test 5: mdnsctl process should be terminated
-	# The key test: after daemon stops, mdnsctl should not be running
-	$mdnsctl_count = count_mdnsctl_processes();
-	is($mdnsctl_count, 0, 'mdnsctl process terminated after daemon stop');
-
-	# Test 6: Verify the specific PIDs are gone
-	my $orphans_remaining = 0;
-	for my $pid (@initial_pids) {
-		if (kill(0, $pid)) {
-			$orphans_remaining++;
-		}
-	}
-	is($orphans_remaining, 0, 'no orphaned mdnsctl processes from initial daemon');
 }
+is($orphans_remaining, 0,
+   'no orphaned mdnsctl processes from initial daemon');
 
 # Restart daemon for other tests
 system('rcctl start openhapd >/dev/null 2>&1');

--- a/t/openhap/integration/mdns.t
+++ b/t/openhap/integration/mdns.t
@@ -3,11 +3,12 @@
 # Integration test: mDNS service advertisement
 
 use v5.36;
-use Test::More tests => 10;
+use Test::More tests => 9;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../../lib";
 
 use OpenHAP::Test::Integration;
+use IO::Socket::INET;
 use Time::HiRes qw(sleep);
 
 my $env = OpenHAP::Test::Integration->new;
@@ -17,81 +18,73 @@ $env->setup;
 my $mdnsctl_available = -x '/usr/sbin/mdnsctl' || -x '/usr/local/bin/mdnsctl';
 ok($mdnsctl_available, 'mdnsctl command available');
 
-SKIP: {
-	skip 'mdnsctl required for mDNS integration tests', 9
-		unless $mdnsctl_available;
+die "mdnsctl required for mDNS integration tests\n" unless $mdnsctl_available;
 
-	# Test 2: OpenHAP daemon is running
-	my $daemon_running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
-	ok($daemon_running, 'OpenHAP daemon is running');
+# Test 2: OpenHAP daemon is running
+my $daemon_running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
+ok($daemon_running, 'OpenHAP daemon is running');
 
-	# Test 3: mdnsd daemon is available
-	my $mdnsd_available = 0;
-
-	# Try to enable and start mdnsd if not running
-	unless (system('rcctl check mdnsd >/dev/null 2>&1') == 0) {
-		system('rcctl enable mdnsd >/dev/null 2>&1');
-		system('rcctl start mdnsd >/dev/null 2>&1');
-		sleep 1;
-	}
-
-	$mdnsd_available = system('rcctl check mdnsd >/dev/null 2>&1') == 0;
-	ok($mdnsd_available, 'mdnsd daemon is running');
-
-	skip 'mdnsd daemon required for mDNS integration tests', 7
-		unless $mdnsd_available;
-
-# Test 4: OpenHAP MDNS module loaded (check logs)
-my @logs = $env->get_log_lines('mDNS|mdns|Starting OpenHAP');
-ok(@logs > 0, 'OpenHAP MDNS-related log entries exist');
-
-# Test 5: HAP service can be browsed
-my $mdns_output = `timeout 3 mdnsctl browse hap tcp 2>&1 || true`;
-my $browse_works = $? == 0 || length($mdns_output) > 0;
-ok($browse_works, 'mdnsctl browse command works');
-
-# Test 6: HAP service is advertised
-sleep 1;  # Give time for registration
-$mdns_output = `timeout 3 mdnsctl browse hap tcp 2>&1 || true`;
-my $hap_found = $mdns_output =~ /hap.*tcp/i;
-ok($hap_found, 'HAP service advertised via mDNS');
-
-# Test 7: Service advertisement includes required fields or is findable
-if ($hap_found) {
-	# Check for HAP service - just verify it's advertised
-	# Required fields (md=, pv=, etc.) may not show in browse output
-	ok($mdns_output =~ /hap/i, 'mDNS service is advertised');
-} else {
-	ok(1, 'cannot verify fields without service');
+# Test 3: mdnsd daemon is running (start it if needed)
+unless (system('rcctl check mdnsd >/dev/null 2>&1') == 0) {
+	system('rcctl enable mdnsd >/dev/null 2>&1');
+	system('rcctl start mdnsd >/dev/null 2>&1');
+	sleep 1;
 }
+my $mdnsd_available = system('rcctl check mdnsd >/dev/null 2>&1') == 0;
+ok($mdnsd_available, 'mdnsd daemon is running');
 
-# Test 8: Daemon restart re-advertises service
+die "mdnsd required for mDNS integration tests\n" unless $mdnsd_available;
+
+# Restart openhapd so it re-registers with the running mdnsd
+system('rcctl restart openhapd >/dev/null 2>&1');
+sleep 2;
+
+# Test 4: mdnsctl browse works
+my $mdns_output = `timeout 5 mdnsctl browse hap tcp 2>&1 || true`;
+ok(length($mdns_output) > 0, 'mdnsctl browse produces output');
+
+# Test 5: HAP service is advertised ([HAP-mDNS §1] _hap._tcp)
+sleep 1;    # Give time for registration
+$mdns_output = `timeout 5 mdnsctl browse hap tcp 2>&1 || true`;
+my $hap_found = $mdns_output =~ /hap.*tcp/i;
+ok($hap_found, '[HAP-mDNS §1] HAP service advertised via mDNS');
+
+# Test 6: Advertised service name matches the configured bridge name
+my $hap_name = $env->get_config_value('hap_name') // 'OpenHAP';
+ok($mdns_output =~ /\Q$hap_name\E/i,
+   '[HAP-mDNS §4] service instance name matches configured name');
+
+# Test 7: Daemon restart re-advertises service
 system('rcctl restart openhapd >/dev/null 2>&1');
 sleep 2;
 
 $daemon_running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
-ok($daemon_running, 'daemon running and mDNS operational after restart');
+ok($daemon_running, 'daemon running after restart');
 
-# Test 9: Device ID format is uppercase (HAP R2 4.5.1 requirement)
-# Get TXT records via lookup or browse
-$mdns_output = `timeout 3 mdnsctl lookup _hap._tcp.local 2>&1 || true`;
-# If we can see TXT records, verify id= field is uppercase
-if ($mdns_output =~ /id=([0-9A-Fa-f:]+)/) {
-	my $device_id = $1;
-	my $is_uppercase = $device_id !~ /[a-f]/;  # No lowercase hex
-	ok($is_uppercase, 'device ID in mDNS is uppercase');
+# Test 8: Service still browsable after restart ([HAP-mDNS §8])
+$mdns_output = `timeout 5 mdnsctl browse hap tcp 2>&1 || true`;
+ok($mdns_output =~ /hap.*tcp/i,
+   '[HAP-mDNS §8] service re-advertised after daemon restart');
+
+# Test 9: Port advertised by daemon matches configuration
+my $hap_port = $env->get_config_value('hap_port')
+    // OpenHAP::Test::Integration::DEFAULT_HAP_PORT;
+my $lookup_output =
+    `timeout 5 mdnsctl browse hap tcp 2>&1 || true`;
+if ($lookup_output =~ /(\d{4,5})/) {
+	ok($lookup_output =~ /\b\Q$hap_port\E\b/,
+	   '[HAP-mDNS §6] advertised port matches configured hap_port');
 } else {
-	# Can't verify without TXT record access, skip test
-	ok(1, 'device ID format verification skipped (no TXT access)');
-}
-
-	# Test 10: Setup hash present if configured (HAP R2 4.5.2 requirement)
-	# This depends on configuration - if setup_id is configured, sh= should be present
-	$mdns_output = `timeout 3 mdnsctl lookup _hap._tcp.local 2>&1 || true`;
-	# Just verify the daemon can provide TXT records at all
-	my $txt_accessible = $mdns_output =~ /pv=|id=|c#=/;
-	ok($txt_accessible || $hap_found,
-	   'mDNS TXT records accessible or service found');
+	# browse output carries no port; verify the daemon listens on it
+	my $listening = IO::Socket::INET->new(
+		PeerAddr => '127.0.0.1',
+		PeerPort => $hap_port,
+		Proto    => 'tcp',
+		Timeout  => 2,
+	);
+	ok(defined $listening,
+	   '[HAP-mDNS §6] daemon listens on the configured HAP port');
+	$listening->close if defined $listening;
 }
 
 $env->teardown;

--- a/t/openhap/integration/mdns.t
+++ b/t/openhap/integration/mdns.t
@@ -3,7 +3,7 @@
 # Integration test: mDNS service advertisement
 
 use v5.36;
-use Test::More tests => 9;
+use Test::More tests => 12;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../../lib";
 
@@ -13,6 +13,7 @@ use Time::HiRes qw(sleep);
 
 my $env = OpenHAP::Test::Integration->new;
 $env->setup;
+$env->ensure_unpaired or die "Cannot reset pairing state\n";
 
 # Test 1: mdnsctl command available
 my $mdnsctl_available = -x '/usr/sbin/mdnsctl' || -x '/usr/local/bin/mdnsctl';
@@ -87,4 +88,36 @@ if ($lookup_output =~ /(\d{4,5})/) {
 	$listening->close if defined $listening;
 }
 
+# browse_txt(): resolved browse output including TXT strings
+sub browse_txt
+{
+	return `timeout 5 mdnsctl browse -r hap tcp 2>&1 || true`;
+}
+
+# Test 10: sf=1 advertised while unpaired
+my $txt_output = browse_txt();
+like($txt_output, qr/sf=1/,
+   '[HAP-mDNS §3.7] sf=1 advertised while unpaired');
+
+# Test 11: after pairing, sf flips to 0 in the browsed TXT record
+my $controller = $env->get_controller;
+$controller->pair_setup
+    or die 'pair-setup failed: ' . ( $controller->last_error // '?' ) . "\n";
+sleep 2;    # allow re-registration to propagate
+
+$txt_output = browse_txt();
+like($txt_output, qr/sf=0/,
+   '[HAP-mDNS §8] sf flips to 0 in the browsed TXT after pairing');
+
+# Test 12: c# persists across a daemon restart
+my ($config_number) = $txt_output =~ /c#=(\d+)/;
+system('rcctl restart openhapd >/dev/null 2>&1');
+sleep 2;
+$txt_output = browse_txt();
+my ($config_number_after) = $txt_output =~ /c#=(\d+)/;
+is($config_number_after, $config_number,
+   '[HAP-mDNS §3.1] c# persisted across daemon restart');
+
+# Teardown: unpair via state wipe (the pairing survived the restart)
+$env->ensure_unpaired or die "Cannot reset pairing state\n";
 $env->teardown;

--- a/t/openhap/integration/mqtt.t
+++ b/t/openhap/integration/mqtt.t
@@ -89,19 +89,17 @@ eval {
 $multiple_ok = 0 if $@;
 ok($multiple_ok, 'multiple MQTT messages handled');
 
-# Test 10: Multiple device topics work
-if (@device_topics > 1) {
-	my $multi_device_ok = 1;
+# Test 10: Publishing works on every configured device topic
+{
+	my $all_topics_ok = 1;
 	eval {
 		for my $t (@device_topics[0..min(2, $#device_topics)]) {
 			$mqtt->publish("stat/$t/POWER", "ON");
 			sleep 0.1;
 		}
 	};
-	$multi_device_ok = 0 if $@;
-	ok($multi_device_ok, 'multiple device topics work');
-} else {
-	ok(1, 'only one device configured (skip multi-device test)');
+	$all_topics_ok = 0 if $@;
+	ok($all_topics_ok, 'all configured device topics accept publishes');
 }
 
 sub min($a, $b) { $a < $b ? $a : $b; }

--- a/t/openhap/integration/pairing.t
+++ b/t/openhap/integration/pairing.t
@@ -39,11 +39,12 @@ ok(length($body) > 0, 'pair-setup M1 returns data');
 # Test 5b: Pair-setup M2 response doesn't contain ASCII '0x' prefix in public key
 # This was a bug where Math::BigInt->as_hex() returned "0x..." which was incorrectly packed
 my $hex = unpack('H*', $body);
-unlike($hex, qr/03..0130783078/, 'M2 public key does not contain ASCII "0x" prefix');
+unlike($hex, qr/03..0130783078/,
+    '[HAP-Pairing §2.4] M2 public key does not contain ASCII "0x" prefix');
 
 # Test 6: Pair-setup responds with proper Content-Type
 ok($response =~ /Content-Type:\s*application\/pairing\+tlv8/i,
-   'pair-setup uses application/pairing+tlv8');
+   '[HAP-HTTP §2] pair-setup uses application/pairing+tlv8');
 
 # Test 7: Pair-verify endpoint available
 $response = $env->http_request('POST', '/pair-verify',
@@ -71,31 +72,32 @@ $response = $env->http_request('GET', '/accessories');
 ($status) = OpenHAP::Test::Integration::parse_http_response($response);
 ok(defined $status, 'daemon responsive after pairing attempts');
 
-# Test 11: Invalid pairing method returns error (Finding 7)
+# Test 11: Invalid pairing method returns error TLV
 $response = $env->http_request('POST', '/pair-setup',
 	"\x06\x01\x01\x00\x01\x63",  # State=M1, Method=0x63 (invalid)
 	{'Content-Type' => 'application/pairing+tlv8'});
 ($status, undef, $body) = OpenHAP::Test::Integration::parse_http_response($response);
 # Response should contain error TLV with kTLVError_Unknown (0x01)
 my $has_error = $body =~ /\x07\x01\x01/;  # Error type (0x07), length 1, value 1
-ok($status == 200 && length($body) > 0, 'invalid method returns error response');
+ok($status == 200 && $has_error,
+   '[HAP-TLV8 §6] invalid method returns kTLVError_Unknown');
 
-# Test 12: /prepare accepts POST method (Finding 9)
+# Test 12: /prepare accepts POST method
 $response = $env->http_request('POST', '/prepare',
 	'{"ttl":10000,"pid":1}',
 	{'Content-Type' => 'application/hap+json'});
 ($status) = OpenHAP::Test::Integration::parse_http_response($response);
-# Should return 470 (unauthorized) since not paired, but endpoint is reachable
-ok($status == 470 || $status == 200, '/prepare accepts POST method');
+# Returns 470 (unauthorized) since not paired, but endpoint is reachable
+is($status, 470, '[HAP-HTTP §10] unpaired /prepare POST returns 470');
 
-# Test 13: /prepare also accepts PUT method (Finding 9 - compatibility)
+# Test 13: /prepare also accepts PUT method (spec shows both)
 $response = $env->http_request('PUT', '/prepare',
 	'{"ttl":10000,"pid":1}',
 	{'Content-Type' => 'application/hap+json'});
 ($status) = OpenHAP::Test::Integration::parse_http_response($response);
-ok($status == 470 || $status == 200, '/prepare accepts PUT method');
+is($status, 470, '[HAP-HTTP §10] unpaired /prepare PUT returns 470');
 
-# Test 14: Concurrent pair-setup from different connections gets Busy (Finding 3)
+# Test 14: Rapid sequential pair-setup attempts are handled
 # Note: This is tricky to test in integration - we test that rapid requests work
 for (1..5) {
 	$response = $env->http_request('POST', '/pair-setup',

--- a/t/openhap/integration/pairing.t
+++ b/t/openhap/integration/pairing.t
@@ -1,110 +1,91 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Integration test: HAP pairing workflow
+# Integration test: complete HAP pairing workflow against the live
+# daemon, driven by OpenHAP::Test::Controller.
 
 use v5.36;
-use Test::More tests => 15;
+use Test::More tests => 18;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../../lib";
 
 use OpenHAP::Test::Integration;
+use OpenHAP::Pairing;
 
 my $env = OpenHAP::Test::Integration->new;
 $env->setup;
+$env->ensure_unpaired or die "Cannot reset pairing state\n";
 
-# Test 1: Pairing data directory exists
+# Test 1: Pairing data directory exists and is readable
 my $storage_dir = '/var/db/openhapd';
-ok(-d $storage_dir, 'pairing storage directory exists');
+ok(-d $storage_dir && -r $storage_dir, 'pairing storage directory exists');
 
-# Test 2: Storage directory is readable
-ok(-r $storage_dir, 'storage directory is readable');
-
-# Test 3: hapctl status shows pairing information
-my $config_file = $env->{config_file};
-my $status_output = `hapctl -c $config_file status 2>&1`;
-my $has_pairing_info = $status_output =~ /(Pairing status|not paired|paired|not initialized|openhapd)/i;
-ok($has_pairing_info, 'hapctl status shows pairing state');
-
-# Test 4: Pair-setup M1: Client sends Start Request
+# Test 2: Pair-setup M1 rejects a stale "0x"-prefixed public key
+# (regression guard: Math::BigInt->as_hex once leaked its 0x prefix)
 my $response = $env->http_request('POST', '/pair-setup',
-	"\x06\x01\x01\x00\x01\x00",  # State=M1 (0x06,0x01,0x01), Method=PairSetup (0x00,0x01,0x00)
+	"\x06\x01\x01\x00\x01\x00",
 	{'Content-Type' => 'application/pairing+tlv8'});
-my ($status) = OpenHAP::Test::Integration::parse_http_response($response);
-ok($status == 200, 'pair-setup M1 accepted');
-
-# Test 5: Pair-setup M1 response contains TLV8 data
-my (undef, undef, $body) = OpenHAP::Test::Integration::parse_http_response($response);
-ok(length($body) > 0, 'pair-setup M1 returns data');
-
-# Test 5b: Pair-setup M2 response doesn't contain ASCII '0x' prefix in public key
-# This was a bug where Math::BigInt->as_hex() returned "0x..." which was incorrectly packed
+my ($status, undef, $body) =
+	OpenHAP::Test::Integration::parse_http_response($response);
+is($status, 200, 'pair-setup M1 accepted');
 my $hex = unpack('H*', $body);
 unlike($hex, qr/03..0130783078/,
     '[HAP-Pairing §2.4] M2 public key does not contain ASCII "0x" prefix');
 
-# Test 6: Pair-setup responds with proper Content-Type
-ok($response =~ /Content-Type:\s*application\/pairing\+tlv8/i,
-   '[HAP-HTTP §2] pair-setup uses application/pairing+tlv8');
+# Restart cleanly so the M1 probe above does not hold the pairing lock
+$env->ensure_daemon_stopped or die "Cannot stop daemon\n";
+$env->ensure_daemon_running or die "Cannot start daemon\n";
 
-# Test 7: Pair-verify endpoint available
-$response = $env->http_request('POST', '/pair-verify',
-	"\x06\x01\x01",  # State=M1
-	{'Content-Type' => 'application/pairing+tlv8'});
-($status) = OpenHAP::Test::Integration::parse_http_response($response);
-ok($status == 200, 'pair-verify endpoint available');
+# Test 3: Full pair-setup with the real PIN
+my $controller = $env->get_controller;
+ok($controller->pair_setup,
+   '[HAP-Pairing §2] full pair-setup M1-M6 with the configured PIN')
+    or diag('pair_setup error: ' . ($controller->last_error // 'none'));
+ok(defined $controller->{accessory_ltpk},
+   '[HAP-Pairing §2.8] accessory LTPK received in M6');
 
-# Test 8: Pair-verify returns TLV8 data
-(undef, undef, $body) = OpenHAP::Test::Integration::parse_http_response($response);
-ok(length($body) > 0, 'pair-verify returns data');
+# Test 4: Pair-verify establishes an encrypted session
+ok($controller->pair_verify,
+   '[HAP-Pairing §3] pair-verify M1-M4 completes')
+    or diag('pair_verify error: ' . ($controller->last_error // 'none'));
+ok($controller->is_encrypted, 'session switched to encrypted framing');
 
-# Test 9: Repeated pair-setup attempts don't crash daemon
-for (1..3) {
-	$response = $env->http_request('POST', '/pair-setup',
-		"\x06\x01\x01\x00\x01\x00",
-		{'Content-Type' => 'application/pairing+tlv8'});
-	($status) = OpenHAP::Test::Integration::parse_http_response($response);
-	last unless $status == 200;
-}
-ok($status == 200, 'repeated pair-setup attempts handled');
+# Test 5: Authenticated endpoint works over the session
+my $result = $controller->request('GET', '/accessories');
+is($result->{status}, 200,
+   '[HAP-HTTP §7] paired GET /accessories returns 200');
 
-# Test 10: Daemon still responsive after pairing attempts
-$response = $env->http_request('GET', '/accessories');
-($status) = OpenHAP::Test::Integration::parse_http_response($response);
-ok(defined $status, 'daemon responsive after pairing attempts');
+# Test 6: Add, list, and remove an additional pairing over the wire
+ok($controller->add_pairing('extra-ctrl', 'X' x 32, 0),
+   '[HAP-Pairing §7.1] add pairing accepted');
+my $pairings = $controller->list_pairings;
+is(scalar @$pairings, 2, '[HAP-Pairing §7.3] both pairings listed');
+ok($controller->remove_pairing('extra-ctrl'),
+   '[HAP-Pairing §7.2] remove pairing accepted');
+$pairings = $controller->list_pairings;
+is(scalar @$pairings, 1, 'extra pairing removed');
 
-# Test 11: Invalid pairing method returns error TLV
-$response = $env->http_request('POST', '/pair-setup',
-	"\x06\x01\x01\x00\x01\x63",  # State=M1, Method=0x63 (invalid)
-	{'Content-Type' => 'application/pairing+tlv8'});
-($status, undef, $body) = OpenHAP::Test::Integration::parse_http_response($response);
-# Response should contain error TLV with kTLVError_Unknown (0x01)
-my $has_error = $body =~ /\x07\x01\x01/;  # Error type (0x07), length 1, value 1
-ok($status == 200 && $has_error,
-   '[HAP-TLV8 §6] invalid method returns kTLVError_Unknown');
+# Test 7: Removing a nonexistent pairing returns success
+ok($controller->remove_pairing('ghost-ctrl'),
+   '[HAP-Pairing §7.4] removing nonexistent pairing succeeds');
 
-# Test 12: /prepare accepts POST method
-$response = $env->http_request('POST', '/prepare',
-	'{"ttl":10000,"pid":1}',
-	{'Content-Type' => 'application/hap+json'});
-($status) = OpenHAP::Test::Integration::parse_http_response($response);
-# Returns 470 (unauthorized) since not paired, but endpoint is reachable
-is($status, 470, '[HAP-HTTP §10] unpaired /prepare POST returns 470');
+# Test 8: Wrong-PIN attempt is rejected and counted after unpairing
+$controller->close;
+$env->ensure_unpaired or die "Cannot reset pairing state\n";
 
-# Test 13: /prepare also accepts PUT method (spec shows both)
-$response = $env->http_request('PUT', '/prepare',
-	'{"ttl":10000,"pid":1}',
-	{'Content-Type' => 'application/hap+json'});
-($status) = OpenHAP::Test::Integration::parse_http_response($response);
-is($status, 470, '[HAP-HTTP §10] unpaired /prepare PUT returns 470');
+my $bad = $env->get_controller(pin => '876-54-321',
+	controller_id => 'bad-ctrl');
+ok(!$bad->pair_setup, 'pair-setup fails with the wrong PIN');
+is($bad->last_error,
+   OpenHAP::Pairing::kTLVError_Authentication(),
+   '[HAP-Pairing §2.6] M4 returns kTLVError_Authentication');
+$bad->close;
 
-# Test 14: Rapid sequential pair-setup attempts are handled
-# Note: This is tricky to test in integration - we test that rapid requests work
-for (1..5) {
-	$response = $env->http_request('POST', '/pair-setup',
-		"\x06\x01\x01\x00\x01\x00",
-		{'Content-Type' => 'application/pairing+tlv8'});
-	($status) = OpenHAP::Test::Integration::parse_http_response($response);
-}
-ok($status == 200, 'rapid pair-setup attempts handled gracefully');
+# Test 9: Re-pair after the failed attempt
+$env->ensure_unpaired or die "Cannot reset pairing state\n";
+my $again = $env->get_controller(controller_id => 're-pair-ctrl');
+ok($again->pair_setup, '[HAP-Pairing §2.4] re-pair succeeds after unpair');
+ok($again->pair_verify, 'pair-verify succeeds on the new pairing');
 
+# Teardown: leave the daemon unpaired for the next test file
+ok($again->remove_pairing, 'unpaired in teardown');
 $env->teardown;

--- a/t/openhap/integration/tasmota-protocol.t
+++ b/t/openhap/integration/tasmota-protocol.t
@@ -1,11 +1,8 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Integration test: Tasmota MQTT message delivery to the daemon's broker
-#
-# Simulated device messages are published on the broker and asserted on an
-# observer subscription. HAP-side effects of these messages (characteristic
-# changes, cmnd/ publishes) require a paired controller and are covered by
-# the paired MQTT round-trip tests.
+# Integration test: MQTT <-> HAP round trips for Tasmota devices. Each
+# simulated device message is published on the real broker and its
+# effect asserted through the paired HAP data plane, and vice versa.
 
 use v5.36;
 use Test::More tests => 11;
@@ -13,142 +10,162 @@ use FindBin qw($RealBin);
 use lib "$RealBin/../../../lib";
 
 use OpenHAP::Test::Integration;
-use Time::HiRes qw(sleep);
+use JSON::PP qw(decode_json encode_json);
+use Time::HiRes qw(sleep time);
 
 my $env = OpenHAP::Test::Integration->new;
 $env->setup;
+$env->ensure_unpaired or die "Cannot reset pairing state\n";
 
-# Test 1: MQTT broker is available
-my $mqtt_ok = $env->ensure_mqtt_running;
-ok( $mqtt_ok, 'MQTT broker is running' );
-
-die "MQTT broker required for protocol compliance tests\n" unless $mqtt_ok;
-
+die "MQTT broker required for protocol tests\n"
+    unless $env->ensure_mqtt_running;
 my $mqtt = $env->get_mqtt;
-ok( defined $mqtt, 'Connected to MQTT broker' );
-
 die "Cannot connect to MQTT broker\n" unless defined $mqtt;
 
-# Get first configured device topic
-my @device_topics = $env->get_device_topics;
-die "No devices configured for testing\n" unless @device_topics;
+my ($light)  = grep { $_->{subtype} eq 'lightbulb' } $env->get_devices;
+my ($sensor) = grep { $_->{subtype} eq 'sensor' } $env->get_devices;
+die "No lightbulb device configured for testing\n" unless $light;
+die "No sensor device configured for testing\n"    unless $sensor;
 
-my $topic = $device_topics[0];
+my $controller = $env->get_controller;
+$controller->pair_setup
+    or die 'pair-setup failed: ' . ( $controller->last_error // '?' ) . "\n";
+$controller->pair_verify
+    or die 'pair-verify failed: ' . ( $controller->last_error // '?' ) . "\n";
 
-# wait_for($flag_ref): tick the connection until the flag is set
-sub wait_for ($flag_ref)
+# Locate accessories by their configured names
+my $result   = $controller->request('GET', '/accessories');
+my $database = decode_json($result->{body});
+
+# find_char($device, $type): (aid, iid) of a characteristic by short
+# type on the accessory whose Name matches the device's config name
+sub find_char ($device, $type)
 {
-	my $start = time;
-	while ( !$$flag_ref && ( time - $start ) < 5 ) {
-		$mqtt->tick(0.2);
+	for my $accessory (@{ $database->{accessories} }) {
+		my $named = 0;
+		for my $service (@{ $accessory->{services} }) {
+			for my $char (@{ $service->{characteristics} }) {
+				$named = 1
+				    if $char->{type} eq '23'
+				    && ($char->{value} // '') eq
+				    $device->{name};
+			}
+		}
+		next unless $named;
+		for my $service (@{ $accessory->{services} }) {
+			for my $char (@{ $service->{characteristics} }) {
+				return ($accessory->{aid}, $char->{iid})
+				    if $char->{type} eq $type;
+			}
+		}
 	}
-	return $$flag_ref;
+	return;
 }
 
-# Test 2: LWT message delivery ([MQTT-Transport §1.4], §4.2)
+# poll_value($aid, $iid, $expected): poll the paired GET endpoint until
+# the value matches (JSON-encoded comparison) or 5 seconds pass
+sub poll_value ($aid, $iid, $expected)
 {
-	my $lwt_received = 0;
-	my $lwt_payload;
-
-	$mqtt->subscribe(
-		"tele/$topic/LWT",
-		sub( $t, $p, $ = undef ) {
-			$lwt_received = 1;
-			$lwt_payload  = $p;
-		} );
-
-	$mqtt->publish( "tele/$topic/LWT", "Online" );
-
-	ok( wait_for( \$lwt_received ),
-		'[MQTT-Transport §1.4] LWT message delivered on tele/+/LWT' );
-	is( $lwt_payload, 'Online',
-		'[MQTT-Transport §4.2] LWT payload is Online' );
+	my $deadline = time + 5;
+	my $seen;
+	while (time < $deadline) {
+		my $res = $controller->request('GET',
+			"/characteristics?id=$aid.$iid");
+		my $data = decode_json($res->{body});
+		$seen = $data->{characteristics}[0]{value};
+		my $normalized =
+		    JSON::PP::is_bool($seen) ? ( $seen ? 1 : 0 ) : $seen;
+		return $normalized
+		    if defined $normalized && "$normalized" eq "$expected";
+		sleep 0.25;
+	}
+	return $seen;
 }
 
-# Test 3: tele/STATE periodic update delivery ([MQTT-State §2], §3)
-{
-	my $state_received = 0;
-	my $state_payload;
+my ($light_aid, $on_iid) = find_char($light, '25');
+ok(defined $on_iid, 'lightbulb On characteristic located');
+my (undef, $brightness_iid) = find_char($light, '8');
+ok(defined $brightness_iid, 'lightbulb Brightness characteristic located');
+my ($sensor_aid, $temp_iid) = find_char($sensor, '11');
+ok(defined $temp_iid, 'sensor CurrentTemperature located');
 
-	$mqtt->subscribe(
-		"tele/$topic/STATE",
-		sub( $t, $p, $ = undef ) {
-			$state_received = 1;
-			$state_payload  = $p;
-		} );
+die "Accessory database missing expected characteristics\n"
+    unless defined $on_iid && defined $brightness_iid && defined $temp_iid;
 
-	my $state_json =
-	    '{"Time":"2024-01-01T00:00:00","POWER":"OFF","Dimmer":50}';
-	$mqtt->publish( "tele/$topic/STATE", $state_json );
+# Test 1: stat/POWER -> HAP On ([MQTT-State §1] -> [MQTT §4])
+$mqtt->publish("stat/$light->{topic}/POWER", 'ON');
+is(poll_value($light_aid, $on_iid, 1), 1,
+   '[MQTT-State §1] published POWER ON visible as HAP On=true');
 
-	ok( wait_for( \$state_received ),
-		'[MQTT-State §2] STATE message delivered on tele/+/STATE' );
-	like( $state_payload, qr/"POWER":"OFF"/,
-		'[MQTT-State §3] STATE payload carries POWER field' );
-}
+# Test 2: tele/STATE -> HAP Brightness ([MQTT-State §3])
+$mqtt->publish("tele/$light->{topic}/STATE",
+	'{"POWER":"ON","Dimmer":42}');
+is(poll_value($light_aid, $brightness_iid, 42), 42,
+   '[MQTT-State §3] STATE Dimmer visible as HAP Brightness');
 
-# Test 4: stat/RESULT command response delivery ([MQTT-State §4])
-{
-	my $result_received = 0;
+# Test 3: tele/SENSOR -> HAP CurrentTemperature ([MQTT-Sensors §1])
+$mqtt->publish("tele/$sensor->{topic}/SENSOR",
+	'{"DS18B20":{"Temperature":23.5},"TempUnit":"C"}');
+is(poll_value($sensor_aid, $temp_iid, 23.5), 23.5,
+   '[MQTT-Sensors §1] SENSOR temperature visible via HAP');
 
-	$mqtt->subscribe(
-		"stat/$topic/RESULT",
-		sub( $t, $p, $ = undef ) {
-			$result_received = 1;
-		} );
+# Test 4: Fahrenheit SENSOR converted ([MQTT-Sensors §3])
+$mqtt->publish("tele/$sensor->{topic}/SENSOR",
+	'{"DS18B20":{"Temperature":77},"TempUnit":"F"}');
+is(poll_value($sensor_aid, $temp_iid, 25), 25,
+   '[MQTT-Sensors §3] Fahrenheit reading converted to Celsius');
 
-	$mqtt->publish( "stat/$topic/RESULT", '{"POWER":"ON"}' );
+# Test 5: HAP write -> cmnd publish ([MQTT-Control §1])
+my $power_cmd;
+$mqtt->subscribe("cmnd/$light->{topic}/Power",
+	sub ($t, $p, $ = undef) { $power_cmd = $p; });
+sleep 0.3;
 
-	ok( wait_for( \$result_received ),
-		'[MQTT-State §4] RESULT message delivered on stat/+/RESULT' );
-}
+my $put = $controller->request('PUT', '/characteristics',
+	encode_json({ characteristics =>
+		[ { aid => $light_aid, iid => $on_iid, value => \0 } ] }),
+	{ 'Content-Type' => 'application/hap+json' });
+is($put->{status}, 204, 'HAP write accepted');
 
-# Test 5: Multi-relay POWER<n> topics ([MQTT-Control §1])
-for my $i ( 1 .. 2 ) {
-	my $power_received = 0;
+my $deadline = time + 5;
+$mqtt->tick(0.2) while !defined $power_cmd && time < $deadline;
+is($power_cmd, 'OFF',
+   '[MQTT-Control §1] HAP On=false observed as cmnd Power OFF');
 
-	$mqtt->subscribe(
-		"stat/$topic/POWER$i",
-		sub( $t, $p, $ = undef ) {
-			$power_received = 1;
-		} );
+# Test 6: HAP Brightness write -> cmnd Dimmer ([MQTT-Control §2])
+my $dimmer_cmd;
+$mqtt->subscribe("cmnd/$light->{topic}/Dimmer",
+	sub ($t, $p, $ = undef) { $dimmer_cmd = $p; });
+sleep 0.3;
 
-	$mqtt->publish( "stat/$topic/POWER$i", "ON" );
+$controller->request('PUT', '/characteristics',
+	encode_json({ characteristics => [
+		{ aid => $light_aid, iid => $brightness_iid, value => 66 }
+	] }),
+	{ 'Content-Type' => 'application/hap+json' });
 
-	ok( wait_for( \$power_received ),
-		"[MQTT-Control §1] POWER$i message delivered" );
-}
+$deadline = time + 5;
+$mqtt->tick(0.2) while !defined $dimmer_cmd && time < $deadline;
+is($dimmer_cmd, '66',
+   '[MQTT-Control §2] HAP Brightness observed as cmnd Dimmer');
 
-# Test 6: SENSOR telemetry delivery ([MQTT-Sensors §1])
-{
-	my $sensor_received = 0;
-	my $sensor_payload;
+# Test 7: LWT Online triggers a Status 11 state query
+# ([MQTT-Transport §1.4][MQTT-State §5.2])
+my $status_cmd;
+$mqtt->subscribe("cmnd/$light->{topic}/Status",
+	sub ($t, $p, $ = undef) { $status_cmd = $p; });
+sleep 0.3;
 
-	$mqtt->subscribe(
-		"tele/$topic/SENSOR",
-		sub( $t, $p, $ = undef ) {
-			$sensor_received = 1;
-			$sensor_payload  = $p;
-		} );
+$mqtt->publish("tele/$light->{topic}/LWT", 'Online');
+$deadline = time + 5;
+$mqtt->tick(0.2) while !defined $status_cmd && time < $deadline;
+is($status_cmd, '11',
+   '[MQTT-Transport §1.4] LWT Online answered with Status 11 query');
 
-	$mqtt->publish( "tele/$topic/SENSOR",
-		'{"DS18B20":{"Temperature":22.5},"TempUnit":"C"}' );
+# Cleanup
+$mqtt->unsubscribe("cmnd/$light->{topic}/Power");
+$mqtt->unsubscribe("cmnd/$light->{topic}/Dimmer");
+$mqtt->unsubscribe("cmnd/$light->{topic}/Status");
 
-	ok( wait_for( \$sensor_received ),
-		'[MQTT-Sensors §1] SENSOR message delivered on tele/+/SENSOR' );
-}
-
-# Test 7: OpenHAP daemon still responsive after all MQTT activity
-sleep 0.5;
-my $response = $env->http_request( 'GET', '/accessories' );
-ok( defined $response, 'Daemon responsive after MQTT tests' );
-
-# Clean up
-$mqtt->unsubscribe("tele/$topic/LWT");
-$mqtt->unsubscribe("tele/$topic/STATE");
-$mqtt->unsubscribe("tele/$topic/SENSOR");
-$mqtt->unsubscribe("stat/$topic/RESULT");
-$mqtt->unsubscribe("stat/$topic/POWER1");
-$mqtt->unsubscribe("stat/$topic/POWER2");
-
+$controller->remove_pairing;
 $env->teardown;

--- a/t/openhap/integration/tasmota-protocol.t
+++ b/t/openhap/integration/tasmota-protocol.t
@@ -1,23 +1,16 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Integration test: MQTT protocol compliance for Tasmota devices
+# Integration test: Tasmota MQTT message delivery to the daemon's broker
+#
+# Simulated device messages are published on the broker and asserted on an
+# observer subscription. HAP-side effects of these messages (characteristic
+# changes, cmnd/ publishes) require a paired controller and are covered by
+# the paired MQTT round-trip tests.
 
 use v5.36;
-use Test::More;
+use Test::More tests => 11;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../../lib";
-
-# Skip if not in VM environment
-unless ( -f '/etc/rc.d/openhapd' || $ENV{OPENHAP_INTEGRATION_TEST} ) {
-	plan skip_all => 'Integration tests require OpenBSD VM environment';
-	exit 0;
-}
-
-eval { require OpenHAP::Test::Integration };
-if ($@) {
-	plan skip_all => 'OpenHAP::Test::Integration not available';
-	exit 0;
-}
 
 use OpenHAP::Test::Integration;
 use Time::HiRes qw(sleep);
@@ -42,7 +35,17 @@ die "No devices configured for testing\n" unless @device_topics;
 
 my $topic = $device_topics[0];
 
-# Test 2: LWT subscription and handling (C1)
+# wait_for($flag_ref): tick the connection until the flag is set
+sub wait_for ($flag_ref)
+{
+	my $start = time;
+	while ( !$$flag_ref && ( time - $start ) < 5 ) {
+		$mqtt->tick(0.2);
+	}
+	return $$flag_ref;
+}
+
+# Test 2: LWT message delivery ([MQTT-Transport §1.4], §4.2)
 {
 	my $lwt_received = 0;
 	my $lwt_payload;
@@ -54,36 +57,37 @@ my $topic = $device_topics[0];
 			$lwt_payload  = $p;
 		} );
 
-	# Simulate LWT Online message
 	$mqtt->publish( "tele/$topic/LWT", "Online" );
-	sleep 0.5;
-	$mqtt->tick(0.5);
 
-	# Check if retained LWT was received or our published one
-	ok( 1, 'C1: LWT topic subscription works' );
+	ok( wait_for( \$lwt_received ),
+		'[MQTT-Transport §1.4] LWT message delivered on tele/+/LWT' );
+	is( $lwt_payload, 'Online',
+		'[MQTT-Transport §4.2] LWT payload is Online' );
 }
 
-# Test 3: tele/STATE periodic updates (C2)
+# Test 3: tele/STATE periodic update delivery ([MQTT-State §2], §3)
 {
 	my $state_received = 0;
+	my $state_payload;
 
 	$mqtt->subscribe(
 		"tele/$topic/STATE",
 		sub( $t, $p, $ = undef ) {
 			$state_received = 1;
+			$state_payload  = $p;
 		} );
 
-	# Simulate STATE message
 	my $state_json =
 	    '{"Time":"2024-01-01T00:00:00","POWER":"OFF","Dimmer":50}';
 	$mqtt->publish( "tele/$topic/STATE", $state_json );
-	sleep 0.3;
-	$mqtt->tick(0.5);
 
-	ok( 1, 'C2: tele/STATE subscription works' );
+	ok( wait_for( \$state_received ),
+		'[MQTT-State §2] STATE message delivered on tele/+/STATE' );
+	like( $state_payload, qr/"POWER":"OFF"/,
+		'[MQTT-State §3] STATE payload carries POWER field' );
 }
 
-# Test 4: stat/RESULT command responses (C3)
+# Test 4: stat/RESULT command response delivery ([MQTT-State §4])
 {
 	my $result_received = 0;
 
@@ -93,270 +97,48 @@ my $topic = $device_topics[0];
 			$result_received = 1;
 		} );
 
-	# Simulate RESULT message
 	$mqtt->publish( "stat/$topic/RESULT", '{"POWER":"ON"}' );
-	sleep 0.3;
-	$mqtt->tick(0.5);
 
-	ok( 1, 'C3: stat/RESULT subscription works' );
+	ok( wait_for( \$result_received ),
+		'[MQTT-State §4] RESULT message delivered on stat/+/RESULT' );
 }
 
-# Test 5: Multi-relay support (H1)
-{
-	# Test POWER1, POWER2 topics
-	for my $i ( 1 .. 2 ) {
-		my $power_received = 0;
+# Test 5: Multi-relay POWER<n> topics ([MQTT-Control §1])
+for my $i ( 1 .. 2 ) {
+	my $power_received = 0;
 
-		$mqtt->subscribe(
-			"stat/$topic/POWER$i",
-			sub( $t, $p, $ = undef ) {
-				$power_received = 1;
-			} );
-
-		$mqtt->publish( "stat/$topic/POWER$i", "ON" );
-		sleep 0.2;
-		$mqtt->tick(0.3);
-
-		ok( 1, "H1: POWER$i subscription works" );
-	}
-}
-
-# Test 6: SENSOR data with multiple types (H5)
-{
-	my @sensor_types = qw(DS18B20 DHT22 BME280);
-
-	for my $type (@sensor_types) {
-		my $json = "{\"$type\":{\"Temperature\":22.5},\"TempUnit\":\"C\"}";
-		$mqtt->publish( "tele/$topic/SENSOR", $json );
-		sleep 0.2;
-		$mqtt->tick(0.3);
-	}
-
-	ok( 1, 'H5: Multiple sensor types supported' );
-}
-
-# Test 7: Temperature unit in SENSOR (H4)
-{
-	# Test Fahrenheit
-	my $json_f = '{"DS18B20":{"Temperature":77},"TempUnit":"F"}';
-	$mqtt->publish( "tele/$topic/SENSOR", $json_f );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	# Test Celsius
-	my $json_c = '{"DS18B20":{"Temperature":25},"TempUnit":"C"}';
-	$mqtt->publish( "tele/$topic/SENSOR", $json_c );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'H4: Temperature unit handling works' );
-}
-
-# Test 8: Lightbulb commands (H2)
-{
-	# Test Dimmer command
-	$mqtt->publish( "cmnd/$topic/Dimmer", "75" );
-	sleep 0.2;
-
-	# Test HSBColor command
-	$mqtt->publish( "cmnd/$topic/HSBColor", "240,100,50" );
-	sleep 0.2;
-
-	# Test CT command
-	$mqtt->publish( "cmnd/$topic/CT", "300" );
-	sleep 0.2;
-
-	$mqtt->tick(0.5);
-
-	ok( 1, 'H2: Lightbulb commands work' );
-}
-
-# Test 9: Status 0 query (H3)
-{
-	# Subscribe to status responses
-	my $status_received = 0;
 	$mqtt->subscribe(
-		"stat/$topic/STATUS",
+		"stat/$topic/POWER$i",
 		sub( $t, $p, $ = undef ) {
-			$status_received = 1;
+			$power_received = 1;
 		} );
 
-	# Send Status 0 command
-	$mqtt->publish( "cmnd/$topic/Status", "0" );
-	sleep 0.5;
-	$mqtt->tick(1);
+	$mqtt->publish( "stat/$topic/POWER$i", "ON" );
 
-	ok( 1, 'H3: Status 0 query sent' );
+	ok( wait_for( \$power_received ),
+		"[MQTT-Control §1] POWER$i message delivered" );
 }
 
-# Test 10: TOGGLE command (L1)
+# Test 6: SENSOR telemetry delivery ([MQTT-Sensors §1])
 {
-	$mqtt->publish( "cmnd/$topic/Power", "TOGGLE" );
-	sleep 0.2;
-	$mqtt->tick(0.3);
+	my $sensor_received = 0;
+	my $sensor_payload;
 
-	ok( 1, 'L1: TOGGLE command works' );
-}
-
-# Test 11: BLINK commands (L2)
-{
-	$mqtt->publish( "cmnd/$topic/Power", "BLINK" );
-	sleep 0.2;
-
-	$mqtt->publish( "cmnd/$topic/Power", "BLINKOFF" );
-	sleep 0.2;
-
-	$mqtt->tick(0.3);
-
-	ok( 1, 'L2: BLINK commands work' );
-}
-
-# Test 12: Dimmer step commands (L3)
-{
-	$mqtt->publish( "cmnd/$topic/Dimmer", "+" );
-	sleep 0.1;
-
-	$mqtt->publish( "cmnd/$topic/Dimmer", "-" );
-	sleep 0.1;
-
-	$mqtt->publish( "cmnd/$topic/Dimmer", "<" );
-	sleep 0.1;
-
-	$mqtt->publish( "cmnd/$topic/Dimmer", ">" );
-	sleep 0.1;
-
-	$mqtt->tick(0.3);
-
-	ok( 1, 'L3: Dimmer step commands work' );
-}
-
-# Test 13: Indexed sensors (H5)
-{
-	my $json = '{"DS18B20-1":{"Temperature":20},"DS18B20-2":{"Temperature":25},"TempUnit":"C"}';
-	$mqtt->publish( "tele/$topic/SENSOR", $json );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'H5: Indexed sensors supported' );
-}
-
-# Test 14: STATUS8 sensor query (M1)
-{
-	my $status8_received = 0;
 	$mqtt->subscribe(
-		"stat/$topic/STATUS8",
+		"tele/$topic/SENSOR",
 		sub( $t, $p, $ = undef ) {
-			$status8_received = 1;
+			$sensor_received = 1;
+			$sensor_payload  = $p;
 		} );
 
-	$mqtt->publish( "cmnd/$topic/Status", "8" );
-	sleep 0.3;
-	$mqtt->tick(0.5);
+	$mqtt->publish( "tele/$topic/SENSOR",
+		'{"DS18B20":{"Temperature":22.5},"TempUnit":"C"}' );
 
-	ok( 1, 'M1: STATUS8 query works' );
+	ok( wait_for( \$sensor_received ),
+		'[MQTT-Sensors §1] SENSOR message delivered on tele/+/SENSOR' );
 }
 
-# Test 15: SetOption4 plain text response (M3)
-{
-	# Test plain text POWER response
-	$mqtt->publish( "stat/$topic/POWER", "ON" );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'M3: Plain text POWER response handled' );
-}
-
-# Test 16: STATUS11 state reconciliation (C1/H1)
-{
-	my $status11_received = 0;
-	$mqtt->subscribe(
-		"stat/$topic/STATUS11",
-		sub( $t, $p, $ = undef ) {
-			$status11_received = 1;
-		} );
-
-	# Send Status 11 command (recommended for state reconciliation)
-	$mqtt->publish( "cmnd/$topic/Status", "11" );
-	sleep 0.3;
-	$mqtt->tick(0.5);
-
-	ok( 1, 'C1/H1: STATUS11 query sent' );
-}
-
-# Test 17: STATUS10 sensor query (recommended per spec)
-{
-	my $status10_received = 0;
-	$mqtt->subscribe(
-		"stat/$topic/STATUS10",
-		sub( $t, $p, $ = undef ) {
-			$status10_received = 1;
-		} );
-
-	$mqtt->publish( "cmnd/$topic/Status", "10" );
-	sleep 0.3;
-	$mqtt->tick(0.5);
-
-	ok( 1, 'STATUS10 sensor query works' );
-}
-
-# Test 18: TelePeriod for forcing telemetry (L1)
-{
-	$mqtt->publish( "cmnd/$topic/TelePeriod", "" );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'L1: TelePeriod command works' );
-}
-
-# Test 19: SetOption4 DIMMER topic (M2)
-{
-	$mqtt->publish( "stat/$topic/DIMMER", "75" );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'M2: DIMMER topic works' );
-}
-
-# Test 20: SetOption4 HSBCOLOR topic (M2)
-{
-	$mqtt->publish( "stat/$topic/HSBCOLOR", "180,100,50" );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'M2: HSBCOLOR topic works' );
-}
-
-# Test 21: SetOption4 CT topic (M2)
-{
-	$mqtt->publish( "stat/$topic/CT", "300" );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'M2: CT topic works' );
-}
-
-# Test 22: SetOption17 decimal color format (M3)
-{
-	# Test decimal color format
-	my $json = '{"Color":"255,128,0","HSBColor":"30,100,100"}';
-	$mqtt->publish( "stat/$topic/RESULT", $json );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'M3: SetOption17 decimal color format works' );
-}
-
-# Test 23: Sensor with Id field (L3)
-{
-	my $json = '{"DS18B20":{"Id":"01131B123456","Temperature":22.5},"TempUnit":"C"}';
-	$mqtt->publish( "tele/$topic/SENSOR", $json );
-	sleep 0.2;
-	$mqtt->tick(0.3);
-
-	ok( 1, 'L3: Sensor Id field supported' );
-}
-
-# Test 24: OpenHAP daemon still responsive after all MQTT activity
+# Test 7: OpenHAP daemon still responsive after all MQTT activity
 sleep 0.5;
 my $response = $env->http_request( 'GET', '/accessories' );
 ok( defined $response, 'Daemon responsive after MQTT tests' );
@@ -364,12 +146,9 @@ ok( defined $response, 'Daemon responsive after MQTT tests' );
 # Clean up
 $mqtt->unsubscribe("tele/$topic/LWT");
 $mqtt->unsubscribe("tele/$topic/STATE");
+$mqtt->unsubscribe("tele/$topic/SENSOR");
 $mqtt->unsubscribe("stat/$topic/RESULT");
-$mqtt->unsubscribe("stat/$topic/STATUS");
-$mqtt->unsubscribe("stat/$topic/STATUS8");
 $mqtt->unsubscribe("stat/$topic/POWER1");
 $mqtt->unsubscribe("stat/$topic/POWER2");
 
 $env->teardown;
-
-done_testing();

--- a/t/openhap/pairing.t
+++ b/t/openhap/pairing.t
@@ -150,21 +150,21 @@ SKIP: {
     ok(defined $response, 'Invalid state returns error response');
 }
 
-# Test new TLV type constants (Finding 6)
+# Test new TLV type constants
 {
     ok(defined &OpenHAP::Pairing::kTLVType_SessionID, 'kTLVType_SessionID defined');
     ok(defined &OpenHAP::Pairing::kTLVType_Flags, 'kTLVType_Flags defined');
-    is(OpenHAP::Pairing::kTLVType_SessionID(), 0x0E, 'kTLVType_SessionID is 0x0E');
-    is(OpenHAP::Pairing::kTLVType_Flags(), 0x13, 'kTLVType_Flags is 0x13');
+    is(OpenHAP::Pairing::kTLVType_SessionID(), 0x0E, '[HAP-TLV8 §5] kTLVType_SessionID is 0x0E');
+    is(OpenHAP::Pairing::kTLVType_Flags(), 0x13, '[HAP-TLV8 §5] kTLVType_Flags is 0x13');
 }
 
-# Test kTLVError_MaxTries constant (Finding 4)
+# Test kTLVError_MaxTries constant
 {
     ok(defined &OpenHAP::Pairing::kTLVError_MaxTries, 'kTLVError_MaxTries defined');
-    is(OpenHAP::Pairing::kTLVError_MaxTries(), 0x05, 'kTLVError_MaxTries is 0x05');
+    is(OpenHAP::Pairing::kTLVError_MaxTries(), 0x05, '[HAP-TLV8 §7] kTLVError_MaxTries is 0x05');
 }
 
-# Test invalid pairing method rejection (Finding 7)
+# Test invalid pairing method rejection
 SKIP: {
     eval {
         require Crypt::Ed25519;
@@ -201,12 +201,13 @@ SKIP: {
     # Decode response to check for error
     my %resp_tlv = OpenHAP::TLV::decode($response);
     my $error = unpack('C', $resp_tlv{ OpenHAP::Pairing::kTLVType_Error() } // '');
-    is($error, OpenHAP::Pairing::kTLVError_Unknown(), 'Invalid method returns kTLVError_Unknown');
-    
+    is($error, OpenHAP::Pairing::kTLVError_Unknown(),
+        '[HAP-TLV8 §6] invalid pairing method returns kTLVError_Unknown');
+
     OpenHAP::Pairing->clear_pairing_state();
 }
 
-# Test already-paired rejection (Finding 2)
+# Test already-paired rejection
 SKIP: {
     eval {
         require Crypt::Ed25519;
@@ -242,7 +243,8 @@ SKIP: {
     my $response = $pairing->handle_pair_setup($body, $session);
     my %resp_tlv = OpenHAP::TLV::decode($response);
     my $error = unpack('C', $resp_tlv{ OpenHAP::Pairing::kTLVType_Error() } // '');
-    is($error, OpenHAP::Pairing::kTLVError_Unavailable(), 'Already paired returns kTLVError_Unavailable');
+    is($error, OpenHAP::Pairing::kTLVError_Unavailable(),
+        '[HAP-Pairing §2.4] already paired returns kTLVError_Unavailable in M2');
     
     # But PairSetupWithAuth (method=1) should be allowed even when paired
     OpenHAP::Pairing->clear_pairing_state();
@@ -255,12 +257,13 @@ SKIP: {
     my $response_auth = $pairing->handle_pair_setup($body_auth, $session2);
     my %resp_auth = OpenHAP::TLV::decode($response_auth);
     my $state = unpack('C', $resp_auth{ OpenHAP::Pairing::kTLVType_State() } // '');
-    is($state, 2, 'PairSetupWithAuth allowed when already paired (returns M2)');
+    is($state, 2,
+        '[HAP-Pairing §2.3] PairSetupWithAuth allowed when already paired (returns M2)');
     
     OpenHAP::Pairing->clear_pairing_state();
 }
 
-# Test concurrent pairing protection (Finding 3)
+# Test concurrent pairing protection
 SKIP: {
     eval {
         require Crypt::Ed25519;
@@ -299,15 +302,17 @@ SKIP: {
     my $response2 = $pairing->handle_pair_setup($body, $session2);
     my %resp2 = OpenHAP::TLV::decode($response2);
     my $error2 = unpack('C', $resp2{ OpenHAP::Pairing::kTLVType_Error() } // '');
-    is($error2, OpenHAP::Pairing::kTLVError_Busy(), 'Concurrent pairing returns kTLVError_Busy');
+    is($error2, OpenHAP::Pairing::kTLVError_Busy(),
+        '[HAP-Pairing §2.4] concurrent pairing returns kTLVError_Busy in M2');
     
     OpenHAP::Pairing->clear_pairing_state();
 }
 
-# Test failed attempt counting (Finding 4)
+# Test failed attempt counting
 {
     OpenHAP::Pairing->reset_auth_attempts();
-    is(OpenHAP::Pairing->get_failed_attempts(), 0, 'Failed attempts starts at 0');
+    is(OpenHAP::Pairing->get_failed_attempts(), 0,
+        '[HAP-Pairing §8] failed attempt counter starts at 0');
 }
 
 # Test M2 response doesn't contain '0x' prefix in public key (Bug fix)
@@ -350,10 +355,12 @@ SKIP: {
     
     # Check that the hex doesn't start with '30' which is ASCII '0'
     # If the bug existed, we'd see '307830...' (0x30='0', 0x78='x')
-    isnt(substr($hex, 0, 4), '3078', 'Public key does not start with ASCII "0x"');
-    
+    isnt(substr($hex, 0, 4), '3078',
+        '[HAP-Pairing §2.4] public key does not start with ASCII "0x"');
+
     # The public key should be 384 bytes (3072 bits)
-    is(length($public_key), 384, 'Public key is 384 bytes (3072 bits)');
+    is(length($public_key), 384,
+        '[HAP-Pairing §2.4] M2 public key B is 384 bytes (3072 bits)');
     
     OpenHAP::Pairing->clear_pairing_state();
 }

--- a/t/openhap/pin.t
+++ b/t/openhap/pin.t
@@ -12,7 +12,8 @@ use_ok('OpenHAP::PIN');
 # Test normalize_pin - basic functionality
 {
 	my $pin = OpenHAP::PIN::normalize_pin('1234-5678');
-	is($pin, '12345678', 'Normalize PIN with single dash');
+	is($pin, '12345678',
+	    '[HAP-Pairing §2.2] 8-digit setup code accepted with dashes');
 }
 
 {
@@ -38,7 +39,8 @@ use_ok('OpenHAP::PIN');
 # Test normalize_pin - invalid formats
 {
 	my $pin = OpenHAP::PIN::normalize_pin('123-4567');
-	is($pin, undef, 'Reject PIN with 7 digits');
+	is($pin, undef,
+	    '[HAP-Pairing §2.2] reject PIN with 7 digits (setup code is 8 digits)');
 }
 
 {
@@ -88,7 +90,8 @@ use_ok('OpenHAP::PIN');
 	ok(OpenHAP::PIN::validate_pin('0000-0001'), 'Valid PIN starting with zeros');
 }
 
-# Test validate_pin - invalid PINs per HAP spec
+# Test validate_pin - trivial setup codes disallowed by HAP
+# (Apple HAP R2 5.3; the trivial-code blacklist is not in spec/)
 {
 	ok(!OpenHAP::PIN::validate_pin('00000000'), 'Reject 00000000');
 }

--- a/t/openhap/spec-coverage.t
+++ b/t/openhap/spec-coverage.t
@@ -1,0 +1,161 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Unit tests for scripts/spec-coverage against a fixture tree
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use File::Temp qw(tempdir);
+
+my $script = "$RealBin/../../scripts/spec-coverage";
+ok( -x $script, 'spec-coverage script is executable' );
+
+# Build a fixture spec/ + t/ tree
+my $fixture  = tempdir( CLEANUP => 1 );
+my $spec_dir = "$fixture/spec";
+my $test_dir = "$fixture/t";
+mkdir $spec_dir or die "mkdir $spec_dir: $!";
+mkdir $test_dir or die "mkdir $test_dir: $!";
+
+sub write_file ( $path, $content )
+{
+	open my $fh, '>', $path or die "Cannot write $path: $!";
+	print $fh $content;
+	close $fh;
+}
+
+write_file( "$spec_dir/HAP-Fixture.md", <<'EOF' );
+# HAP Fixture
+
+## 1. First Section
+
+Text.
+
+### 1.1 Subsection
+
+More text.
+
+## 2. Second Section
+
+### 2.1 Covered Table
+
+| Row | Value |
+
+## 3. Uncovered Section
+
+Nothing cites this.
+EOF
+
+# Index file (stem without '-'): listed but not counted
+write_file( "$spec_dir/HAP.md", <<'EOF' );
+# Index
+
+## 1. Glossary
+EOF
+
+# Unnumbered file: tolerated, nothing to cover
+write_file( "$spec_dir/IMPLEMENTATIONS.md", <<'EOF' );
+# Implementations
+
+## Patterns
+
+No numbered anchors here.
+EOF
+
+# Citation strings are assembled at runtime so this file's own source
+# never matches the citation grep when the tool runs on the real tree.
+my $STEM = 'HAP-' . 'Fixture';
+
+write_file( "$test_dir/fixture.t", <<EOF );
+ok(1, '[$STEM §1] first section requirement');
+ok(1, '[$STEM §1.1] subsection requirement');
+ok(1, '[$STEM §2.1/RowName] table row citation');
+EOF
+
+sub run_tool (@args)
+{
+	my $cmd    = join ' ', $script, '--spec-dir', $spec_dir,
+	    '--test-dir', $test_dir, @args;
+	my $output = `$cmd 2>&1`;
+	return ( $? >> 8, $output );
+}
+
+# Basic run: citations parsed and joined
+{
+	my ( $exit, $output ) = run_tool();
+	is( $exit, 0, 'exits 0 with no stale citations' );
+	like( $output, qr/HAP-Fixture\.md\s+3\/5 sections cited/,
+		'per-file coverage counts cited sections' );
+	like( $output, qr/§1\s+\S*fixture\.t:1/,
+		'citation resolved to file:line' );
+	like( $output, qr/§2\.1\s+\S*fixture\.t:3/,
+		'row-suffixed citation resolves to its section' );
+	like( $output, qr/§3\s+UNCOVERED/, 'uncovered section reported' );
+	like( $output, qr/§2\s+UNCOVERED/,
+		'parent section not covered by child citation' );
+	like( $output, qr/TOTAL: 3\/5 numbered sections cited/,
+		'total line present' );
+	like( $output, qr/HAP\.md\s+\(index, not counted\)/,
+		'index file listed but not counted' );
+	like( $output, qr/IMPLEMENTATIONS\.md\s+\(unnumbered, not counted\)/,
+		'unnumbered file tolerated' );
+}
+
+# --quiet: totals only
+{
+	my ( $exit, $output ) = run_tool('--quiet');
+	is( $exit, 0, '--quiet exits 0' );
+	like( $output, qr/^TOTAL: 3\/5 numbered sections cited/m,
+		'--quiet prints totals' );
+	unlike( $output, qr/UNCOVERED/, '--quiet omits section detail' );
+}
+
+# --uncovered: only gaps
+{
+	my ( $exit, $output ) = run_tool('--uncovered');
+	is( $exit, 0, '--uncovered exits 0' );
+	like( $output, qr/§3\s+UNCOVERED/, '--uncovered lists gaps' );
+	unlike( $output, qr/fixture\.t:1/,
+		'--uncovered omits covered sections' );
+}
+
+# Stale citation: nonexistent section
+{
+	write_file( "$test_dir/stale.t", <<EOF );
+ok(1, '[$STEM §9.9] no such section');
+EOF
+	my ( $exit, $output ) = run_tool('--quiet');
+	is( $exit, 1, 'stale citation exits non-zero' );
+	like( $output,
+		qr/STALE: \S*stale\.t:1 cites HAP-Fixture §9\.9 \(no such section\)/,
+		'stale citation names file:line and section' );
+	unlink "$test_dir/stale.t";
+}
+
+# Stale citation: nonexistent spec file
+{
+	my $bogus = 'HAP-' . 'Bogus';
+	write_file( "$test_dir/stale2.t", <<EOF );
+ok(1, '[$bogus §1] no such spec file');
+EOF
+	my ( $exit, $output ) = run_tool('--quiet');
+	is( $exit, 1, 'unknown spec stem exits non-zero' );
+	like( $output, qr/STALE: \S*stale2\.t:1 cites HAP-Bogus §1 \(no such spec file\)/,
+		'unknown stem reported with file:line' );
+	unlink "$test_dir/stale2.t";
+}
+
+# Citation in a .pm helper under t/ is scanned too
+{
+	write_file( "$test_dir/Helper.pm", <<EOF );
+# [$STEM §3] helper-level citation
+1;
+EOF
+	my ( $exit, $output ) = run_tool();
+	is( $exit, 0, 'helper citation accepted' );
+	like( $output, qr/§3\s+\S*Helper\.pm:1/,
+		'.pm files under the test dir are scanned' );
+	unlink "$test_dir/Helper.pm";
+}
+
+done_testing();

--- a/t/openhap/spec-coverage.t
+++ b/t/openhap/spec-coverage.t
@@ -24,7 +24,7 @@ sub write_file ( $path, $content )
 	close $fh;
 }
 
-write_file( "$spec_dir/HAP-Fixture.md", <<'EOF' );
+write_file( "$spec_dir/HAP-Fixture8.md", <<'EOF' );
 # HAP Fixture
 
 ## 1. First Section
@@ -64,7 +64,8 @@ EOF
 
 # Citation strings are assembled at runtime so this file's own source
 # never matches the citation grep when the tool runs on the real tree.
-my $STEM = 'HAP-' . 'Fixture';
+# The stem carries a digit to cover stems like HAP-TLV8.
+my $STEM = 'HAP-' . 'Fixture8';
 
 write_file( "$test_dir/fixture.t", <<EOF );
 ok(1, '[$STEM §1] first section requirement');
@@ -84,7 +85,7 @@ sub run_tool (@args)
 {
 	my ( $exit, $output ) = run_tool();
 	is( $exit, 0, 'exits 0 with no stale citations' );
-	like( $output, qr/HAP-Fixture\.md\s+3\/5 sections cited/,
+	like( $output, qr/HAP-Fixture8\.md\s+3\/5 sections cited/,
 		'per-file coverage counts cited sections' );
 	like( $output, qr/§1\s+\S*fixture\.t:1/,
 		'citation resolved to file:line' );
@@ -127,7 +128,7 @@ EOF
 	my ( $exit, $output ) = run_tool('--quiet');
 	is( $exit, 1, 'stale citation exits non-zero' );
 	like( $output,
-		qr/STALE: \S*stale\.t:1 cites HAP-Fixture §9\.9 \(no such section\)/,
+		qr/STALE: \S*stale\.t:1 cites HAP-Fixture8 §9\.9 \(no such section\)/,
 		'stale citation names file:line and section' );
 	unlink "$test_dir/stale.t";
 }

--- a/t/openhap/srp.t
+++ b/t/openhap/srp.t
@@ -134,7 +134,7 @@ use_ok('OpenHAP::SRP');
     is(length($K), 64, 'Session key is 64 bytes (SHA-512)');
 }
 
-# Test SRP A mod N == 0 validation (Finding 1 - Security)
+# Test SRP A mod N == 0 validation
 {
     my $srp = OpenHAP::SRP->new(password => '123-45-678');
 
@@ -145,7 +145,7 @@ use_ok('OpenHAP::SRP');
     # Test with A = 0 (should be rejected)
     my $A_zero = "\x00" x 384;  # 3072 bits = 384 bytes
     my $K = $srp->compute_session_key($A_zero);
-    ok(!defined $K, 'Session key rejected when A is zero');
+    ok(!defined $K, '[HAP-Pairing §2.6] session key rejected when A is zero');
 
     # Test with A = N (should be rejected since A mod N == 0)
     # Get N as bytes
@@ -153,7 +153,8 @@ use_ok('OpenHAP::SRP');
     $N_hex =~ s/^0x//;
     my $A_equals_N = pack('H*', $N_hex);
     $K = $srp->compute_session_key($A_equals_N);
-    ok(!defined $K, 'Session key rejected when A equals N');
+    ok(!defined $K,
+        '[HAP-Pairing §2.6] session key rejected when A mod N == 0');
 }
 
 # Test get_session_key

--- a/t/openhap/srp_padding.t
+++ b/t/openhap/srp_padding.t
@@ -24,11 +24,6 @@ use_ok('OpenHAP::Crypto');
 #
 # Bug: The original implementation did not pad A and B to 384 bytes before
 # hashing, causing proof verification failures with iOS Home app.
-#
-# References:
-# - HAP-Pairing.md §2.5-2.6: Specifies u = H(A | B) and M1 = H(...)
-# - HAP-python hsrp.py: Uses _padN() to pad both A and B to N_len
-# - SRP-6a spec: Requires consistent encoding/padding of group elements
 
 # Test padding of A and B in u computation
 {
@@ -41,19 +36,19 @@ use_ok('OpenHAP::Crypto');
     # For example, a small value like 256 (0x100) would be 2 bytes unpadded
     my $A_small = Math::BigInt->new(256);
     my $A_bytes_unpadded = OpenHAP::SRP::_bigint_to_bytes($A_small);
-    
+
     # Without padding, this would be 2 bytes
-    ok(length($A_bytes_unpadded) < 384, 
+    ok(length($A_bytes_unpadded) < 384,
         'Small A is less than 384 bytes without padding');
-    
+
     # With padding, it should be 384 bytes
     my $A_bytes_padded = OpenHAP::SRP::_bigint_to_bytes($A_small, 384);
-    is(length($A_bytes_padded), 384, 
-        'Small A is exactly 384 bytes with padding');
-    
+    is(length($A_bytes_padded), 384,
+        '[HAP-Pairing §2.5] small A is left-padded to 384 bytes');
+
     # Verify padding is with leading zeros
     is(unpack('H*', $A_bytes_padded), ('00' x 382) . '0100',
-        'A is padded with leading zeros');
+        '[HAP-Pairing §2.5] A is padded with leading zeros');
 }
 
 # Test that compute_session_key uses padded A and B for u
@@ -71,11 +66,11 @@ use_ok('OpenHAP::Crypto');
     
     isnt(length($A_bytes_unpadded), length($A_bytes_padded),
         'Padded and unpadded A have different lengths');
-    
+
     # Both should produce the same session key because internally
-    # compute_session_key should pad before computing u
+    # compute_session_key pads A to 384 bytes before computing u
     my $K1 = $srp->compute_session_key($A_bytes_unpadded);
-    
+
     # Need a fresh SRP instance for second test
     my $srp2 = OpenHAP::SRP->new(password => '123-45-678');
     $srp2->generate_salt();
@@ -85,15 +80,16 @@ use_ok('OpenHAP::Crypto');
     $srp2->{B} = $srp->{B};
     $srp2->{v} = $srp->{v};
     $srp2->{salt} = $srp->{salt};
-    
+
     my $K2 = $srp2->compute_session_key($A_bytes_padded);
-    
-    # Note: These might differ because A is interpreted as a different number
-    # What matters is that the padding happens consistently internally
+
+    ok(defined $K1 && defined $K2, 'Both session keys computed');
+    is(unpack('H*', $K1), unpack('H*', $K2),
+        '[HAP-Pairing §2.6] u uses PAD(A): unpadded and padded A '
+        . 'wire encodings derive the same session key');
 }
 
 # Test full SRP exchange with known values to verify padding
-# This tests against a reference implementation (HAP-python)
 {
     # Set up SRP with known parameters
     my $password = '123-45-678';
@@ -112,7 +108,8 @@ use_ok('OpenHAP::Crypto');
     # Compute session key (this internally computes u = H(PAD(A) | PAD(B)))
     my $K = $srp->compute_session_key($A_bytes);
     ok(defined $K, 'Session key computed successfully');
-    is(length($K), 64, 'Session key is 64 bytes (SHA-512 output)');
+    is(length($K), 64,
+        '[HAP-Pairing §2.6] session key K = H(S) is 64 bytes (SHA-512)');
     
     # Verify internal A is stored correctly
     ok(defined $srp->{A}, 'A is stored in SRP object');
@@ -122,14 +119,15 @@ use_ok('OpenHAP::Crypto');
     # For now, just test that verify_client_proof uses padded values
     my $M1_dummy = 'X' x 64;  # Wrong proof for this test
     my $result = $srp->verify_client_proof($M1_dummy);
-    ok(!$result, 'Wrong proof is rejected');
+    ok(!$result, '[HAP-Pairing §2.6] wrong client proof M1 is rejected');
 }
 
 # Test N_len constant matches our padding expectation
 {
     # N is 3072 bits = 384 bytes
     my $N_len = length($OpenHAP::Crypto::N_3072);
-    is($N_len, 384, 'N_3072 constant is 384 bytes');
+    is($N_len, 384,
+        '[HAP-Pairing §2.2] N_3072 group prime is 384 bytes (3072 bits)');
 }
 
 done_testing();

--- a/t/openhap/storage.t
+++ b/t/openhap/storage.t
@@ -103,7 +103,7 @@ my $temp_dir = tempdir(CLEANUP => 1);
     is($pairings->{'binary-controller'}{ltpk}, $binary_ltpk, 'Binary LTPK stored correctly');
 }
 
-# Test remove_all_pairings (Finding 8)
+# Test remove_all_pairings ([HAP-Pairing §7.2] last-admin removal)
 {
     my $temp_dir3 = tempdir(CLEANUP => 1);
     my $storage = OpenHAP::Storage->new(db_path => $temp_dir3);
@@ -118,9 +118,10 @@ my $temp_dir = tempdir(CLEANUP => 1);
     
     # Remove all pairings
     $storage->remove_all_pairings();
-    
+
     $pairings = $storage->load_pairings();
-    is(scalar keys %$pairings, 0, 'All pairings removed');
+    is(scalar keys %$pairings, 0,
+        '[HAP-Pairing §7.2] all pairings removed');
 }
 
 done_testing();

--- a/t/openhap/tasmota.t
+++ b/t/openhap/tasmota.t
@@ -1,90 +1,35 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Unit tests for Tasmota device modules
+# Unit tests for the Tasmota device modules: constructors, initial
+# state, and helper math. Protocol behavior (topics, payloads, message
+# handling) is covered by the spec-cited tests in t/conformance/.
 
 use v5.36;
 use Test::More;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../lib";
+use lib "$RealBin/../lib";
 use FuguLib::Log;
-$OpenHAP::logger = FuguLib::Log->new(mode => 'quiet', ident => 'test');
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
 
-# Mock MQTT client for testing
-package MockMQTT;
-
-sub new($class) {
-	bless {
-		subscriptions => {},
-		published     => [],
-		connected     => 1,
-	}, $class;
-}
-
-sub is_connected($self) { $self->{connected} }
-
-sub subscribe( $self, $topic, $callback )
-{
-	$self->{subscriptions}{$topic} = $callback;
-}
-
-sub publish( $self, $topic, $payload )
-{
-	push @{ $self->{published} }, { topic => $topic, payload => $payload };
-}
-
-sub get_subscriptions($self) { keys %{ $self->{subscriptions} } }
-
-sub get_published($self) { @{ $self->{published} } }
-
-sub clear_published($self) { $self->{published} = [] }
-
-sub simulate_message( $self, $topic, $payload )
-{
-	for my $pattern ( keys %{ $self->{subscriptions} } ) {
-		if ( _topic_matches( $pattern, $topic ) ) {
-			$self->{subscriptions}{$pattern}->( $topic, $payload );
-		}
-	}
-}
-
-sub _topic_matches( $pattern, $topic )
-{
-	return 1 if $pattern eq $topic;
-	return 0 unless $pattern =~ m{[+#]};
-
-	my @pattern_parts = split m{/}, $pattern;
-	my @topic_parts   = split m{/}, $topic;
-
-	for my $i ( 0 .. $#pattern_parts ) {
-		my $p = $pattern_parts[$i];
-		return 1 if $p eq '#';
-		return 0 if $i > $#topic_parts;
-		next     if $p eq '+';
-		return 0 if $p ne $topic_parts[$i];
-	}
-
-	return @topic_parts == @pattern_parts;
-}
-
-package main;
-
+use_ok('OpenHAP::TestMock::MQTT');
 use_ok('OpenHAP::Tasmota::Base');
 use_ok('OpenHAP::Tasmota::Heater');
 use_ok('OpenHAP::Tasmota::Sensor');
 use_ok('OpenHAP::Tasmota::Thermostat');
 use_ok('OpenHAP::Tasmota::Lightbulb');
 
-# Import constants for easier use in tests
 use constant AVAILABILITY_UNKNOWN => 0;
 use constant AVAILABILITY_ONLINE  => 1;
 use constant AVAILABILITY_OFFLINE => 2;
-use constant CAP_DIMMER           => 1;
-use constant CAP_COLOR            => 2;
-use constant CAP_CT               => 4;
 
-# Test Base class
+my $CAP_DIMMER = OpenHAP::Tasmota::Lightbulb::CAP_DIMMER();
+my $CAP_COLOR  = OpenHAP::Tasmota::Lightbulb::CAP_COLOR();
+my $CAP_CT     = OpenHAP::Tasmota::Lightbulb::CAP_CT();
+
+# Test Base class construction and availability accessors
 {
-	my $mqtt = MockMQTT->new();
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
 	my $base = OpenHAP::Tasmota::Base->new(
 		aid         => 2,
 		name        => 'Test Base',
@@ -97,11 +42,18 @@ use constant CAP_CT               => 4;
 	is( $base->{availability},
 		AVAILABILITY_UNKNOWN,
 		'Initial availability is unknown' );
+	ok( !$base->is_online, 'is_online false while unknown' );
+
+	$base->{availability} = AVAILABILITY_ONLINE;
+	ok( $base->is_online, 'is_online true when online' );
+
+	$base->{availability} = AVAILABILITY_OFFLINE;
+	ok( !$base->is_online, 'is_online false when offline' );
 }
 
-# Test Base MQTT subscriptions
+# Test temperature conversion helper
 {
-	my $mqtt = MockMQTT->new();
+	my $mqtt = OpenHAP::TestMock::MQTT->new;
 	my $base = OpenHAP::Tasmota::Base->new(
 		aid         => 2,
 		name        => 'Test Base',
@@ -109,108 +61,20 @@ use constant CAP_CT               => 4;
 		mqtt_client => $mqtt,
 	);
 
-	$base->subscribe_mqtt();
-
-	my @subs = $mqtt->get_subscriptions();
-	ok( ( grep { $_ eq 'tele/test_device/LWT' } @subs ),
-		'[MQTT-Transport §1.4] Subscribed to LWT' );
-	ok( ( grep { $_ eq 'tele/test_device/STATE' } @subs ),
-		'[MQTT-State §2] Subscribed to tele/STATE' );
-	ok( ( grep { $_ eq 'stat/test_device/RESULT' } @subs ),
-		'[MQTT-State §1] Subscribed to stat/RESULT' );
-	ok( ( grep { $_ eq 'tele/test_device/SENSOR' } @subs ),
-		'[MQTT-Sensors §1] Subscribed to tele/SENSOR' );
-}
-
-# Test LWT handling
-{
-	my $mqtt = MockMQTT->new();
-	my $base = OpenHAP::Tasmota::Base->new(
-		aid         => 2,
-		name        => 'Test Base',
-		mqtt_topic  => 'test_device',
-		mqtt_client => $mqtt,
-	);
-
-	$base->subscribe_mqtt();
-
-	# Simulate Online message
-	$mqtt->simulate_message( 'tele/test_device/LWT', 'Online' );
-	is( $base->{availability},
-		AVAILABILITY_ONLINE,
-		'[MQTT-Transport §4.2] LWT Online sets availability' );
-	ok( $base->is_online(), 'is_online() returns true' );
-
-	# Check that Status 11 was queried
-	my @published = $mqtt->get_published();
-	ok( ( grep { $_->{topic} eq 'cmnd/test_device/Status'
-			    && $_->{payload} eq '11' } @published ),
-		'[MQTT-State §5.2] Status 11 queried on Online' );
-
-	# Simulate Offline message
-	$mqtt->simulate_message( 'tele/test_device/LWT', 'Offline' );
-	is( $base->{availability},
-		AVAILABILITY_OFFLINE,
-		'[MQTT-Transport §4.2] LWT Offline sets availability' );
-	ok( !$base->is_online(), 'is_online() returns false' );
-}
-
-# Test temperature conversion
-{
-	my $mqtt = MockMQTT->new();
-	my $base = OpenHAP::Tasmota::Base->new(
-		aid         => 2,
-		name        => 'Test Base',
-		mqtt_topic  => 'test_device',
-		mqtt_client => $mqtt,
-	);
-
-	# Test Celsius passthrough
 	$base->{temp_unit} = 'C';
-	is( $base->convert_temperature(25), 25, '[MQTT-Sensors §3] Celsius passthrough' );
+	is( $base->convert_temperature(25), 25, 'Celsius passthrough' );
 
-	# Test Fahrenheit to Celsius conversion
 	$base->{temp_unit} = 'F';
 	my $celsius = $base->convert_temperature(77);    # 77F = 25C
-	ok( abs( $celsius - 25 ) < 0.1, '[MQTT-Sensors §3] Fahrenheit to Celsius conversion' );
+	ok( abs( $celsius - 25 ) < 0.1, 'Fahrenheit to Celsius conversion' );
 
-	# Test 32F = 0C
 	$celsius = $base->convert_temperature(32);
-	ok( abs($celsius) < 0.1, '[MQTT-Sensors §3] 32F = 0C' );
+	ok( abs($celsius) < 0.1, '32F = 0C' );
 }
 
-# Test multi-relay support
+# Test Heater construction and initial state
 {
-	my $mqtt = MockMQTT->new();
-
-	# Default (no index)
-	my $heater1 = OpenHAP::Tasmota::Heater->new(
-		aid         => 2,
-		name        => 'Heater 1',
-		mqtt_topic  => 'device',
-		mqtt_client => $mqtt,
-	);
-
-	is( $heater1->_get_power_key(),   'POWER',           '[MQTT-Control §1] No index: POWER' );
-	is( $heater1->_get_power_topic(), 'cmnd/device/Power', 'No index topic' );
-
-	# With relay index
-	my $heater2 = OpenHAP::Tasmota::Heater->new(
-		aid         => 3,
-		name        => 'Heater 2',
-		mqtt_topic  => 'device',
-		mqtt_client => $mqtt,
-		relay_index => 2,
-	);
-
-	is( $heater2->_get_power_key(), 'POWER2', '[MQTT-Control §1] Index 2: POWER2' );
-	is( $heater2->_get_power_topic(),
-		'cmnd/device/Power2', 'Index 2 topic' );
-}
-
-# Test Heater device
-{
-	my $mqtt = MockMQTT->new();
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
 	my $heater = OpenHAP::Tasmota::Heater->new(
 		aid         => 2,
 		name        => 'Test Heater',
@@ -218,66 +82,15 @@ use constant CAP_CT               => 4;
 		mqtt_client => $mqtt,
 	);
 
-	ok( defined $heater,            'Heater created' );
-	is( $heater->{power_state}, 0,  'Initial power state is off' );
-
-	$heater->subscribe_mqtt();
-
-	# Test power control
-	$mqtt->clear_published();
-	$heater->set_power(1);
-
-	my @published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/heater/Power', '[MQTT-Control §1] Power topic correct' );
-	is( $published[0]{payload}, 'ON',                '[MQTT-Control §1] Power ON sent' );
-
-	# Test TOGGLE
-	$mqtt->clear_published();
-	$heater->toggle_power();
-	@published = $mqtt->get_published();
-	is( $published[0]{payload}, 'TOGGLE', '[MQTT-Control §1] TOGGLE command works' );
-
-	# Test BLINK
-	$mqtt->clear_published();
-	$heater->blink(1);
-	@published = $mqtt->get_published();
-	is( $published[0]{payload}, 'BLINK', '[MQTT-Control §1] BLINK command works' );
-
-	$mqtt->clear_published();
-	$heater->blink(0);
-	@published = $mqtt->get_published();
-	is( $published[0]{payload}, 'BLINKOFF', '[MQTT-Control §1] BLINKOFF command works' );
+	ok( defined $heater, 'Heater created' );
+	is( $heater->{power_state}, 0, 'Initial power state is off' );
+	ok( $heater->can($_), "Heater has $_ method" )
+	    for qw(set_power toggle_power blink subscribe_mqtt);
 }
 
-# Test Heater state updates
+# Test Sensor construction and initial state
 {
-	my $mqtt = MockMQTT->new();
-	my $heater = OpenHAP::Tasmota::Heater->new(
-		aid         => 2,
-		name        => 'Test Heater',
-		mqtt_topic  => 'heater',
-		mqtt_client => $mqtt,
-	);
-
-	$heater->subscribe_mqtt();
-
-	# Test RESULT message
-	$mqtt->simulate_message( 'stat/heater/RESULT', '{"POWER":"ON"}' );
-	is( $heater->{power_state}, 1, '[MQTT-State §4] RESULT updates power state' );
-
-	# Test plain POWER message
-	$mqtt->simulate_message( 'stat/heater/POWER', 'OFF' );
-	is( $heater->{power_state}, 0, '[MQTT-State §1] plain POWER updates power state' );
-
-	# Test STATE message
-	$mqtt->simulate_message( 'tele/heater/STATE',
-		'{"POWER":"ON","Uptime":"1T00:00:00"}' );
-	is( $heater->{power_state}, 1, '[MQTT-State §3] STATE updates power state' );
-}
-
-# Test Sensor device with multiple sensor types
-{
-	my $mqtt = MockMQTT->new();
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
 	my $sensor = OpenHAP::Tasmota::Sensor->new(
 		aid         => 2,
 		name        => 'Test Sensor',
@@ -287,84 +100,11 @@ use constant CAP_CT               => 4;
 
 	ok( defined $sensor, 'Sensor created' );
 	is( $sensor->{current_temp}, 20.0, 'Initial temperature' );
-
-	$sensor->subscribe_mqtt();
-
-	# Test DS18B20 sensor
-	$mqtt->simulate_message( 'tele/sensor/SENSOR',
-		'{"Time":"2024-01-01T00:00:00","DS18B20":{"Temperature":25.5},"TempUnit":"C"}'
-	);
-	is( $sensor->{current_temp}, 25.5, '[MQTT-Sensors §2] DS18B20 temperature updated' );
-	is( $sensor->{sensor_type}, 'DS18B20', '[MQTT-Sensors §2] sensor type auto-detected' );
 }
 
-# Test Sensor with Fahrenheit
+# Test Thermostat construction and initial state
 {
-	my $mqtt = MockMQTT->new();
-	my $sensor = OpenHAP::Tasmota::Sensor->new(
-		aid         => 2,
-		name        => 'Test Sensor',
-		mqtt_topic  => 'sensor',
-		mqtt_client => $mqtt,
-	);
-
-	$sensor->subscribe_mqtt();
-
-	# Simulate Fahrenheit reading
-	$mqtt->simulate_message( 'tele/sensor/SENSOR',
-		'{"Time":"2024-01-01T00:00:00","DS18B20":{"Temperature":77},"TempUnit":"F"}'
-	);
-
-	# 77F = 25C
-	ok( abs( $sensor->{current_temp} - 25 ) < 0.1,
-		'[MQTT-Sensors §3] Fahrenheit converted to Celsius' );
-}
-
-# Test Sensor with DHT22
-{
-	my $mqtt = MockMQTT->new();
-	my $sensor = OpenHAP::Tasmota::Sensor->new(
-		aid          => 2,
-		name         => 'DHT Sensor',
-		mqtt_topic   => 'dht',
-		mqtt_client  => $mqtt,
-		has_humidity => 1,
-	);
-
-	$sensor->subscribe_mqtt();
-
-	$mqtt->simulate_message( 'tele/dht/SENSOR',
-		'{"DHT22":{"Temperature":22.5,"Humidity":65},"TempUnit":"C"}' );
-
-	is( $sensor->{current_temp},     22.5, '[MQTT-Sensors §4] DHT22 temperature' );
-	is( $sensor->{current_humidity}, 65,   '[MQTT-Sensors §4] DHT22 humidity' );
-	is( $sensor->{sensor_type}, 'DHT22', '[MQTT-Sensors §2] DHT22 auto-detected' );
-}
-
-# Test Sensor with indexed sensors
-{
-	my $mqtt = MockMQTT->new();
-	my $sensor = OpenHAP::Tasmota::Sensor->new(
-		aid          => 2,
-		name         => 'Multi Sensor',
-		mqtt_topic   => 'multi',
-		mqtt_client  => $mqtt,
-		sensor_type  => 'DS18B20',
-		sensor_index => 2,
-	);
-
-	$sensor->subscribe_mqtt();
-
-	$mqtt->simulate_message( 'tele/multi/SENSOR',
-		'{"DS18B20-1":{"Temperature":20},"DS18B20-2":{"Temperature":25},"TempUnit":"C"}'
-	);
-
-	is( $sensor->{current_temp}, 25, '[MQTT-Sensors §3] indexed sensor DS18B20-2' );
-}
-
-# Test Thermostat device
-{
-	my $mqtt = MockMQTT->new();
+	my $mqtt       = OpenHAP::TestMock::MQTT->new;
 	my $thermostat = OpenHAP::Tasmota::Thermostat->new(
 		aid         => 2,
 		name        => 'Test Thermostat',
@@ -375,508 +115,54 @@ use constant CAP_CT               => 4;
 	ok( defined $thermostat, 'Thermostat created' );
 	is( $thermostat->{current_temp},  20.0, 'Initial current temp' );
 	is( $thermostat->{target_temp},   20.0, 'Initial target temp' );
-	is( $thermostat->{heating_state}, 0,    'Initial heating state off' );
-
-	$thermostat->subscribe_mqtt();
-
-	# Check Status 10 was queried (recommended per spec)
-	my @published = $mqtt->get_published();
-	ok( ( grep { $_->{topic} eq 'cmnd/thermostat/Status'
-			    && $_->{payload} eq '10' } @published ),
-		'[MQTT-Control §5] Status 10 queried on subscribe' );
+	is( $thermostat->{heating_state}, 0, 'Initial heating state off' );
 }
 
-# Test Thermostat temperature updates
+# Test Lightbulb construction and initial state
 {
-	my $mqtt = MockMQTT->new();
-	my $thermostat = OpenHAP::Tasmota::Thermostat->new(
-		aid         => 2,
-		name        => 'Test Thermostat',
-		mqtt_topic  => 'thermostat',
-		mqtt_client => $mqtt,
-	);
-
-	$thermostat->subscribe_mqtt();
-
-	# Test SENSOR message
-	$mqtt->simulate_message( 'tele/thermostat/SENSOR',
-		'{"DS18B20":{"Temperature":22.5},"TempUnit":"C"}' );
-	is( $thermostat->{current_temp}, 22.5, '[MQTT-Sensors §1] SENSOR updates temperature' );
-
-	# Test STATUS8 response
-	$mqtt->simulate_message( 'stat/thermostat/STATUS8',
-		'{"StatusSNS":{"DS18B20":{"Temperature":23},"TempUnit":"C"}}' );
-	is( $thermostat->{current_temp}, 23, '[MQTT-Control §5] STATUS8 updates temperature' );
-}
-
-# Test Lightbulb device
-{
-	my $mqtt = MockMQTT->new();
+	my $mqtt      = OpenHAP::TestMock::MQTT->new;
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
 		aid          => 2,
 		name         => 'Test Light',
 		mqtt_topic   => 'light',
 		mqtt_client  => $mqtt,
-		capabilities => CAP_DIMMER
-		    | CAP_COLOR
-		    | CAP_CT,
+		capabilities => $CAP_DIMMER | $CAP_COLOR | $CAP_CT,
 	);
 
 	ok( defined $lightbulb, 'Lightbulb created' );
 	is( $lightbulb->{power_state}, 0,   'Initial power off' );
 	is( $lightbulb->{brightness},  100, 'Initial brightness 100' );
-
-	$lightbulb->subscribe_mqtt();
 }
 
-# Test Lightbulb Dimmer control
+# Test RGB to HSB conversion helper math
 {
-	my $mqtt = MockMQTT->new();
-	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
-		aid          => 2,
-		name         => 'Test Light',
-		mqtt_topic   => 'light',
-		mqtt_client  => $mqtt,
-		capabilities => CAP_DIMMER,
-	);
-
-	$lightbulb->subscribe_mqtt();
-
-	# Test brightness control
-	$mqtt->clear_published();
-	$lightbulb->_set_brightness(75);
-
-	my @published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/light/Dimmer', '[MQTT-Control §2] Dimmer topic' );
-	is( $published[0]{payload}, '75',                '[MQTT-Control §2] Dimmer value' );
-
-	# Test dimmer step commands
-	$mqtt->clear_published();
-	$lightbulb->dimmer_step('+');
-	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '+', '[MQTT-Control §2] Dimmer step +' );
-
-	$mqtt->clear_published();
-	$lightbulb->dimmer_step('-');
-	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '-', '[MQTT-Control §2] Dimmer step -' );
-
-	$mqtt->clear_published();
-	$lightbulb->dimmer_min();
-	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '<', '[MQTT-Control §2] Dimmer min' );
-
-	$mqtt->clear_published();
-	$lightbulb->dimmer_max();
-	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '>', '[MQTT-Control §2] Dimmer max' );
-}
-
-# Test Lightbulb Color control
-{
-	my $mqtt = MockMQTT->new();
-	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
-		aid          => 2,
-		name         => 'Test Light',
-		mqtt_topic   => 'light',
-		mqtt_client  => $mqtt,
-		capabilities => CAP_DIMMER
-		    | CAP_COLOR,
-	);
-
-	$lightbulb->subscribe_mqtt();
-
-	# Test hue control
-	$mqtt->clear_published();
-	$lightbulb->_set_hue(240);
-	my @published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/light/HSBColor1', '[MQTT-Control §3.1] Hue topic' );
-	is( $published[0]{payload}, '240',                  '[MQTT-Control §3.1] Hue value' );
-
-	# Test saturation control
-	$mqtt->clear_published();
-	$lightbulb->_set_saturation(80);
-	@published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/light/HSBColor2', '[MQTT-Control §3.1] Saturation topic' );
-	is( $published[0]{payload}, '80',                   '[MQTT-Control §3.1] Saturation value' );
-
-	# Test combined color
-	$mqtt->clear_published();
-	$lightbulb->set_color( 120, 100, 50 );
-	@published = $mqtt->get_published();
-	is( $published[0]{topic}, 'cmnd/light/HSBColor', '[MQTT-Control §3.1] HSBColor topic' );
-	is( $published[0]{payload}, '120,100,50', '[MQTT-Control §3.1] HSBColor value' );
-}
-
-# Test Lightbulb CT control
-{
-	my $mqtt = MockMQTT->new();
-	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
-		aid          => 2,
-		name         => 'Test Light',
-		mqtt_topic   => 'light',
-		mqtt_client  => $mqtt,
-		capabilities => CAP_CT,
-	);
-
-	$lightbulb->subscribe_mqtt();
-
-	# Test CT control
-	$mqtt->clear_published();
-	$lightbulb->_set_ct(300);
-	my @published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/light/CT', '[MQTT-Control §4] CT topic' );
-	is( $published[0]{payload}, '300',           '[MQTT-Control §4] CT value' );
-
-	# Test CT clamping (min)
-	$mqtt->clear_published();
-	$lightbulb->_set_ct(100);    # Below min 153
-	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '153', '[MQTT-Control §4] CT clamped to min' );
-}
-
-# Test Lightbulb state updates from RESULT
-{
-	my $mqtt = MockMQTT->new();
-	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
-		aid          => 2,
-		name         => 'Test Light',
-		mqtt_topic   => 'light',
-		mqtt_client  => $mqtt,
-		capabilities => CAP_DIMMER
-		    | CAP_COLOR
-		    | CAP_CT,
-	);
-
-	$lightbulb->subscribe_mqtt();
-
-	# Test RESULT with dimmer
-	$mqtt->simulate_message( 'stat/light/RESULT', '{"Dimmer":75}' );
-	is( $lightbulb->{brightness}, 75, '[MQTT-State §4] RESULT updates brightness' );
-
-	# Test RESULT with HSBColor
-	$mqtt->simulate_message( 'stat/light/RESULT',
-		'{"HSBColor":"180,50,80"}' );
-	is( $lightbulb->{hue},        180, '[MQTT-State §4] RESULT updates hue' );
-	is( $lightbulb->{saturation}, 50,  '[MQTT-State §4] RESULT updates saturation' );
-	is( $lightbulb->{brightness}, 80,  '[MQTT-State §4] RESULT updates brightness from HSB' );
-
-	# Test RESULT with CT
-	$mqtt->simulate_message( 'stat/light/RESULT', '{"CT":250}' );
-	is( $lightbulb->{ct}, 250, '[MQTT-State §4] RESULT updates CT' );
-
-	# Test STATE message
-	$mqtt->simulate_message( 'tele/light/STATE',
-		'{"POWER":"ON","Dimmer":60,"HSBColor":"90,100,60","CT":400}' );
-	is( $lightbulb->{power_state}, 1,  '[MQTT-State §3] STATE updates power' );
-	is( $lightbulb->{brightness},  60, '[MQTT-State §3] STATE updates brightness' );
-}
-
-# ==============================================================================
-# New tests for compliance fixes
-# ==============================================================================
-
-# Test FullTopic support
-{
-	my $mqtt = MockMQTT->new();
-	my $base = OpenHAP::Tasmota::Base->new(
-		aid         => 2,
-		name        => 'FullTopic Test',
-		mqtt_topic  => 'bedroom_light',
-		mqtt_client => $mqtt,
-		fulltopic   => 'tasmota/%topic%/%prefix%/',
-	);
-
-	# Test custom FullTopic pattern
-	is( $base->_build_topic( 'cmnd', 'Power' ),
-		'tasmota/bedroom_light/cmnd/Power',
-		'[MQTT-Transport §1.2] custom FullTopic builds correctly' );
-
-	is( $base->_build_topic( 'stat', 'RESULT' ),
-		'tasmota/bedroom_light/stat/RESULT',
-		'[MQTT-Transport §1.2] FullTopic stat topic correct' );
-
-	is( $base->_build_topic( 'tele', 'STATE' ),
-		'tasmota/bedroom_light/tele/STATE',
-		'[MQTT-Transport §1.2] FullTopic tele topic correct' );
-}
-
-# Test default FullTopic
-{
-	my $mqtt = MockMQTT->new();
-	my $base = OpenHAP::Tasmota::Base->new(
-		aid         => 2,
-		name        => 'Default FullTopic',
-		mqtt_topic  => 'test_device',
-		mqtt_client => $mqtt,
-	);
-
-	is( $base->_build_topic( 'cmnd', 'Power' ),
-		'cmnd/test_device/Power',
-		'[MQTT-Transport §1.2] default FullTopic works' );
-}
-
-# Test SetOption26 support
-{
-	my $mqtt = MockMQTT->new();
-
-	# Without SetOption26
-	my $heater1 = OpenHAP::Tasmota::Heater->new(
-		aid         => 2,
-		name        => 'Normal Heater',
-		mqtt_topic  => 'device',
-		mqtt_client => $mqtt,
-	);
-
-	is( $heater1->_get_power_key(), 'POWER',
-		'[MQTT-Control §1] without SetOption26 uses POWER' );
-
-	# With SetOption26
-	my $heater2 = OpenHAP::Tasmota::Heater->new(
-		aid         => 3,
-		name        => 'SetOption26 Heater',
-		mqtt_topic  => 'device',
-		mqtt_client => $mqtt,
-		setoption26 => 1,
-	);
-
-	is( $heater2->_get_power_key(), 'POWER1',
-		'[MQTT-Control §1] with SetOption26 uses POWER1' );
-	is( $heater2->_get_power_topic(), 'cmnd/device/Power1',
-		'[MQTT-Control §1] SetOption26 power topic correct' );
-}
-
-# Test STATUS11 handling
-{
-	my $mqtt = MockMQTT->new();
-	my $heater = OpenHAP::Tasmota::Heater->new(
-		aid         => 2,
-		name        => 'Status11 Test',
-		mqtt_topic  => 'device',
-		mqtt_client => $mqtt,
-	);
-
-	$heater->subscribe_mqtt();
-
-	# Check STATUS11 subscription exists
-	my @subs = $mqtt->get_subscriptions();
-	ok( ( grep { $_ eq 'stat/device/STATUS11' } @subs ),
-		'[MQTT-Control §5] Subscribed to STATUS11' );
-
-	# Simulate STATUS11 response
-	my $status11 = '{"StatusSTS":{"POWER":"ON","Uptime":"1T00:00:00"}}';
-	$mqtt->simulate_message( 'stat/device/STATUS11', $status11 );
-	is( $heater->{power_state}, 1, '[MQTT-Control §5] STATUS11 updates power state' );
-}
-
-# Test Status 11 query on LWT Online
-{
-	my $mqtt = MockMQTT->new();
-	my $base = OpenHAP::Tasmota::Base->new(
-		aid         => 2,
-		name        => 'Query Test',
-		mqtt_topic  => 'device',
-		mqtt_client => $mqtt,
-	);
-
-	$base->subscribe_mqtt();
-	$mqtt->clear_published();
-
-	# Simulate LWT Online
-	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );
-
-	# Verify Status 11 was queried (not Status 0)
-	my @published = $mqtt->get_published();
-	ok( ( grep { $_->{topic} eq 'cmnd/device/Status'
-			    && $_->{payload} eq '11' } @published ),
-		'[MQTT-State §5.2] Status 11 queried on Online' );
-}
-
-# Test force_telemetry
-{
-	my $mqtt = MockMQTT->new();
-	my $base = OpenHAP::Tasmota::Base->new(
-		aid         => 2,
-		name        => 'Telemetry Test',
-		mqtt_topic  => 'device',
-		mqtt_client => $mqtt,
-	);
-
-	$mqtt->clear_published();
-	$base->force_telemetry();
-
-	my @published = $mqtt->get_published();
-	ok( ( grep { $_->{topic} eq 'cmnd/device/TelePeriod' } @published ),
-		'[MQTT-Sensors §5.1] TelePeriod command sent' );
-}
-
-# Test SetOption4 topic subscriptions for Lightbulb
-{
-	my $mqtt = MockMQTT->new();
-	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
-		aid          => 2,
-		name         => 'SetOption4 Light',
-		mqtt_topic   => 'light',
-		mqtt_client  => $mqtt,
-		capabilities => CAP_DIMMER | CAP_COLOR | CAP_CT,
-	);
-
-	$lightbulb->subscribe_mqtt();
-
-	my @subs = $mqtt->get_subscriptions();
-
-	ok( ( grep { $_ eq 'stat/light/DIMMER' } @subs ),
-		'[MQTT-Transport §3.2] SetOption4: subscribed to DIMMER topic' );
-	ok( ( grep { $_ eq 'stat/light/HSBCOLOR' } @subs ),
-		'[MQTT-Transport §3.2] SetOption4: subscribed to HSBCOLOR topic' );
-	ok( ( grep { $_ eq 'stat/light/CT' } @subs ),
-		'[MQTT-Transport §3.2] SetOption4: subscribed to CT topic' );
-}
-
-# Test SetOption17 decimal color format
-{
-	my $mqtt = MockMQTT->new();
-	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
-		aid          => 2,
-		name         => 'Color Test',
-		mqtt_topic   => 'light',
-		mqtt_client  => $mqtt,
-		capabilities => CAP_COLOR,
-	);
-
-	$lightbulb->subscribe_mqtt();
-
-	# Test hex color format (default)
-	$mqtt->simulate_message( 'stat/light/RESULT',
-		'{"Color":"FF0000"}' );
-	is( $lightbulb->{hue}, 0, '[MQTT-Control §3.2] hex color red hue=0' );
-
-	# Test decimal color format (SetOption17 1)
-	$mqtt->simulate_message( 'stat/light/RESULT',
-		'{"Color":"0,255,0"}' );
-	is( $lightbulb->{hue}, 120, '[MQTT-Control §3.2] SetOption17 decimal color green hue=120' );
-
-	# Test blue
-	$mqtt->simulate_message( 'stat/light/RESULT',
-		'{"Color":"0,0,255"}' );
-	is( $lightbulb->{hue}, 240, '[MQTT-Control §3.2] SetOption17 decimal color blue hue=240' );
-}
-
-# Test CT range clamping
-{
-	my $mqtt = MockMQTT->new();
-	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
-		aid          => 2,
-		name         => 'CT Test',
-		mqtt_topic   => 'light',
-		mqtt_client  => $mqtt,
-		capabilities => CAP_CT,
-	);
-
-	$lightbulb->subscribe_mqtt();
-
-	# Verify HomeKit min is 153 (not 140)
-	# The characteristic is defined in new(), check the clamping behavior
-	$mqtt->simulate_message( 'stat/light/RESULT', '{"CT":100}' );
-	is( $lightbulb->{ct}, 153, '[MQTT-Control §4] CT clamped to min 153' );
-
-	$mqtt->simulate_message( 'stat/light/RESULT', '{"CT":600}' );
-	is( $lightbulb->{ct}, 500, '[MQTT-Control §4] CT clamped to max 500' );
-}
-
-# Test sensor ID tracking
-{
-	my $mqtt = MockMQTT->new();
-	my $sensor = OpenHAP::Tasmota::Sensor->new(
-		aid         => 2,
-		name        => 'ID Sensor',
-		mqtt_topic  => 'sensor',
-		mqtt_client => $mqtt,
-	);
-
-	$sensor->subscribe_mqtt();
-
-	# Simulate SENSOR with ID
-	$mqtt->simulate_message( 'tele/sensor/SENSOR',
-		'{"DS18B20":{"Id":"01131B123456","Temperature":22.5},"TempUnit":"C"}'
-	);
-
-	is( $sensor->{sensor_id}, '01131B123456', '[MQTT-Sensors §3] sensor Id tracked' );
-}
-
-# Test STATUS10 subscription for sensors
-{
-	my $mqtt = MockMQTT->new();
-	my $sensor = OpenHAP::Tasmota::Sensor->new(
-		aid         => 2,
-		name        => 'STATUS10 Test',
-		mqtt_topic  => 'sensor',
-		mqtt_client => $mqtt,
-	);
-
-	$sensor->subscribe_mqtt();
-
-	my @subs = $mqtt->get_subscriptions();
-	ok( ( grep { $_ eq 'stat/sensor/STATUS10' } @subs ),
-		'[MQTT-Control §5] Subscribed to STATUS10' );
-
-	# Simulate STATUS10 response
-	$mqtt->simulate_message( 'stat/sensor/STATUS10',
-		'{"StatusSNS":{"DS18B20":{"Temperature":26},"TempUnit":"C"}}' );
-	is( $sensor->{current_temp}, 26, '[MQTT-Control §5] STATUS10 updates temperature' );
-}
-
-# Test RGB to HSB conversion accuracy
-{
-	my $mqtt = MockMQTT->new();
+	my $mqtt      = OpenHAP::TestMock::MQTT->new;
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
 		aid          => 2,
 		name         => 'RGB Test',
 		mqtt_topic   => 'light',
 		mqtt_client  => $mqtt,
-		capabilities => CAP_COLOR,
+		capabilities => $CAP_COLOR,
 	);
 
-	# Test pure red
 	my ( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 255, 0, 0 );
-	is( $h, 0,   '[MQTT-Control §3.2] RGB red: hue=0' );
+	is( $h, 0,   'RGB red: hue=0' );
 	is( $s, 100, 'RGB red: saturation=100' );
 	is( $b, 100, 'RGB red: brightness=100' );
 
-	# Test pure green
 	( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 0, 255, 0 );
-	is( $h, 120, '[MQTT-Control §3.2] RGB green: hue=120' );
+	is( $h, 120, 'RGB green: hue=120' );
 
-	# Test pure blue
 	( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 0, 0, 255 );
-	is( $h, 240, '[MQTT-Control §3.2] RGB blue: hue=240' );
+	is( $h, 240, 'RGB blue: hue=240' );
 
-	# Test white (no saturation)
 	( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 255, 255, 255 );
 	is( $s, 0,   'RGB white: saturation=0' );
 	is( $b, 100, 'RGB white: brightness=100' );
 
-	# Test 50% gray
 	( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 128, 128, 128 );
 	is( $s, 0,  'RGB gray: saturation=0' );
 	is( $b, 50, 'RGB gray: brightness=50' );
-}
-
-# Test FullTopic with multi-relay and SetOption26
-{
-	my $mqtt = MockMQTT->new();
-	my $base = OpenHAP::Tasmota::Base->new(
-		aid         => 2,
-		name        => 'FullTopic Relay',
-		mqtt_topic  => 'device',
-		mqtt_client => $mqtt,
-		relay_index => 2,
-		fulltopic   => 'home/%topic%/%prefix%/',
-	);
-
-	is( $base->_get_power_topic(),
-		'home/device/cmnd/Power2',
-		'FullTopic + relay_index builds correct topic' );
 }
 
 done_testing();

--- a/t/openhap/tasmota.t
+++ b/t/openhap/tasmota.t
@@ -99,7 +99,7 @@ use constant CAP_CT               => 4;
 		'Initial availability is unknown' );
 }
 
-# Test Base MQTT subscriptions (C1, C2, C3)
+# Test Base MQTT subscriptions
 {
 	my $mqtt = MockMQTT->new();
 	my $base = OpenHAP::Tasmota::Base->new(
@@ -113,16 +113,16 @@ use constant CAP_CT               => 4;
 
 	my @subs = $mqtt->get_subscriptions();
 	ok( ( grep { $_ eq 'tele/test_device/LWT' } @subs ),
-		'C1: Subscribed to LWT' );
+		'[MQTT-Transport §1.4] Subscribed to LWT' );
 	ok( ( grep { $_ eq 'tele/test_device/STATE' } @subs ),
-		'C2: Subscribed to tele/STATE' );
+		'[MQTT-State §2] Subscribed to tele/STATE' );
 	ok( ( grep { $_ eq 'stat/test_device/RESULT' } @subs ),
-		'C3: Subscribed to stat/RESULT' );
+		'[MQTT-State §1] Subscribed to stat/RESULT' );
 	ok( ( grep { $_ eq 'tele/test_device/SENSOR' } @subs ),
-		'Subscribed to tele/SENSOR' );
+		'[MQTT-Sensors §1] Subscribed to tele/SENSOR' );
 }
 
-# Test LWT handling (C1)
+# Test LWT handling
 {
 	my $mqtt = MockMQTT->new();
 	my $base = OpenHAP::Tasmota::Base->new(
@@ -138,24 +138,24 @@ use constant CAP_CT               => 4;
 	$mqtt->simulate_message( 'tele/test_device/LWT', 'Online' );
 	is( $base->{availability},
 		AVAILABILITY_ONLINE,
-		'LWT Online sets availability' );
+		'[MQTT-Transport §4.2] LWT Online sets availability' );
 	ok( $base->is_online(), 'is_online() returns true' );
 
-	# Check that Status 11 was queried (C1/H1)
+	# Check that Status 11 was queried
 	my @published = $mqtt->get_published();
 	ok( ( grep { $_->{topic} eq 'cmnd/test_device/Status'
 			    && $_->{payload} eq '11' } @published ),
-		'C1/H1: Status 11 queried on Online' );
+		'[MQTT-State §5.2] Status 11 queried on Online' );
 
 	# Simulate Offline message
 	$mqtt->simulate_message( 'tele/test_device/LWT', 'Offline' );
 	is( $base->{availability},
 		AVAILABILITY_OFFLINE,
-		'LWT Offline sets availability' );
+		'[MQTT-Transport §4.2] LWT Offline sets availability' );
 	ok( !$base->is_online(), 'is_online() returns false' );
 }
 
-# Test temperature conversion (H4)
+# Test temperature conversion
 {
 	my $mqtt = MockMQTT->new();
 	my $base = OpenHAP::Tasmota::Base->new(
@@ -167,19 +167,19 @@ use constant CAP_CT               => 4;
 
 	# Test Celsius passthrough
 	$base->{temp_unit} = 'C';
-	is( $base->convert_temperature(25), 25, 'Celsius passthrough' );
+	is( $base->convert_temperature(25), 25, '[MQTT-Sensors §3] Celsius passthrough' );
 
 	# Test Fahrenheit to Celsius conversion
 	$base->{temp_unit} = 'F';
 	my $celsius = $base->convert_temperature(77);    # 77F = 25C
-	ok( abs( $celsius - 25 ) < 0.1, 'Fahrenheit to Celsius conversion' );
+	ok( abs( $celsius - 25 ) < 0.1, '[MQTT-Sensors §3] Fahrenheit to Celsius conversion' );
 
 	# Test 32F = 0C
 	$celsius = $base->convert_temperature(32);
-	ok( abs($celsius) < 0.1, '32F = 0C' );
+	ok( abs($celsius) < 0.1, '[MQTT-Sensors §3] 32F = 0C' );
 }
 
-# Test multi-relay support (H1)
+# Test multi-relay support
 {
 	my $mqtt = MockMQTT->new();
 
@@ -191,7 +191,7 @@ use constant CAP_CT               => 4;
 		mqtt_client => $mqtt,
 	);
 
-	is( $heater1->_get_power_key(),   'POWER',           'No index: POWER' );
+	is( $heater1->_get_power_key(),   'POWER',           '[MQTT-Control §1] No index: POWER' );
 	is( $heater1->_get_power_topic(), 'cmnd/device/Power', 'No index topic' );
 
 	# With relay index
@@ -203,7 +203,7 @@ use constant CAP_CT               => 4;
 		relay_index => 2,
 	);
 
-	is( $heater2->_get_power_key(), 'POWER2', 'Index 2: POWER2' );
+	is( $heater2->_get_power_key(), 'POWER2', '[MQTT-Control §1] Index 2: POWER2' );
 	is( $heater2->_get_power_topic(),
 		'cmnd/device/Power2', 'Index 2 topic' );
 }
@@ -228,25 +228,25 @@ use constant CAP_CT               => 4;
 	$heater->set_power(1);
 
 	my @published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/heater/Power', 'Power topic correct' );
-	is( $published[0]{payload}, 'ON',                'Power ON sent' );
+	is( $published[0]{topic},   'cmnd/heater/Power', '[MQTT-Control §1] Power topic correct' );
+	is( $published[0]{payload}, 'ON',                '[MQTT-Control §1] Power ON sent' );
 
-	# Test TOGGLE (L1)
+	# Test TOGGLE
 	$mqtt->clear_published();
 	$heater->toggle_power();
 	@published = $mqtt->get_published();
-	is( $published[0]{payload}, 'TOGGLE', 'L1: TOGGLE command works' );
+	is( $published[0]{payload}, 'TOGGLE', '[MQTT-Control §1] TOGGLE command works' );
 
-	# Test BLINK (L2)
+	# Test BLINK
 	$mqtt->clear_published();
 	$heater->blink(1);
 	@published = $mqtt->get_published();
-	is( $published[0]{payload}, 'BLINK', 'L2: BLINK command works' );
+	is( $published[0]{payload}, 'BLINK', '[MQTT-Control §1] BLINK command works' );
 
 	$mqtt->clear_published();
 	$heater->blink(0);
 	@published = $mqtt->get_published();
-	is( $published[0]{payload}, 'BLINKOFF', 'L2: BLINKOFF command works' );
+	is( $published[0]{payload}, 'BLINKOFF', '[MQTT-Control §1] BLINKOFF command works' );
 }
 
 # Test Heater state updates
@@ -261,21 +261,21 @@ use constant CAP_CT               => 4;
 
 	$heater->subscribe_mqtt();
 
-	# Test RESULT message (C3)
+	# Test RESULT message
 	$mqtt->simulate_message( 'stat/heater/RESULT', '{"POWER":"ON"}' );
-	is( $heater->{power_state}, 1, 'C3: RESULT updates power state' );
+	is( $heater->{power_state}, 1, '[MQTT-State §4] RESULT updates power state' );
 
-	# Test plain POWER message (M3)
+	# Test plain POWER message
 	$mqtt->simulate_message( 'stat/heater/POWER', 'OFF' );
-	is( $heater->{power_state}, 0, 'M3: POWER updates power state' );
+	is( $heater->{power_state}, 0, '[MQTT-State §1] plain POWER updates power state' );
 
-	# Test STATE message (C2)
+	# Test STATE message
 	$mqtt->simulate_message( 'tele/heater/STATE',
 		'{"POWER":"ON","Uptime":"1T00:00:00"}' );
-	is( $heater->{power_state}, 1, 'C2: STATE updates power state' );
+	is( $heater->{power_state}, 1, '[MQTT-State §3] STATE updates power state' );
 }
 
-# Test Sensor device (H5 - multiple sensor types)
+# Test Sensor device with multiple sensor types
 {
 	my $mqtt = MockMQTT->new();
 	my $sensor = OpenHAP::Tasmota::Sensor->new(
@@ -294,11 +294,11 @@ use constant CAP_CT               => 4;
 	$mqtt->simulate_message( 'tele/sensor/SENSOR',
 		'{"Time":"2024-01-01T00:00:00","DS18B20":{"Temperature":25.5},"TempUnit":"C"}'
 	);
-	is( $sensor->{current_temp}, 25.5, 'DS18B20 temperature updated' );
-	is( $sensor->{sensor_type}, 'DS18B20', 'Sensor type auto-detected' );
+	is( $sensor->{current_temp}, 25.5, '[MQTT-Sensors §2] DS18B20 temperature updated' );
+	is( $sensor->{sensor_type}, 'DS18B20', '[MQTT-Sensors §2] sensor type auto-detected' );
 }
 
-# Test Sensor with Fahrenheit (H4)
+# Test Sensor with Fahrenheit
 {
 	my $mqtt = MockMQTT->new();
 	my $sensor = OpenHAP::Tasmota::Sensor->new(
@@ -317,10 +317,10 @@ use constant CAP_CT               => 4;
 
 	# 77F = 25C
 	ok( abs( $sensor->{current_temp} - 25 ) < 0.1,
-		'H4: Fahrenheit converted to Celsius' );
+		'[MQTT-Sensors §3] Fahrenheit converted to Celsius' );
 }
 
-# Test Sensor with DHT22 (H5)
+# Test Sensor with DHT22
 {
 	my $mqtt = MockMQTT->new();
 	my $sensor = OpenHAP::Tasmota::Sensor->new(
@@ -336,12 +336,12 @@ use constant CAP_CT               => 4;
 	$mqtt->simulate_message( 'tele/dht/SENSOR',
 		'{"DHT22":{"Temperature":22.5,"Humidity":65},"TempUnit":"C"}' );
 
-	is( $sensor->{current_temp},     22.5, 'DHT22 temperature' );
-	is( $sensor->{current_humidity}, 65,   'DHT22 humidity' );
-	is( $sensor->{sensor_type}, 'DHT22', 'DHT22 auto-detected' );
+	is( $sensor->{current_temp},     22.5, '[MQTT-Sensors §4] DHT22 temperature' );
+	is( $sensor->{current_humidity}, 65,   '[MQTT-Sensors §4] DHT22 humidity' );
+	is( $sensor->{sensor_type}, 'DHT22', '[MQTT-Sensors §2] DHT22 auto-detected' );
 }
 
-# Test Sensor with indexed sensors (H5)
+# Test Sensor with indexed sensors
 {
 	my $mqtt = MockMQTT->new();
 	my $sensor = OpenHAP::Tasmota::Sensor->new(
@@ -359,7 +359,7 @@ use constant CAP_CT               => 4;
 		'{"DS18B20-1":{"Temperature":20},"DS18B20-2":{"Temperature":25},"TempUnit":"C"}'
 	);
 
-	is( $sensor->{current_temp}, 25, 'H5: Indexed sensor DS18B20-2' );
+	is( $sensor->{current_temp}, 25, '[MQTT-Sensors §3] indexed sensor DS18B20-2' );
 }
 
 # Test Thermostat device
@@ -383,7 +383,7 @@ use constant CAP_CT               => 4;
 	my @published = $mqtt->get_published();
 	ok( ( grep { $_->{topic} eq 'cmnd/thermostat/Status'
 			    && $_->{payload} eq '10' } @published ),
-		'Status 10 queried on subscribe' );
+		'[MQTT-Control §5] Status 10 queried on subscribe' );
 }
 
 # Test Thermostat temperature updates
@@ -401,15 +401,15 @@ use constant CAP_CT               => 4;
 	# Test SENSOR message
 	$mqtt->simulate_message( 'tele/thermostat/SENSOR',
 		'{"DS18B20":{"Temperature":22.5},"TempUnit":"C"}' );
-	is( $thermostat->{current_temp}, 22.5, 'SENSOR updates temperature' );
+	is( $thermostat->{current_temp}, 22.5, '[MQTT-Sensors §1] SENSOR updates temperature' );
 
 	# Test STATUS8 response
 	$mqtt->simulate_message( 'stat/thermostat/STATUS8',
 		'{"StatusSNS":{"DS18B20":{"Temperature":23},"TempUnit":"C"}}' );
-	is( $thermostat->{current_temp}, 23, 'STATUS8 updates temperature' );
+	is( $thermostat->{current_temp}, 23, '[MQTT-Control §5] STATUS8 updates temperature' );
 }
 
-# Test Lightbulb device (H2)
+# Test Lightbulb device
 {
 	my $mqtt = MockMQTT->new();
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
@@ -429,7 +429,7 @@ use constant CAP_CT               => 4;
 	$lightbulb->subscribe_mqtt();
 }
 
-# Test Lightbulb Dimmer control (H2)
+# Test Lightbulb Dimmer control
 {
 	my $mqtt = MockMQTT->new();
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
@@ -447,32 +447,32 @@ use constant CAP_CT               => 4;
 	$lightbulb->_set_brightness(75);
 
 	my @published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/light/Dimmer', 'Dimmer topic' );
-	is( $published[0]{payload}, '75',                'Dimmer value' );
+	is( $published[0]{topic},   'cmnd/light/Dimmer', '[MQTT-Control §2] Dimmer topic' );
+	is( $published[0]{payload}, '75',                '[MQTT-Control §2] Dimmer value' );
 
-	# Test dimmer step commands (L3)
+	# Test dimmer step commands
 	$mqtt->clear_published();
 	$lightbulb->dimmer_step('+');
 	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '+', 'L3: Dimmer step +' );
+	is( $published[0]{payload}, '+', '[MQTT-Control §2] Dimmer step +' );
 
 	$mqtt->clear_published();
 	$lightbulb->dimmer_step('-');
 	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '-', 'L3: Dimmer step -' );
+	is( $published[0]{payload}, '-', '[MQTT-Control §2] Dimmer step -' );
 
 	$mqtt->clear_published();
 	$lightbulb->dimmer_min();
 	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '<', 'L3: Dimmer min' );
+	is( $published[0]{payload}, '<', '[MQTT-Control §2] Dimmer min' );
 
 	$mqtt->clear_published();
 	$lightbulb->dimmer_max();
 	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '>', 'L3: Dimmer max' );
+	is( $published[0]{payload}, '>', '[MQTT-Control §2] Dimmer max' );
 }
 
-# Test Lightbulb Color control (H2)
+# Test Lightbulb Color control
 {
 	my $mqtt = MockMQTT->new();
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
@@ -490,25 +490,25 @@ use constant CAP_CT               => 4;
 	$mqtt->clear_published();
 	$lightbulb->_set_hue(240);
 	my @published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/light/HSBColor1', 'Hue topic' );
-	is( $published[0]{payload}, '240',                  'Hue value' );
+	is( $published[0]{topic},   'cmnd/light/HSBColor1', '[MQTT-Control §3.1] Hue topic' );
+	is( $published[0]{payload}, '240',                  '[MQTT-Control §3.1] Hue value' );
 
 	# Test saturation control
 	$mqtt->clear_published();
 	$lightbulb->_set_saturation(80);
 	@published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/light/HSBColor2', 'Saturation topic' );
-	is( $published[0]{payload}, '80',                   'Saturation value' );
+	is( $published[0]{topic},   'cmnd/light/HSBColor2', '[MQTT-Control §3.1] Saturation topic' );
+	is( $published[0]{payload}, '80',                   '[MQTT-Control §3.1] Saturation value' );
 
 	# Test combined color
 	$mqtt->clear_published();
 	$lightbulb->set_color( 120, 100, 50 );
 	@published = $mqtt->get_published();
-	is( $published[0]{topic}, 'cmnd/light/HSBColor', 'HSBColor topic' );
-	is( $published[0]{payload}, '120,100,50', 'HSBColor value' );
+	is( $published[0]{topic}, 'cmnd/light/HSBColor', '[MQTT-Control §3.1] HSBColor topic' );
+	is( $published[0]{payload}, '120,100,50', '[MQTT-Control §3.1] HSBColor value' );
 }
 
-# Test Lightbulb CT control (H2)
+# Test Lightbulb CT control
 {
 	my $mqtt = MockMQTT->new();
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
@@ -525,17 +525,17 @@ use constant CAP_CT               => 4;
 	$mqtt->clear_published();
 	$lightbulb->_set_ct(300);
 	my @published = $mqtt->get_published();
-	is( $published[0]{topic},   'cmnd/light/CT', 'CT topic' );
-	is( $published[0]{payload}, '300',           'CT value' );
+	is( $published[0]{topic},   'cmnd/light/CT', '[MQTT-Control §4] CT topic' );
+	is( $published[0]{payload}, '300',           '[MQTT-Control §4] CT value' );
 
 	# Test CT clamping (min)
 	$mqtt->clear_published();
 	$lightbulb->_set_ct(100);    # Below min 153
 	@published = $mqtt->get_published();
-	is( $published[0]{payload}, '153', 'CT clamped to min' );
+	is( $published[0]{payload}, '153', '[MQTT-Control §4] CT clamped to min' );
 }
 
-# Test Lightbulb state updates from RESULT (C3, H2)
+# Test Lightbulb state updates from RESULT
 {
 	my $mqtt = MockMQTT->new();
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
@@ -552,31 +552,31 @@ use constant CAP_CT               => 4;
 
 	# Test RESULT with dimmer
 	$mqtt->simulate_message( 'stat/light/RESULT', '{"Dimmer":75}' );
-	is( $lightbulb->{brightness}, 75, 'RESULT updates brightness' );
+	is( $lightbulb->{brightness}, 75, '[MQTT-State §4] RESULT updates brightness' );
 
 	# Test RESULT with HSBColor
 	$mqtt->simulate_message( 'stat/light/RESULT',
 		'{"HSBColor":"180,50,80"}' );
-	is( $lightbulb->{hue},        180, 'RESULT updates hue' );
-	is( $lightbulb->{saturation}, 50,  'RESULT updates saturation' );
-	is( $lightbulb->{brightness}, 80,  'RESULT updates brightness from HSB' );
+	is( $lightbulb->{hue},        180, '[MQTT-State §4] RESULT updates hue' );
+	is( $lightbulb->{saturation}, 50,  '[MQTT-State §4] RESULT updates saturation' );
+	is( $lightbulb->{brightness}, 80,  '[MQTT-State §4] RESULT updates brightness from HSB' );
 
 	# Test RESULT with CT
 	$mqtt->simulate_message( 'stat/light/RESULT', '{"CT":250}' );
-	is( $lightbulb->{ct}, 250, 'RESULT updates CT' );
+	is( $lightbulb->{ct}, 250, '[MQTT-State §4] RESULT updates CT' );
 
-	# Test STATE message (C2)
+	# Test STATE message
 	$mqtt->simulate_message( 'tele/light/STATE',
 		'{"POWER":"ON","Dimmer":60,"HSBColor":"90,100,60","CT":400}' );
-	is( $lightbulb->{power_state}, 1,  'STATE updates power' );
-	is( $lightbulb->{brightness},  60, 'STATE updates brightness' );
+	is( $lightbulb->{power_state}, 1,  '[MQTT-State §3] STATE updates power' );
+	is( $lightbulb->{brightness},  60, '[MQTT-State §3] STATE updates brightness' );
 }
 
 # ==============================================================================
 # New tests for compliance fixes
 # ==============================================================================
 
-# Test FullTopic support (H2)
+# Test FullTopic support
 {
 	my $mqtt = MockMQTT->new();
 	my $base = OpenHAP::Tasmota::Base->new(
@@ -590,18 +590,18 @@ use constant CAP_CT               => 4;
 	# Test custom FullTopic pattern
 	is( $base->_build_topic( 'cmnd', 'Power' ),
 		'tasmota/bedroom_light/cmnd/Power',
-		'H2: Custom FullTopic builds correctly' );
+		'[MQTT-Transport §1.2] custom FullTopic builds correctly' );
 
 	is( $base->_build_topic( 'stat', 'RESULT' ),
 		'tasmota/bedroom_light/stat/RESULT',
-		'H2: FullTopic stat topic correct' );
+		'[MQTT-Transport §1.2] FullTopic stat topic correct' );
 
 	is( $base->_build_topic( 'tele', 'STATE' ),
 		'tasmota/bedroom_light/tele/STATE',
-		'H2: FullTopic tele topic correct' );
+		'[MQTT-Transport §1.2] FullTopic tele topic correct' );
 }
 
-# Test default FullTopic (H2)
+# Test default FullTopic
 {
 	my $mqtt = MockMQTT->new();
 	my $base = OpenHAP::Tasmota::Base->new(
@@ -613,10 +613,10 @@ use constant CAP_CT               => 4;
 
 	is( $base->_build_topic( 'cmnd', 'Power' ),
 		'cmnd/test_device/Power',
-		'H2: Default FullTopic works' );
+		'[MQTT-Transport §1.2] default FullTopic works' );
 }
 
-# Test SetOption26 support (M1)
+# Test SetOption26 support
 {
 	my $mqtt = MockMQTT->new();
 
@@ -629,7 +629,7 @@ use constant CAP_CT               => 4;
 	);
 
 	is( $heater1->_get_power_key(), 'POWER',
-		'M1: Without SetOption26 uses POWER' );
+		'[MQTT-Control §1] without SetOption26 uses POWER' );
 
 	# With SetOption26
 	my $heater2 = OpenHAP::Tasmota::Heater->new(
@@ -641,12 +641,12 @@ use constant CAP_CT               => 4;
 	);
 
 	is( $heater2->_get_power_key(), 'POWER1',
-		'M1: With SetOption26 uses POWER1' );
+		'[MQTT-Control §1] with SetOption26 uses POWER1' );
 	is( $heater2->_get_power_topic(), 'cmnd/device/Power1',
-		'M1: SetOption26 power topic correct' );
+		'[MQTT-Control §1] SetOption26 power topic correct' );
 }
 
-# Test STATUS11 handling (C1/H1)
+# Test STATUS11 handling
 {
 	my $mqtt = MockMQTT->new();
 	my $heater = OpenHAP::Tasmota::Heater->new(
@@ -661,15 +661,15 @@ use constant CAP_CT               => 4;
 	# Check STATUS11 subscription exists
 	my @subs = $mqtt->get_subscriptions();
 	ok( ( grep { $_ eq 'stat/device/STATUS11' } @subs ),
-		'C1/H1: Subscribed to STATUS11' );
+		'[MQTT-Control §5] Subscribed to STATUS11' );
 
 	# Simulate STATUS11 response
 	my $status11 = '{"StatusSTS":{"POWER":"ON","Uptime":"1T00:00:00"}}';
 	$mqtt->simulate_message( 'stat/device/STATUS11', $status11 );
-	is( $heater->{power_state}, 1, 'C1/H1: STATUS11 updates power state' );
+	is( $heater->{power_state}, 1, '[MQTT-Control §5] STATUS11 updates power state' );
 }
 
-# Test Status 11 query on LWT Online (C1/H1)
+# Test Status 11 query on LWT Online
 {
 	my $mqtt = MockMQTT->new();
 	my $base = OpenHAP::Tasmota::Base->new(
@@ -689,10 +689,10 @@ use constant CAP_CT               => 4;
 	my @published = $mqtt->get_published();
 	ok( ( grep { $_->{topic} eq 'cmnd/device/Status'
 			    && $_->{payload} eq '11' } @published ),
-		'C1/H1: Status 11 queried on Online' );
+		'[MQTT-State §5.2] Status 11 queried on Online' );
 }
 
-# Test force_telemetry (L1)
+# Test force_telemetry
 {
 	my $mqtt = MockMQTT->new();
 	my $base = OpenHAP::Tasmota::Base->new(
@@ -707,10 +707,10 @@ use constant CAP_CT               => 4;
 
 	my @published = $mqtt->get_published();
 	ok( ( grep { $_->{topic} eq 'cmnd/device/TelePeriod' } @published ),
-		'L1: TelePeriod command sent' );
+		'[MQTT-Sensors §5.1] TelePeriod command sent' );
 }
 
-# Test SetOption4 topic subscriptions for Lightbulb (M2)
+# Test SetOption4 topic subscriptions for Lightbulb
 {
 	my $mqtt = MockMQTT->new();
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
@@ -726,14 +726,14 @@ use constant CAP_CT               => 4;
 	my @subs = $mqtt->get_subscriptions();
 
 	ok( ( grep { $_ eq 'stat/light/DIMMER' } @subs ),
-		'M2: Subscribed to DIMMER topic' );
+		'[MQTT-Transport §3.2] SetOption4: subscribed to DIMMER topic' );
 	ok( ( grep { $_ eq 'stat/light/HSBCOLOR' } @subs ),
-		'M2: Subscribed to HSBCOLOR topic' );
+		'[MQTT-Transport §3.2] SetOption4: subscribed to HSBCOLOR topic' );
 	ok( ( grep { $_ eq 'stat/light/CT' } @subs ),
-		'M2: Subscribed to CT topic' );
+		'[MQTT-Transport §3.2] SetOption4: subscribed to CT topic' );
 }
 
-# Test SetOption17 decimal color format (M3)
+# Test SetOption17 decimal color format
 {
 	my $mqtt = MockMQTT->new();
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
@@ -749,20 +749,20 @@ use constant CAP_CT               => 4;
 	# Test hex color format (default)
 	$mqtt->simulate_message( 'stat/light/RESULT',
 		'{"Color":"FF0000"}' );
-	is( $lightbulb->{hue}, 0, 'M3: Hex color red hue=0' );
+	is( $lightbulb->{hue}, 0, '[MQTT-Control §3.2] hex color red hue=0' );
 
 	# Test decimal color format (SetOption17 1)
 	$mqtt->simulate_message( 'stat/light/RESULT',
 		'{"Color":"0,255,0"}' );
-	is( $lightbulb->{hue}, 120, 'M3: Decimal color green hue=120' );
+	is( $lightbulb->{hue}, 120, '[MQTT-Control §3.2] SetOption17 decimal color green hue=120' );
 
 	# Test blue
 	$mqtt->simulate_message( 'stat/light/RESULT',
 		'{"Color":"0,0,255"}' );
-	is( $lightbulb->{hue}, 240, 'M3: Decimal color blue hue=240' );
+	is( $lightbulb->{hue}, 240, '[MQTT-Control §3.2] SetOption17 decimal color blue hue=240' );
 }
 
-# Test CT range clamping (M4)
+# Test CT range clamping
 {
 	my $mqtt = MockMQTT->new();
 	my $lightbulb = OpenHAP::Tasmota::Lightbulb->new(
@@ -778,13 +778,13 @@ use constant CAP_CT               => 4;
 	# Verify HomeKit min is 153 (not 140)
 	# The characteristic is defined in new(), check the clamping behavior
 	$mqtt->simulate_message( 'stat/light/RESULT', '{"CT":100}' );
-	is( $lightbulb->{ct}, 153, 'M4: CT clamped to min 153' );
+	is( $lightbulb->{ct}, 153, '[MQTT-Control §4] CT clamped to min 153' );
 
 	$mqtt->simulate_message( 'stat/light/RESULT', '{"CT":600}' );
-	is( $lightbulb->{ct}, 500, 'M4: CT clamped to max 500' );
+	is( $lightbulb->{ct}, 500, '[MQTT-Control §4] CT clamped to max 500' );
 }
 
-# Test sensor ID tracking (L3)
+# Test sensor ID tracking
 {
 	my $mqtt = MockMQTT->new();
 	my $sensor = OpenHAP::Tasmota::Sensor->new(
@@ -801,7 +801,7 @@ use constant CAP_CT               => 4;
 		'{"DS18B20":{"Id":"01131B123456","Temperature":22.5},"TempUnit":"C"}'
 	);
 
-	is( $sensor->{sensor_id}, '01131B123456', 'L3: Sensor ID tracked' );
+	is( $sensor->{sensor_id}, '01131B123456', '[MQTT-Sensors §3] sensor Id tracked' );
 }
 
 # Test STATUS10 subscription for sensors
@@ -818,12 +818,12 @@ use constant CAP_CT               => 4;
 
 	my @subs = $mqtt->get_subscriptions();
 	ok( ( grep { $_ eq 'stat/sensor/STATUS10' } @subs ),
-		'Subscribed to STATUS10' );
+		'[MQTT-Control §5] Subscribed to STATUS10' );
 
 	# Simulate STATUS10 response
 	$mqtt->simulate_message( 'stat/sensor/STATUS10',
 		'{"StatusSNS":{"DS18B20":{"Temperature":26},"TempUnit":"C"}}' );
-	is( $sensor->{current_temp}, 26, 'STATUS10 updates temperature' );
+	is( $sensor->{current_temp}, 26, '[MQTT-Control §5] STATUS10 updates temperature' );
 }
 
 # Test RGB to HSB conversion accuracy
@@ -839,17 +839,17 @@ use constant CAP_CT               => 4;
 
 	# Test pure red
 	my ( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 255, 0, 0 );
-	is( $h, 0,   'RGB red: hue=0' );
+	is( $h, 0,   '[MQTT-Control §3.2] RGB red: hue=0' );
 	is( $s, 100, 'RGB red: saturation=100' );
 	is( $b, 100, 'RGB red: brightness=100' );
 
 	# Test pure green
 	( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 0, 255, 0 );
-	is( $h, 120, 'RGB green: hue=120' );
+	is( $h, 120, '[MQTT-Control §3.2] RGB green: hue=120' );
 
 	# Test pure blue
 	( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 0, 0, 255 );
-	is( $h, 240, 'RGB blue: hue=240' );
+	is( $h, 240, '[MQTT-Control §3.2] RGB blue: hue=240' );
 
 	# Test white (no saturation)
 	( $h, $s, $b ) = $lightbulb->_rgb_to_hsb( 255, 255, 255 );

--- a/t/openhap/test-controller.t
+++ b/t/openhap/test-controller.t
@@ -1,0 +1,157 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Unit tests for OpenHAP::Test::Controller: constructor, transport
+# injection and error paths. Full protocol exchanges are covered by
+# t/conformance/hap-pairing-exchange.t.
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use FuguLib::Log;
+$OpenHAP::logger = FuguLib::Log->new( mode => 'quiet', ident => 'test' );
+
+BEGIN {
+	eval {
+		require Math::BigInt;
+		require Crypt::Ed25519;
+		require Crypt::Curve25519;
+		require Crypt::AuthEnc::ChaCha20Poly1305;
+	};
+	if ($@) {
+		plan skip_all => 'Crypto dependencies not available';
+	}
+}
+
+use_ok('OpenHAP::Test::Controller');
+use_ok('OpenHAP::Test::Controller::SRP');
+use_ok('OpenHAP::TLV');
+use_ok('OpenHAP::Pairing');
+
+# Constructor defaults and identity generation
+{
+	my $controller = OpenHAP::Test::Controller->new;
+
+	ok( defined $controller, 'controller created with defaults' );
+	is( $controller->{host}, '127.0.0.1', 'default host' );
+	is( $controller->{port}, 51827,       'default port' );
+	ok( defined $controller->{ltsk}, 'controller LTSK generated' );
+	is( length( $controller->{ltpk} ), 32, 'LTPK is 32 bytes' );
+	ok( !$controller->is_encrypted, 'session starts unencrypted' );
+	is( $controller->last_error, undef, 'no error initially' );
+}
+
+# Transport injection: requests flow through the code ref
+{
+	my $seen;
+	my $transport = sub ($request) {
+		$seen = $request;
+		return "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi";
+	};
+	my $controller =
+	    OpenHAP::Test::Controller->new( transport => $transport );
+
+	my $response = $controller->request( 'GET', '/accessories' );
+	like( $seen, qr{^GET /accessories HTTP/1\.1\r\n},
+		'request bytes passed to the transport' );
+	is( $response->{status}, 200,  'status parsed' );
+	is( $response->{body},   'hi', 'body parsed' );
+	is( $response->{headers}{'content-length'},
+		2, 'headers parsed and lowercased' );
+}
+
+# Connection refused: pair_setup fails with last_error set
+{
+	my $controller = OpenHAP::Test::Controller->new(
+		host    => '127.0.0.1',
+		port    => 1,      # nothing listens here
+		timeout => 1,
+	);
+
+	ok( !$controller->pair_setup, 'pair_setup fails without server' );
+	ok( defined $controller->last_error, 'last_error set' );
+	like( $controller->last_error, qr/connect|no response/,
+		'error mentions the connection failure' );
+}
+
+# Malformed TLV response: error recorded, no crash
+{
+	my $transport = sub ($request) {
+		my $body = "\x06\xFF\x01";    # length past end of buffer
+		return
+		      "HTTP/1.1 200 OK\r\n"
+		    . 'Content-Length: '
+		    . length($body)
+		    . "\r\n\r\n"
+		    . $body;
+	};
+	my $controller =
+	    OpenHAP::Test::Controller->new( transport => $transport );
+
+	ok( !$controller->pair_setup, 'malformed TLV response fails' );
+	ok( defined $controller->last_error, 'last_error set' );
+}
+
+# TLV error response: the error code is exposed via last_error
+{
+	my $transport = sub ($request) {
+		my $body = OpenHAP::TLV::encode(
+			OpenHAP::Pairing::kTLVType_State() => pack( 'C', 2 ),
+			OpenHAP::Pairing::kTLVType_Error() => pack(
+				'C', OpenHAP::Pairing::kTLVError_MaxTries()
+			),
+		);
+		return
+		      "HTTP/1.1 200 OK\r\n"
+		    . 'Content-Length: '
+		    . length($body)
+		    . "\r\n\r\n"
+		    . $body;
+	};
+	my $controller =
+	    OpenHAP::Test::Controller->new( transport => $transport );
+
+	ok( !$controller->pair_setup, 'error TLV fails the exchange' );
+	is( $controller->last_error,
+		OpenHAP::Pairing::kTLVError_MaxTries(),
+		'TLV error code exposed through last_error' );
+}
+
+# Non-200 HTTP status is an error
+{
+	my $transport = sub ($request) {
+		return "HTTP/1.1 470 Connection Authorization Required\r\n"
+		    . "Content-Length: 0\r\n\r\n";
+	};
+	my $controller =
+	    OpenHAP::Test::Controller->new( transport => $transport );
+
+	ok( !$controller->pair_setup, 'non-200 status fails' );
+	is( $controller->last_error, 'HTTP 470', 'status in last_error' );
+}
+
+# Client SRP dies on out-of-order calls
+{
+	my $srp =
+	    OpenHAP::Test::Controller::SRP->new( password => '123-45-678' );
+
+	eval { $srp->compute_proof( 'salt', 'B' ) };
+	like( $@, qr/compute_public not called/,
+		'compute_proof before compute_public dies' );
+
+	eval { $srp->verify_server_proof('M2') };
+	like( $@, qr/compute_proof not called/,
+		'verify_server_proof before compute_proof dies' );
+}
+
+# Client SRP rejects a bogus server public key
+{
+	my $srp =
+	    OpenHAP::Test::Controller::SRP->new( password => '123-45-678' );
+	$srp->compute_public;
+
+	my $M1 = $srp->compute_proof( 'x' x 16, "\x00" x 384 );
+	ok( !defined $M1, 'B mod N == 0 rejected' );
+}
+
+done_testing();

--- a/t/openhvf/ssh.t
+++ b/t/openhvf/ssh.t
@@ -49,4 +49,18 @@ is(OpenHVF::SSH::BUFFER_SIZE(), 32768, 'BUFFER_SIZE is 32768');
     ok(!$ssh->is_available, 'is_available false for closed port');
 }
 
+# _exit_code maps a raw wait status to a 0-255 exit code. This is what
+# lets `openhvf ssh` running a script over stdin propagate a failing
+# remote command (e.g. a failing `prove` run) instead of truncating a
+# raw status like 256 down to exit(256) -> 0.
+{
+    is(OpenHVF::SSH::_exit_code(0), 0, 'status 0 -> exit 0');
+    is(OpenHVF::SSH::_exit_code(1 << 8), 1, 'exit code 1 preserved');
+    is(OpenHVF::SSH::_exit_code(2 << 8), 2, 'exit code 2 preserved');
+    is(OpenHVF::SSH::_exit_code(255 << 8), 255, 'exit code 255 preserved');
+    is(OpenHVF::SSH::_exit_code(-1), 1, 'system() failure (-1) -> EXIT_ERROR');
+    is(OpenHVF::SSH::_exit_code(15), 143, 'signal 15 -> 128 + signal');
+    is(OpenHVF::SSH::_exit_code(2), 130, 'signal 2 -> 128 + signal');
+}
+
 done_testing();

--- a/t/openhvf/vm.t
+++ b/t/openhvf/vm.t
@@ -31,4 +31,29 @@ use_ok('OpenHVF::VM');
 	is(OpenHVF::VM::EXIT_TIMEOUT(), 7, 'EXIT_TIMEOUT is 7');
 }
 
+# Accelerator selection
+{
+	# --emulate always forces TCG with a named CPU model
+	my $emulated = OpenHVF::VM->new(emulate => 1);
+	my %args = ($emulated->_accel_args);
+	is($args{'-accel'}, 'tcg', '--emulate forces TCG');
+	is($args{'-cpu'}, OpenHVF::VM::TCG_CPU(),
+	    'TCG uses a named CPU model, not host passthrough');
+
+	# Auto-selection returns a consistent accel/cpu pair
+	my $auto = OpenHVF::VM->new;
+	%args = ($auto->_accel_args);
+	like($args{'-accel'}, qr/^(hvf|kvm|tcg)$/, 'known accelerator');
+	if ($args{'-accel'} eq 'tcg') {
+		is($args{'-cpu'}, OpenHVF::VM::TCG_CPU(),
+		    'software emulation pairs with a named CPU');
+	} else {
+		is($args{'-cpu'}, 'host',
+		    'hardware acceleration pairs with host CPU');
+	}
+
+	# Host arch helper returns a non-empty machine string
+	ok(length(OpenHVF::VM::_host_arch()), 'host arch detected');
+}
+
 done_testing();

--- a/t/openhvf/vm.t
+++ b/t/openhvf/vm.t
@@ -56,4 +56,26 @@ use_ok('OpenHVF::VM');
 	ok(length(OpenHVF::VM::_host_arch()), 'host arch detected');
 }
 
+# Bounded guest interaction: _bounded must return the code's value when
+# it finishes in time and undef (without hanging) when it does not, so a
+# wedged guest can never stall shutdown.
+{
+	my $vm = OpenHVF::VM->new;
+	$vm->{log} = TestLog->new;    # swallow the timeout warning
+
+	is($vm->_bounded(5, sub { return 'done' }), 'done',
+	    '_bounded returns the code result when it finishes in time');
+
+	my $start = time;
+	my $ret = $vm->_bounded(1, sub { sleep 5; return 'late' });
+	is($ret, undef, '_bounded returns undef when the deadline elapses');
+	ok(time - $start < 4, '_bounded aborts near the deadline, not later');
+	ok($vm->{log}{warned}, '_bounded warns on timeout');
+}
+
 done_testing();
+
+# Minimal log stub capturing the timeout warning from _bounded
+package TestLog;
+sub new { return bless { warned => 0 }, shift }
+sub warning { my $self = shift; $self->{warned}++; return; }


### PR DESCRIPTION
Implements all five phases of `plans/001-test-structure/` and adds a CI workflow that runs the VM integration suite.

## Test suite

- **Phase 1 — hygiene**: `t/fugulib` wired into `make test`; vacuous assertions, SKIP blocks, and log-parsing removed; the `[<spec-stem> §<section>]` citation convention established in `t/CLAUDE.md` and seeded across the suite.
- **Phase 2 — tooling**: `scripts/spec-coverage` computes spec/ section coverage from citations and fails CI on stale citations (`make spec-coverage`).
- **Phase 3 — conformance tier**: one spec-cited test file per spec topic under `t/conformance/`, with byte-exact wire examples, crypto known-answer vectors (RFC 8032/7748/8439, HKDF-SHA-512), data-driven catalogs, and hostile-buffer parser tests. Coverage went from 26% to 89% of numbered spec sections.
- **Phase 4 — test controller**: `OpenHAP::Test::Controller` completes real SRP pair-setup, pair-verify, and encrypted sessions, over TCP or in-process; exchange tests leave the accessory actually paired.
- **Phase 5 — integration upgrade**: the VM suite now drives the paired protocol end to end (full pairing, authenticated data plane, EVENT/1.0 notifications, MQTT↔HAP round trips, dynamic mDNS semantics).

## Protocol fixes found by the new tests

- SRP was spec-incorrect: `bmodpow` mutated the group parameters and the proof check XOR was numeric under v5.36 — pairing could never complete.
- The pair-verify M4 response was sent encrypted; controllers expect it in the clear.
- A bare `die` in the Characteristic constructor swallowed every attribute after `iid`.
- Missing UUID mappings (Brightness, Hue, Saturation, ColorTemperature, …), bool values encoded as 0/1 instead of JSON booleans, missing ProtocolInformation service.
- An aborted pair-setup held the pairing lock until restart; the auth-attempt counter wasn't persistent; `c#` never incremented; `sf` was never re-advertised after pairing.

## CI

- New **Integration** workflow runs `make integration` (OpenBSD VM via openhvf) on every PR and push to main, plus manual dispatch. The openhvf harness gained Linux support: accelerator auto-selection (HVF/KVM/TCG), Debian EFI firmware paths, and environment-driven timeouts for emulated runs. The miniroot image and provisioned VM disk are cached between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9kBnLstCfPtWobADVoEX4

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9kBnLstCfPtWobADVoEX4)_