### PR TITLE
docs(plan): rework plan 002 around verified root causes

### DIFF
--- a/plans/002-integration-ci-green/design.md
+++ b/plans/002-integration-ci-green/design.md
@@ -3,49 +3,56 @@
 ## Problem
 
 The `Integration` workflow (`.github/workflows/integration.yml`) provisions an
-OpenBSD guest under QEMU and runs `t/openhap/integration/*.t` on every push and
-pull request. Standing the pipeline up exposed a chain of defects. The harness
-defects (console/SSH addressing, install halt, SSH-key provisioning, bounded
-shutdown, exit-code propagation) and the SRP performance defect are fixed; what
-remains is to make the integration **suite** pass reliably in that environment
-and keep it green.
+OpenBSD guest under QEMU and runs `t/openhap/integration/*.t` on pushes to main,
+pull requests targeting main, and manual dispatch. Standing the pipeline up
+exposed a chain of defects. The harness defects (console/SSH addressing, install
+halt, SSH-key provisioning, bounded shutdown, exit-code propagation) and the SRP
+performance defect are fixed; what remains is to make the integration **suite**
+pass reliably in that environment and keep it green.
 
-Two properties of the CI environment shape the remaining failures:
+Two properties of the execution environment shape the remaining work:
 
-1. **No hardware virtualization.** The `ubuntu-24.04-arm` runner has no
+1. **No hardware virtualization in CI.** The `ubuntu-24.04-arm` runner has no
    `/dev/kvm`, so QEMU uses TCG software emulation — an order of magnitude
    slower than native, which is why CPU-bound crypto needed the GMP backend and
    why timing-sensitive tests are fragile.
-2. **User-mode (SLIRP) networking.** The guest reaches the network through
-   QEMU's user-mode stack, which does not forward link-local multicast — the
-   transport mDNS relies on.
+2. **User-mode (SLIRP) networking — everywhere, not only in CI.** The harness
+   has exactly one network backend (`-netdev user` with hostfwd, built in
+   `lib/OpenHVF/VM.pm`), so the guest's network is identical on a developer host
+   and in CI. SLIRP does not carry multicast off-host, but nothing the suite
+   asserts requires a packet to leave the guest — mDNS registration is local
+   `mdnsctl` IPC against `/var/run/mdnsd.sock` — so SLIRP is not established as
+   a cause of any current failure.
 
 ## Current state (baseline for this plan)
 
-Run of commit `796b1c6` (GMP backend landed):
+One run of commit `796b1c6` (GMP backend landed) — a single-run baseline, so
+per-phase acceptance requires stable repetition (see plan-4):
 
 - Green: `environment`, `accessories`, **`characteristics` (16/16)**,
   `configuration`, `daemon`, `hap-protocol`, `hapctl`, `mqtt`.
 - Failing: `pairing`, `tasmota-protocol`, `events`, `mdns`, `mdns-cleanup`.
 
-The GMP fix worked: `characteristics.t` now completes full pair-setup,
-pair-verify, and encrypted reads/writes. The remaining failures are no longer
-about crypto speed.
+The GMP fix worked: `characteristics.t` completes full pair-setup, pair-verify,
+and encrypted reads/writes. Static review of the tree has since root-caused the
+pairing and event failures (taxonomy below); the mDNS failure still needs
+runtime diagnosis.
 
 ## Failure taxonomy
 
-| Class                   | Tests                                     | Root cause                                                                                                                                                             | Status                                                       |
-| ----------------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| SRP performance         | (was `characteristics`, `pairing` crypto) | pure-Perl `Math::BigInt`; 3072-bit `bmodpow` ~2s native, far worse under TCG                                                                                           | **Fixed** — `use Math::BigInt try => 'GMP'` + GMP dependency |
-| Pairing state isolation | `pairing`, `tasmota-protocol`             | `pair_setup` returns `kTLVError_Unavailable` (6) in the late-running tests, though both call `ensure_unpaired`; early tests (`characteristics`, `events`) pair cleanly | Open                                                         |
-| Event delivery          | `events` (subtests 5–6)                   | a subscribed controller never receives the async `EVENT/1.0` notification; the body then decodes as undef and the test dies                                            | Open                                                         |
-| mDNS availability       | `mdns`, `mdns-cleanup`                    | `mdnsd` is not running at test time (suspected SLIRP multicast limitation; not yet confirmed)                                                                          | Open                                                         |
-| Provisioning noise      | (none failing)                            | `make install`'s `[ ! -e <glob> ]` guard errors when the glob matches multiple files                                                                                   | Open                                                         |
+| Class                   | Tests                                     | Root cause                                                                                                                                                                                                                                                                                                                                              | Status                                                       |
+| ----------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| SRP performance         | (was `characteristics`, `pairing` crypto) | pure-Perl `Math::BigInt`; 3072-bit `bmodpow` ~2s native, far worse under TCG                                                                                                                                                                                                                                                                            | **Fixed** — `use Math::BigInt try => 'GMP'` + GMP dependency |
+| Pairing state isolation | `pairing`, `tasmota-protocol`             | **Root-caused (static):** `ensure_unpaired` checks/unlinks `/var/db/openhapd/pairings` but the daemon persists to `pairings.db` (`lib/OpenHAP/Storage.pm`) — the helper has never wiped anything. `events.t` dies before its unpair teardown, and the leaked pairing makes every later `method=0` M1 return `kTLVError_Unavailable` (6) before SRP runs | Open — fixed by phase 1                                      |
+| Event delivery          | `events` (assertions 5–6)                 | **Root-caused (static):** the daemon never emits events — `queue_event` (`lib/OpenHAP/HAP.pm`) has no callers; the `/characteristics` PUT handler sets values without notifying, and the device path dead-ends in the bridge forwarder                                                                                                                  | Open — fixed by phase 2                                      |
+| mDNS availability       | `mdns`, `mdns-cleanup`                    | `mdnsd` is down at test time and the tests' own restart fails. Unconfirmed; leading hypothesis: mdnsd exits shortly after every start and provisioning's point-in-time verify races green. SLIRP multicast is refuted as an explanation (all failing assertions are guest-local)                                                                        | Open — diagnosed and fixed by phase 3                        |
+| Provisioning noise      | (none failing)                            | `make install`'s `[ ! -e <glob> ]` guard errors when the glob matches multiple files                                                                                                                                                                                                                                                                    | Open — fixed by phase 4                                      |
 
 ## Goals
 
-1. The full `t/openhap/integration/*.t` suite passes in the workflow, on both a
-   cold cache (fresh install) and a warm cache (reused disk).
+1. The full `t/openhap/integration/*.t` suite passes in the workflow,
+   repeatably, on both a cold cache (fresh install) and a warm cache (reused
+   disk) — verified by the procedure phase 4 defines.
 2. Failures stay legible: no silent fallback that turns a broken environment
    into a slow-but-green or falsely-green run.
 3. `t/openhap/integration/CLAUDE.md` rules hold — tests never `skip`; a missing
@@ -60,40 +67,46 @@ about crypto speed.
 - Making the integration job fast; TCG is inherently slow and the generous
   timeouts stand.
 - Real Apple-device or certified-controller interop.
+- Fixing `hapctl status`'s pairing readout (`bin/hapctl` calls Storage methods
+  that do not exist, so it always prints "unknown") — a latent defect noted
+  during review; it causes no test failure and is tracked separately.
 
 ## Strategy
 
 Four independently shippable phases, each ending with a named set of integration
 files green in CI. Order is by blast radius and independence:
 
-- **Phase 1 — Pairing state isolation.** Root-cause the `kTLVError_Unavailable`
-  returned to the late-running tests and make every pairing test start from a
-  genuinely unpaired accessory. Unblocks the largest group and everything that
-  pairs first.
-- **Phase 2 — Event delivery.** Determine why the subscribed controller does not
-  receive the `EVENT/1.0` push, fix it, and make the event read fail cleanly
-  instead of dying on an undef body.
-- **Phase 3 — mDNS under emulated networking.** Confirm why `mdnsd` does not
-  survive to test time, then either make it run under the guest's network or
-  give the harness a network mode that carries multicast — rather than weakening
-  the tests.
-- **Phase 4 — Cleanup and regression guards.** Fix the `make install` glob
-  guard, guard against a silent regression to the pure-Perl bigint backend,
-  remove the temporary diagnostics added while chasing these failures, and
-  confirm cold- and warm-cache runs are both green.
+- **Phase 1 — Pairing state isolation.** Fix the root-caused `ensure_unpaired`
+  no-op (wrong filename), make the wipe authoritative and verified by a probe
+  that can actually fail, and start each run from a clean state directory.
+  Unblocks `pairing.t`/`tasmota-protocol.t` and immunizes the suite against any
+  earlier file dying before its unpair teardown.
+- **Phase 2 — Event delivery.** Wire the daemon's dead event-emission path into
+  the write handlers, prove it host-side with a trigger-driven conformance test,
+  and make the event read fail cleanly instead of dying on an undef body.
+- **Phase 3 — mDNS in the test VM.** Diagnose at test time — with captured
+  output — why `mdnsd` is down, fix the in-guest lifecycle cause, and treat any
+  network-backend change as a separately planned last resort rather than
+  weakening the tests.
+- **Phase 4 — Cleanup, guards, and verification.** Fix the `make install` glob
+  guard, gate the GMP backend with a hard environment assertion, make failure
+  diagnostics reachable, define the cold/warm-cache procedure, and add a
+  scheduled run so "green" stays observed.
 
 ## Contracts for the target state
 
 - **Crypto backend.** `OpenHAP::SRP` and the controller SRP obtain the GMP
-  `Math::BigInt` backend in the guest; a missing backend is a visible error, not
-  a silent multi-minute pair-setup.
-- **Pairing isolation.** After `ensure_unpaired`, `/pair-setup` from a fresh
-  controller reaches M6 regardless of what earlier tests did.
+  `Math::BigInt` backend in the guest; a missing backend is a hard, visible
+  integration failure (`environment.t`), not a silent multi-minute pair-setup.
+- **Pairing isolation.** After `ensure_unpaired`, the accessory is verifiably
+  unpaired (`POST /identify` returns 204) and `/pair-setup` from a fresh
+  controller reaches M6 regardless of what earlier tests did — or died doing.
 - **Events.** A controller subscribed to a characteristic receives an
-  `EVENT/1.0` notification after a value change, within the emulated-timing
-  budget.
+  `EVENT/1.0` notification after a value change from another connection, within
+  the emulated-timing budget; emission is exercised host-side by a conformance
+  test that drives the write handler, not the emitter directly.
 - **mDNS.** `mdnsd` is running and answering `mdnsctl` for the duration of the
-  mDNS tests, on the interface `openhapd` advertises on.
+  mDNS tests, on the interface its flags configure.
 
 Once a phase's acceptance criteria hold in CI, the code, tests, and
 `t/openhap/integration/CLAUDE.md` are the source of truth; this plan records

--- a/plans/002-integration-ci-green/plan-1.md
+++ b/plans/002-integration-ci-green/plan-1.md
@@ -1,70 +1,89 @@
 # Phase 1 — Pairing state isolation
 
 `pairing.t` and `tasmota-protocol.t` fail with `pair_setup error: 6`
-(`kTLVError_Unavailable`) even though both call `ensure_unpaired` in setup. The
-early-running `characteristics.t` and `events.t` pair cleanly, so the accessory
-_can_ pair from a clean state; the late-running tests cannot. This phase finds
-why and makes every pairing test deterministic.
+(`kTLVError_Unavailable`) on every attempt, including the wrong-PIN case. Static
+review has settled why; this phase fixes it and locks the fix in.
 
-## Hypotheses to confirm first
+## Root cause (established by code reading; confirm, don't rediscover)
 
-Do not fix blind — the run log shows every `/pair-setup` in the failing files
-returns `6`, including the wrong-PIN case, which means the accessory believes it
-is already paired (or a pair-setup is already in progress). Candidates:
-
-- `ensure_unpaired` (`lib/OpenHAP/Test/Integration.pm`) only wipes when
-  `-s pairings_file`; a pairing persisted elsewhere (e.g. in-memory across the
-  stop/start, or a second state file) survives it.
-- `pairing.t`'s raw M1 probe (test 2) opens a pair-setup session; the stop/start
-  meant to release it does not, and the server rejects the next M1 with
-  `Unavailable`. (Does not explain `tasmota-protocol.t`, which has no probe — so
-  this is at most a second, additive cause.)
-- The daemon does not reset a stale/incomplete pair-setup session, so once one
-  is left dangling every later attempt is `Unavailable` until restart.
+- `ensure_unpaired` (`lib/OpenHAP/Test/Integration.pm`) checks and unlinks
+  `/var/db/openhapd/pairings`, but the daemon persists pairings to `pairings.db`
+  (`lib/OpenHAP/Storage.pm`, same `db_path`). Nothing ever creates a file named
+  `pairings`, so the `-s` guard is always false and the stop/wipe/restart body
+  has never executed — the helper is, and always has been, a no-op.
+- The pairing that trips the late files leaks from `events.t`, which dies at its
+  event assertion (line 74, fixed in phase 2) before its `remove_pairing`
+  teardown. The daemon's already-paired check runs before any SRP processing and
+  returns error 6 to every `method=0` M1 while `pairings.db` is non-empty
+  (`lib/OpenHAP/Pairing.pm`) — which is why even wrong-PIN attempts see 6 rather
+  than `kTLVError_Authentication`.
+- `pairing.t` fails in isolation too: its own test 3 pairs, and the mid-file
+  `ensure_unpaired` calls before tests 8 and 9 no-op, so those assertions and
+  the teardown fail even on a clean disk.
+- Refuted hypotheses (do not spend time here): a stale or concurrent pair-setup
+  session returns `kTLVError_Busy` (7), never 6, and the pair-setup lock is
+  per-process state, released on connection close and by any daemon restart. No
+  server-side pairing change is needed for this failure class — the daemon's
+  `spec/HAP-Pairing.md` §2.4 behavior is correct as-is. If the confirmation run
+  contradicts any of this, stop and re-plan rather than patching forward.
 
 ## Tasks
 
-### 1.1 Reproduce and localize
+### 1.1 Confirm the diagnosis (cheap)
 
-- Run the two failing files in isolation and in suite order in a local VM
-  (`make integration`, now fast with GMP) to see whether order alone triggers
-  it.
-- Capture `/var/db/openhapd/pairings` and the daemon log around a failing
-  `pair_setup` to see the accessory's paired/in-progress state at M1.
+- In one failing CI or local-VM run, capture `/var/db/openhapd/pairings.db` and
+  the daemon log around a failing M1; confirm the file is non-empty and the log
+  shows the already-paired rejection. This is confirmation of a known cause, not
+  discovery.
 
-### 1.2 Make `ensure_unpaired` authoritative
+### 1.2 Fix `ensure_unpaired`
 
-- Ensure it removes every persisted pairing artifact (pairings, any
-  in-progress/session state) and that the daemon reloads a clean state — verify
-  the daemon is actually stopped before the unlink and fully up after.
-- Add a post-condition check: after `ensure_unpaired`, an unauthenticated
-  `GET /accessories` returns 470 (unpaired), failing loudly if not.
+- Point it at the real pairings file, and make "unpaired" content-based: after
+  its first save the daemon always leaves comment headers in `pairings.db`, so a
+  size check would bounce the daemon on every call (slow under TCG) — parse for
+  non-comment entries instead.
+- Wipe every pairing artifact — pairings and `auth_attempts`, unconditionally,
+  checking the unlink return values — with the daemon verifiably stopped before
+  the wipe and verifiably up afterwards.
+- Update `lib/OpenHAP/Test/Integration.pod` for the changed semantics.
 
-### 1.3 Fix the server side if it is at fault
+### 1.3 Post-condition that can actually fail
 
-- If the daemon returns `Unavailable` because of a stale in-progress pair-setup
-  rather than an established pairing, reset a prior incomplete session when a
-  new M1 arrives (per HAP: a fresh M1 starts a new session), citing
-  `spec/HAP-Pairing.md`. Keep the correct `Unavailable` when a real admin
-  pairing already exists.
+- After `ensure_unpaired`, probe pairing state with `POST /identify`: 204 when
+  unpaired, 400 with `{"status":-70401}` when still paired (`spec/HAP-HTTP.md`
+  §3 — identify only works when unpaired). Fail loudly on the paired answer.
+- An unauthenticated `GET /accessories` cannot serve here: 470 means "no
+  verified session" and is returned identically in both pairing states.
+  `hapctl status` is also unusable today (its pairing readout is broken — see
+  design non-goals).
 
-### 1.4 Harden the tests
+### 1.4 Start clean regardless of history
 
-- `pairing.t`: after the raw M1 probe, guarantee the session is released before
-  the controller flow (explicit reset, not only a daemon bounce).
-- Keep assertions spec-cited; do not weaken them to pass.
+- Provisioning removes `/etc/openhapd.conf` "to ensure fresh installation for
+  testing" but preserves `/var/db/openhapd` (as does `make uninstall`), so a
+  warm-cached disk carries the previous run's pairing state into file 1. Have
+  `scripts/vm_provision.sh` remove the pairing state (`pairings.db`,
+  `auth_attempts` — keep the accessory identity keys) so every run starts
+  unpaired even on a reused disk.
+- `pairing.t` hygiene: close the raw M1 probe's socket right after test 2
+  instead of leaving it registered until teardown. The daemon bounce already
+  releases the pair-setup lock; this only removes the lingering connection.
 
 ## Deliverables
 
-- Root-cause note (in the PR description or commit body) distinguishing test bug
-  vs. daemon bug.
-- Fixes in `lib/OpenHAP/Test/Integration.pm` and/or the daemon pairing code
-  and/or the two test files.
+- Fixes in `lib/OpenHAP/Test/Integration.pm` (+ its `.pod`),
+  `scripts/vm_provision.sh`, and `t/openhap/integration/pairing.t`.
+- Root-cause note in the commit body distinguishing the harness bug (the no-op
+  wipe) from the seeding test bug (`events.t` dying before teardown, owned by
+  phase 2).
 
 ## Acceptance criteria
 
-- `pairing.t` (18/18) and `tasmota-protocol.t` (11/11) pass in the Integration
-  workflow, in suite order, on both cold and warm cache.
-- `characteristics.t` and `events.t` still pass (no regression from changes to
-  shared `ensure_unpaired`).
+- `pairing.t` (all 18 assertions; update the `tests =>` plan if the
+  post-condition adds any) and `tasmota-protocol.t` (11/11) pass in the
+  Integration workflow in suite order, and `pairing.t` also passes in isolation
+  in a local VM run.
+- `characteristics.t` still passes, and `events.t` still pairs cleanly and fails
+  no earlier than its event assertions (assertions 1–4 pass) — its full pass is
+  phase 2's criterion.
 - `make check` stays green.

--- a/plans/002-integration-ci-green/plan-2.md
+++ b/plans/002-integration-ci-green/plan-2.md
@@ -1,56 +1,99 @@
 # Phase 2 — Event delivery
 
-With pairing fixed (Phase 1) and GMP in place, `events.t` reaches its event
-assertions: subtests 1–4 pass (subscription accepted, second controller verifies
-its session, value changed), but subtest 5
-`[HAP-HTTP §14] EVENT/1.0 message received` fails and the test then dies:
+With GMP in place `events.t` reaches its event assertions (assertions 1–4 pass),
+then assertion 5 `[HAP-HTTP §14] EVENT/1.0 message received` fails and the file
+dies decoding the undef body at line 74:
 
 ```
 malformed JSON string, neither array, object, number, string or atom,
 at character offset 0 ... at t/openhap/integration/events.t line 74
 ```
 
-So the subscribed controller never receives the asynchronous `EVENT/1.0`
-notification, and the code then tries to JSON-decode an undef/empty body and
-dies instead of failing the assertion cleanly.
+Static review has settled why; this phase wires the daemon's event path, proves
+it host-side, and makes the test fail cleanly.
+
+## Root cause (established by code reading)
+
+The daemon never sends events. `queue_event` (`lib/OpenHAP/HAP.pm`) has no
+callers anywhere in `lib/` or `bin/`:
+
+- The `/characteristics` PUT handler calls `set_value` and returns; nothing
+  notifies subscribers (`lib/OpenHAP/Characteristic.pm` only stores the value
+  and runs `on_set`).
+- The device path dead-ends: Tasmota devices call `notify_change`, whose only
+  registered callback forwards to the Bridge while discarding the device `$aid`
+  (`lib/OpenHAP/Bridge.pm`), and nothing subscribes to the Bridge's own callback
+  list — `send_event`/`flush_events` stay unreachable.
+- Existing coverage is why this shipped: the unit test asserts only
+  `can('queue_event')` and the conformance test calls `send_event` directly,
+  bypassing the trigger chain.
+
+Controller-side timing is not the cause — no bytes are ever written to the
+subscriber's socket, so no wait extension can turn assertion 5 green. The
+controller has real but secondary weaknesses, fixed below.
 
 ## Tasks
 
-### 2.1 Determine why the event is not received
+### 2.1 Wire event emission in the daemon
 
-- Confirm the daemon actually emits the event: change a value from a second
-  connection (as the test does) and watch the daemon log / the subscriber
-  socket. Establish whether the push is never sent, sent on the wrong
-  connection, or sent but not read in time.
-- Check the controller's event read path
-  (`OpenHAP::Test::Controller::next_event` and the `inbuf` handling in
-  `request`) for a timing or framing issue: under TCG the event may arrive after
-  a short read window that is too tight.
+- HTTP path: after a successful value write in the `/characteristics` PUT
+  handler, call `queue_event` for each changed characteristic (cite
+  `spec/HAP-HTTP.md` §14).
+- Device path: forward `notify_change` through the bridge into `queue_event`
+  with the correct device `$aid` (fix the forwarder that currently discards it).
+- While in the file: align `IMMEDIATE_EVENT_TYPES` with §14's list (the spec
+  names four types; the constant has two) and purge a connection's
+  `event_subscriptions` on disconnect.
+- Delivery scope: §14 as extracted does not state the upstream rule that the
+  originating controller must not receive its own event. Do not implement an
+  uncitable behavior — regenerate the spec first (`spec-hap` skill; needs
+  `external/` fetched) and follow what it yields, recording the outcome in the
+  commit body. (`events.t` is insensitive either way: its writer is not
+  subscribed.)
 
-### 2.2 Fix the delivery gap
+### 2.2 Host-side conformance test (unconditional)
 
-- If it is a controller-side read/timing issue, extend the event wait using the
-  same `OPENHAP_TEST_TIMEOUT` knob as the request path and ensure a back-to-back
-  event framed after a response is not dropped.
-- If the daemon does not push events to a subscribed session, fix the daemon
-  (cite `spec/HAP-HTTP.md §14`) and add/extend a conformance test so the
-  regression is caught host-side, not only in the VM.
+- Extend `t/conformance/hap-http.t`: drive the `/characteristics` PUT handler on
+  a subscribed mock session and assert a decryptable `EVENT/1.0` message reaches
+  the subscriber's socket — and none reaches an unsubscribed one. This replaces
+  the vacuous `can('queue_event')`-style assertions in `t/openhap/hap.t` that
+  let the dead path count as §14 coverage.
 
-### 2.3 Make the read fail cleanly
+### 2.3 Controller event-read hardening
 
-- `events.t` line ~74: never feed an undef/empty body to the JSON decoder;
-  assert the event was received first and `diag` the raw bytes on failure, so a
-  missed event is a clean `not ok`, not a `die`.
+- `next_event` (`lib/OpenHAP/Test/Controller.pm`): honor `OPENHAP_TEST_TIMEOUT`
+  for the positive wait instead of the hardcoded 5 s default that callers
+  override with literals.
+- Fix the partial-frame weakness: `next_event` decrypts each `sysread` chunk in
+  isolation, so an event frame split across reads returns undef and desyncs the
+  nonce counter — accumulate and retry as `_round_trip` already does.
+- Keep the negative probe (`next_event(2)` on the unsubscribed connection) short
+  and fixed: it always runs to its full window, and it executes after the
+  subscriber's event has already arrived, which bounds delivery latency
+  observationally.
+
+### 2.4 Make `events.t` fail cleanly
+
+- Assert the event was received before decoding; on failure `diag` the raw
+  buffered bytes and continue as a normal `not ok`, so the teardown
+  (`remove_pairing`) always runs and later files start unpaired even when this
+  file fails. Update the `tests =>` plan if assertions change.
 
 ## Deliverables
 
-- Fix in the controller and/or daemon event path; hardened `events.t`.
-- If a daemon bug is found, a host-side conformance assertion covering it.
+- Daemon wiring and conformance assertions; controller fixes; hardened
+  `events.t`; `.pod` update for the changed `next_event` semantics; spec-gap
+  resolution (regenerated spec or documented decision) for the delivery-scope
+  rule.
 
 ## Acceptance criteria
 
-- `events.t` (8/8) passes in the Integration workflow on both cold and warm
-  cache, and does not die on a missing event.
-- No new flakiness: the event wait is bounded by `OPENHAP_TEST_TIMEOUT`, not a
-  fixed short sleep.
+- `events.t` (all 8 assertions; update the `tests =>` plan if the count changes)
+  passes in the Integration workflow in suite order and no longer dies on a
+  missed event — the clean-fail path is exercised host-side, where a miss can be
+  induced deterministically.
+- The new conformance assertions pass in `make test` on the host.
+- The positive event wait is bounded by `OPENHAP_TEST_TIMEOUT`; the negative
+  probe stays a short fixed window.
+- `characteristics.t` still passes.
 - `make check` stays green.

--- a/plans/002-integration-ci-green/plan-3.md
+++ b/plans/002-integration-ci-green/plan-3.md
@@ -1,57 +1,98 @@
-# Phase 3 — mDNS under emulated networking
+# Phase 3 — mDNS in the test VM
 
-`mdns.t` fails at subtest 3 (`mdnsd daemon is running`) and `mdns-cleanup.t`
-dies at its `mdnsd required` precondition. Both files then cannot run. The
-provisioning hardening added this session (set flags to the default-route
-interface, enable, restart, verify) did not change the outcome, and the
-foreground-`mdnsd` diagnostics did not print — meaning either the provisioning
-block did not reach them or `mdnsd` was alive at provisioning time but not at
-test time. mDNS depends on link-local multicast, which QEMU user-mode (SLIRP)
-networking does not carry.
+`mdns.t` fails at test 3 (`mdnsd daemon is running`) and `mdns-cleanup.t` dies
+at its `mdnsd required` precondition — in both cases after the test's own
+`rcctl enable` + `start` + check retry also fails. Provisioning's hardening (set
+flags to the default-route interface, enable, restart, verify) passed in the
+baseline run, yet `mdnsd` is down by test time.
+
+## What the evidence supports (and rules out)
+
+Everything the two files assert is guest-local: `rcctl check`, `mdnsctl` against
+`/var/run/mdnsd.sock`, and `ps` for `mdnsctl publish` children. openhapd
+registers by spawning `mdnsctl publish` against that local socket
+(`lib/OpenHAP/MDNS.pm`). No assertion requires multicast to leave the guest, so
+SLIRP's lack of off-host multicast cannot explain "mdnsd is not running" and is
+not this phase's lever. (The harness also has only one network backend, used
+locally and in CI alike — if SLIRP were the blocker, this phase's local
+acceptance criterion could never hold.)
+
+Ranked hypotheses for 3.1 to discriminate:
+
+1. **`mdnsd` starts, then exits shortly after, every time.** Provisioning's
+   verify (`rcctl restart` then an immediate check) is a point-in-time probe
+   that can race green. This is the only single cause that fits all three
+   observations: the earlier run where the verify itself failed (`d77a9cd`), the
+   baseline (verify passed, dead at test time), and the tests' own failed
+   restarts.
+2. **`mdnsd` is killed or crashes under client churn**: `pkill -9 mdnsctl` at
+   suite start, ~20 openhapd restarts before the mDNS files, and `OpenHAP::MDNS`
+   kill-and-respawning `mdnsctl publish` on every TXT update. Weakened — not
+   excluded — by the failed fresh restarts.
+3. **`rcctl check` misreports.** Cheap to eliminate first.
 
 ## Tasks
 
-### 3.1 Establish the actual failure
+### 3.1 Diagnose at test time, with captured output
 
-- Read the provisioning-phase diagnostics already emitted
-  (`scripts/vm_provision.sh`): the chosen interface, `rcctl get mdnsd`, and the
-  short foreground `mdnsd -d` output. Determine definitively whether `mdnsd`
-  fails to start, starts then exits, or runs but `rcctl check` misreports it.
-- In a local VM, start `mdnsd` by hand on the guest interface and observe
-  whether it stays up and whether `mdnsctl browse` returns anything under
-  user-mode networking.
+- The tests currently discard all rcctl/mdnsd output and die bare. Capture the
+  reason: run `mdnsd -d` with output to a file (or start it supervised with
+  stderr/syslog recorded) at suite start, and include that plus `rcctl` output
+  in the failure diagnostics. Determine which ranked hypothesis holds —
+  including whether mdnsd's exit follows its start by a fixed interval (verify
+  race) or follows client activity (churn).
+- In a local VM, start `mdnsd` by hand on the guest interface, watch its
+  lifetime, and run `mdnsctl browse` to observe whether it sees its own
+  published services under the guest kernel's multicast loopback.
 
-### 3.2 Decide the resolution path
+### 3.2 Fix the in-guest cause
 
-Pick based on 3.1, in preference order:
+In preference order, based on 3.1:
 
-1. **Make mdnsd run as-is.** If it is a flags/interface/rc issue (not a
-   transport limit), fix provisioning so `mdnsd` is reliably up before the
-   tests, and the tests pass unchanged.
-2. **Give the guest real multicast.** If user-mode networking is the blocker,
-   switch the VM's network for CI to a mode that carries multicast (e.g. a
-   tap/bridged backend) in `lib/OpenHVF/VM.pm` / `.openhvfrc`, gated so local
-   development is unaffected. Document the requirement.
+1. **Lifecycle/config fix**: make `mdnsd` stay up — correct flags/interface
+   timing, a settle-then-verify longer than a raced pgrep, rc ordering on
+   warm-cache boots (the rc autostart path is never exercised by provisioning,
+   which always restarts explicitly).
+2. **Client hygiene**, if 3.1 shows churn kills the daemon: withdraw
+   registrations gracefully instead of kill/respawn on TXT updates in
+   `OpenHAP::MDNS`, and drop the `pkill -9 mdnsctl` from
+   `scripts/integration.sh`.
+3. **Network backend change — separately planned last resort**: only if 3.1
+   proves an in-guest multicast-loopback deficit (mdnsd cannot hear its own
+   answers). This is phase-sized, not a task: every host→guest path assumes
+   SLIRP hostfwd to 127.0.0.1 (`lib/OpenHVF/`, both scripts), the installer
+   answers `dhcp` against SLIRP's DHCP, the package proxy assumes the `10.0.2.2`
+   gateway, macOS development hosts cannot exercise a Linux bridge, and touching
+   `.openhvfrc` invalidates both CI caches. If this branch is reached, write a
+   new design/plan with abort criteria; do not bolt it onto this phase.
 
 Do **not** add a `skip` to the mDNS tests — `t/openhap/integration/CLAUDE.md`
-forbids it. If mDNS genuinely cannot run in the chosen CI network, that is a
-harness capability to provide (option 2), not a test to soften.
+forbids it, and these files once had SKIP blocks that were deliberately removed.
+If mDNS genuinely cannot run, that is a harness capability to provide, not a
+test to soften.
 
 ### 3.3 Implement and verify
 
-- Apply the chosen fix; confirm `mdnsd` is up and `mdnsctl browse` sees the
-  `_hap._tcp` service `openhapd` registers.
+- Apply the chosen fix; confirm `mdnsd` is up and answering `mdnsctl` for the
+  duration of both files, and that `mdnsctl browse` sees the `_hap._tcp` service
+  `openhapd` registers.
 
 ## Deliverables
 
-- Provisioning and/or `OpenHVF` networking change with a one-paragraph rationale
-  in the commit body (which of 3.2's paths and why).
-- Any doc updates (`INSTALL.md` / `man/openhvf/openhvf.1`) if the VM network
-  configuration changes.
+- Provisioning and/or `OpenHAP::MDNS` and/or harness change with a one-paragraph
+  rationale in the commit body (which hypothesis 3.1 confirmed and how).
+- Doc updates: `lib/OpenHAP/Test/Integration.pod`'s ENVIRONMENT section gains
+  the mdnsd (and mosquitto) prerequisites it currently omits; `INSTALL.md` /
+  `man/openhvf/openhvf.1` only if the VM configuration changes.
 
 ## Acceptance criteria
 
-- `mdns.t` (12/12) and `mdns-cleanup.t` (6/6) pass in the Integration workflow.
-- Local `make integration` on a developer host (HVF/KVM) still passes, i.e. the
-  networking change does not regress the non-CI path.
+- `mdns.t` (12/12) and `mdns-cleanup.t` (6/6) pass in the Integration workflow —
+  and the **full suite stays green in suite order**: a running mdnsd makes
+  `mdns.t` pair, restart the daemon while paired, and unpair via
+  `ensure_unpaired` for the first time, directly upstream of `pairing.t` and
+  `tasmota-protocol.t`. (This phase therefore depends on phase 1's
+  `ensure_unpaired` fix.)
+- Local `make integration` on a developer host (HVF/KVM) passes, with the host,
+  accelerator, and result recorded in the PR description.
 - `make check` stays green.

--- a/plans/002-integration-ci-green/plan-4.md
+++ b/plans/002-integration-ci-green/plan-4.md
@@ -1,8 +1,9 @@
-# Phase 4 — Cleanup and regression guards
+# Phase 4 — Cleanup, guards, and verification procedure
 
 With Phases 1–3 landed the integration suite is green. This phase removes the
-scaffolding added while chasing the failures and guards against silent
-regressions, so a future change cannot quietly re-break what was fixed.
+scaffolding added while chasing the failures, guards against silent regressions,
+repairs the failure-diagnostics path, and defines the procedure that actually
+verifies "green" — repeatably, on cold and warm caches.
 
 ## Tasks
 
@@ -10,43 +11,68 @@ regressions, so a future change cannot quietly re-break what was fixed.
 
 - `Makefile`: `[ ! -e lib/OpenHAP/Test/*.pm ] || install ...` errors with
   `[: ...: unexpected operator/operand` when the glob matches more than one file
-  (it now matches `Integration.pm` and others). Rewrite so the guard works with
-  zero, one, or many matches (e.g. a `for` loop, or a `set --` on the glob and
-  test `$#`), and produces no stderr noise. Confirm the `Test/` and
+  (it now matches `Controller.pm` and `Integration.pm`). Rewrite so the guard
+  works with zero, one, or many matches (e.g. a `for` loop, or `set --` on the
+  glob and test `$#`), and produces no stderr noise. Confirm the `Test/` and
   `Test/Controller/` modules still install.
 
-### 4.2 Guard the GMP backend in the guest
+### 4.2 Guard the GMP backend — hard failure, not a warning
 
 - The `try => 'GMP'` selection falls back silently to pure-Perl `Math::BigInt`,
-  which under TCG reintroduces multi-minute pair-setups. Make the loss of GMP
-  visible where it matters: e.g. an integration/environment assertion that
-  `Math::BigInt->config->{lib}` is the GMP backend in the VM, or a daemon
-  startup warning. Keep `make check` on hosts without GMP green (the guard is a
-  warning/CI assertion, not a hard `require`).
+  which under TCG reintroduces multi-minute pair-setups — exactly the
+  "slow-but-green" outcome design goal 2 forbids. A daemon log warning cannot
+  guard this: integration tests never parse logs, and nothing reads the guest
+  console on a green run.
+- Add a hard assertion to `t/openhap/integration/environment.t` (which runs
+  first) that `Math::BigInt->config->{lib}` is the GMP backend, updating its
+  `tests =>` plan (10 → 11). `make check` on hosts without GMP is unaffected:
+  the integration tier is not part of `make test`.
+- Close the delivery hole: the guest heredocs in `scripts/vm_provision.sh` and
+  `scripts/integration.sh` run without `set -e`, so a failed
+  `pkg_add`/`make deps` still reports a provisioned guest. Make them fail fast
+  and loudly.
 
-### 4.3 Remove temporary diagnostics
+### 4.3 Repair and trim diagnostics
 
-- `scripts/vm_provision.sh`: drop the foreground-`mdnsd` diagnostic block once
+- `scripts/integration.sh`: the failure log-capture block after the test heredoc
+  is unreachable today — `set -e` aborts the script at the failing `vm_run`
+  before `result=$?` runs. Restructure so the capture executes on failure, and
+  extend it to include `/var/db/openhapd` contents (pairing state) and
+  mdnsd/rcctl status alongside the daemon log.
+- `.github/workflows/integration.yml`: gate the VM diagnostics step on
+  `always() && !success()` so a `timeout-minutes` cancellation still runs it;
+  correct the disk-cache comment (saving is gated on job success, not on the
+  shutdown step); drop the foreground-`mdnsd` provisioning diagnostics once
   Phase 3 resolves mDNS, keeping only what a normal run needs.
-- `.github/workflows/integration.yml`: keep the failure-only VM diagnostics step
-  (it is cheap and useful) but prune anything made redundant.
 
-### 4.4 Full-suite verification
+### 4.4 Verification procedure and keep-it-green mechanism
 
-- Confirm a **cold-cache** run (cache miss → fresh install) and a **warm-cache**
-  run (reused disk) are both fully green — the warm path was rarely exercised
-  while every change invalidated the disk cache.
-- Confirm the workflow's `workflow_dispatch` path still runs against an
-  arbitrary branch.
+- Document how to produce each cache state on demand, in the `integration-tests`
+  skill: cold via a cache-version suffix in the disk-cache key (bump to
+  invalidate) or `gh cache delete`; warm via a re-run after a green run (the
+  cache saves only on success, so no warm cache exists until the suite first
+  passes end-to-end).
+- "Green" is repetition, not one run: three consecutive green workflow runs
+  (dispatch re-runs count), at least one cold-cache and one warm-cache, with
+  wall clock recorded against the job's 180-minute budget.
+- Add a weekly `schedule:` trigger to the Integration workflow so regressions
+  surface between pushes.
+- Confirm the `workflow_dispatch` path still runs against an arbitrary branch.
 
 ## Deliverables
 
-- `Makefile` glob fix; GMP-presence guard; trimmed provisioning/workflow.
+- `Makefile` glob fix; `environment.t` GMP assertion; fail-fast provisioning
+  heredocs; reachable and extended failure diagnostics; corrected workflow
+  comment; scheduled run; cache procedure documented in the `integration-tests`
+  skill.
 
 ## Acceptance criteria
 
 - `make install` runs with no stderr noise and installs all shipped modules.
-- The Integration workflow is green end-to-end on cold and warm cache, and a
-  missing GMP backend fails or warns visibly rather than silently slowing the
-  run.
+- A missing GMP backend fails the suite loudly at `environment.t`, verified once
+  by forcing the pure-Perl backend in a dispatch run.
+- Failure diagnostics demonstrably print on a red run, verified once by a
+  deliberately failed dispatch run.
+- Three consecutive green Integration runs, including one cold-cache and one
+  warm-cache run produced by the documented procedure, within the time budget.
 - `make check` stays green.


### PR DESCRIPTION
Amends plan 002 (integration CI green) after a two-round adversarial review whose load-bearing findings were verified against the tree. Docs-only: touches the five files under `plans/002-integration-ci-green/`.

- **Phase 1** now states the verified root cause — `ensure_unpaired` checks/unlinks `/var/db/openhapd/pairings` while the daemon persists to `pairings.db` (a no-op since it was written), seeded by `events.t` dying before its unpair teardown. The refuted stale-session hypotheses (that path returns Busy/7, never Unavailable/6) and the uncitable server-side reset are dropped; the vacuous 470 post-condition is replaced with `POST /identify`; provisioning wipes pairing state so warm-cache runs start clean; `events.t` passing is no longer a phase-1 criterion (forward dependency removed).
- **Phase 2** now leads with the verified daemon defect — `queue_event` has no callers, so no event is ever emitted — with an unconditional trigger-driven conformance test, `next_event` timeout/partial-frame fixes, and the timeout criterion scoped to the positive wait.
- **Phase 3** drops the SLIRP-multicast framing (all failing assertions are guest-local), ranks in-guest mdnsd lifecycle hypotheses (raced provisioning verify first), demotes any network-backend change to a separately planned last resort, and requires the full suite green.
- **Phase 4** makes the GMP guard a hard `environment.t` assertion, adds `set -e` to the guest heredocs, repairs the unreachable failure log-capture in `scripts/integration.sh`, defines the cold/warm cache forcing procedure, and adds a scheduled run plus a three-consecutive-green acceptance bar.
- **design.md** corrects the trigger description, the SLIRP framing, the taxonomy root causes, and the mDNS contract wording; the broken `hapctl status` readout is noted as out of scope.

Note: the Integration workflow is expected to stay red on this PR — the suite's baseline failures are what plan 002 exists to fix, and this change is documentation only (same situation as #10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196zmfNk6Z2uycDXRTjX1uJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0196zmfNk6Z2uycDXRTjX1uJ)_