### PR TITLE
ci: skip test and integration CI on docs-only changes, add prettier job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,10 @@ name: Build
 
 on:
   workflow_run:
-    workflows: ["Check"]
+    # Gate releases on the test suite. The Test workflow only runs when
+    # production code changed, so docs-only merges produce no release;
+    # the commit-count-derived tag simply skips ahead on the next one.
+    workflows: ["Test"]
     types:
       - completed
     branches:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,30 +3,8 @@ name: Check
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "**.pod"
-      - "spec/**"
-      - "plans/**"
-      - "man/**"
-      - ".claude/**"
-      - ".devcontainer/**"
-      - ".prettierrc"
-      - ".gitignore"
-      - "LICENSE"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "**.pod"
-      - "spec/**"
-      - "plans/**"
-      - "man/**"
-      - ".claude/**"
-      - ".devcontainer/**"
-      - ".prettierrc"
-      - ".gitignore"
-      - "LICENSE"
 
 jobs:
   tidy:
@@ -44,6 +22,16 @@ jobs:
 
       - name: Check formatting
         run: make tidy
+
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Markdown/JSON/YAML formatting
+        run: make prettier
 
   lint:
     name: Lint
@@ -65,22 +53,3 @@ jobs:
         run: |
           find lib -name "*.pm" -exec perl -I lib -cw {} \;
           find bin -type f -exec perl -I lib -cw {} \;
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Perl
-        uses: ./.github/actions/setup-perl
-
-      - name: Install test dependencies
-        run: make deps-test
-
-      - name: Run tests
-        run: make test
-
-      - name: Check spec coverage
-        run: make spec-coverage

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,8 +3,30 @@ name: Check
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "**.pod"
+      - "spec/**"
+      - "plans/**"
+      - "man/**"
+      - ".claude/**"
+      - ".devcontainer/**"
+      - ".prettierrc"
+      - ".gitignore"
+      - "LICENSE"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "**.pod"
+      - "spec/**"
+      - "plans/**"
+      - "man/**"
+      - ".claude/**"
+      - ".devcontainer/**"
+      - ".prettierrc"
+      - ".gitignore"
+      - "LICENSE"
 
 jobs:
   tidy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,8 +3,30 @@ name: Integration
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "**.pod"
+      - "spec/**"
+      - "plans/**"
+      - "man/**"
+      - ".claude/**"
+      - ".devcontainer/**"
+      - ".prettierrc"
+      - ".gitignore"
+      - "LICENSE"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "**.pod"
+      - "spec/**"
+      - "plans/**"
+      - "man/**"
+      - ".claude/**"
+      - ".devcontainer/**"
+      - ".prettierrc"
+      - ".gitignore"
+      - "LICENSE"
   # Manual runs against any branch, e.g. to test workflow changes
   # before merging
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "**.pod"
+      - "spec/**"
+      - "plans/**"
+      - "man/**"
+      - ".claude/**"
+      - ".devcontainer/**"
+      - ".prettierrc"
+      - ".gitignore"
+      - "LICENSE"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "**.pod"
+      - "spec/**"
+      - "plans/**"
+      - "man/**"
+      - ".claude/**"
+      - ".devcontainer/**"
+      - ".prettierrc"
+      - ".gitignore"
+      - "LICENSE"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Perl
+        uses: ./.github/actions/setup-perl
+
+      - name: Install test dependencies
+        run: make deps-test
+
+      - name: Run tests
+        run: make test
+
+      - name: Check spec coverage
+        run: make spec-coverage

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ GITHUB_RELEASE	= https://github.com/$(GITHUB_OWNER)/$(GITHUB_REPO)/releases/down
 # Build tools
 MANDOC			?= mandoc
 PERLTIDY		= perl -MPerl::Tidy -e 'Perl::Tidy::perltidy()'
+# Pinned so local runs and CI agree on formatting
+PRETTIER		= npx prettier@3.9.6
 
 # OS detection
 UNAME			!= uname
@@ -105,10 +107,10 @@ lint:
 man: $(CATMAN1) $(CATMAN5) $(CATMAN8)
 
 prettier:
-	@npx prettier --check '**/*.md' '**/*.json' '**/*.yml' || { echo "Run 'make prettier-fix' to fix formatting"; exit 1; }
+	@$(PRETTIER) --check '**/*.md' '**/*.json' '**/*.yml' || { echo "Run 'make prettier-fix' to fix formatting"; exit 1; }
 
 prettier-fix:
-	npx prettier --write '**/*.md' '**/*.json' '**/*.yml'
+	$(PRETTIER) --write '**/*.md' '**/*.json' '**/*.yml'
 
 spec-coverage:
 	@perl scripts/spec-coverage --quiet

--- a/spec/HAP-Encryption.md
+++ b/spec/HAP-Encryption.md
@@ -106,7 +106,7 @@ From `hapCrypto.ts` (`layerEncrypt`):
 export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
   const chunks: Buffer[] = [];
   const total = data.length;
-  for (let offset = 0; offset < total; ) {
+  for (let offset = 0; offset < total;) {
     const length = Math.min(total - offset, 0x400);
     const leLength = Buffer.alloc(2);
     leLength.writeUInt16LE(length, 0);

--- a/spec/IMPLEMENTATIONS.md
+++ b/spec/IMPLEMENTATIONS.md
@@ -608,7 +608,7 @@ ChaCha20-Poly1305.
 export function layerEncrypt(data: Buffer, encryption: HAPEncryption): Buffer {
   const chunks: Buffer[] = [];
   const total = data.length;
-  for (let offset = 0; offset < total; ) {
+  for (let offset = 0; offset < total;) {
     const length = Math.min(total - offset, 0x400);
     const leLength = Buffer.alloc(2);
     leLength.writeUInt16LE(length, 0);


### PR DESCRIPTION
Run the test suite and the OpenBSD VM integration job only when production code changed, while formatting and lint checks always run.

- **New `Test` workflow**: the test job (`make test` + `make spec-coverage`) moves out of Check into its own workflow with `paths-ignore` filters, so it skips on changes limited to `**.md`, `**.pod`, `spec/**`, `plans/**`, `man/**`, `.claude/**`, `.devcontainer/**`, `.prettierrc`, `.gitignore`, `LICENSE`.
- **`Integration` workflow** gets the same `paths-ignore` filters on its `push`/`pull_request` triggers; manual `workflow_dispatch` runs are unaffected.
- **`Check` workflow** (tidy, lint) always runs, and gains a new **Prettier** job running `make prettier` — Markdown/JSON/YAML formatting was previously not checked in CI at all.
- **`Build` workflow** re-points its `workflow_run` trigger from Check to Test so releases stay gated on the test suite.

A denylist was chosen over a "production paths" allowlist so anything not explicitly known to be inert still triggers the test workflows: `lib/`, `bin/`, `t/`, `share/` (openhvf expect scripts used by integration tests), `etc/`, `deps/`, `scripts/`, `Makefile`, `cpanfile`, lint/tidy/openhvf configuration, and the workflow files themselves all remain triggers.

Known tradeoffs:

- A spec-only change skips `make spec-coverage`, so a renamed/removed spec section cited by a conformance test is only caught on the next code-triggering push.
- Docs-only merges to `main` skip the Test workflow and therefore produce no release; the commit-count-derived tag simply skips ahead on the next one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDsJrUgFNjvfcaatqBZkKo