### PR TITLE
Implement plan 002: integration CI green

### DIFF
--- a/.claude/skills/integration-tests/SKILL.md
+++ b/.claude/skills/integration-tests/SKILL.md
@@ -53,6 +53,25 @@ Common causes:
   (`rcctl start mosquitto`).
 - mDNS tests fail — mdnsd not installed or not started (`rcctl start mdnsd`).
 
+## CI verification procedure
+
+The Integration workflow (`.github/workflows/integration.yml`) runs the suite in
+an OpenBSD VM on pushes to main, PRs, a weekly schedule, and `workflow_dispatch`
+against any branch. "Green" means repetition, not one run: **three consecutive
+green workflow runs, at least one cold-cache and one warm-cache**, with wall
+clock recorded against the job's 180-minute budget.
+
+Producing each cache state on demand:
+
+- **Cold cache** (fresh OpenBSD install from the miniroot): bump the `v<N>`
+  suffix in the `openhvf-state-*` cache key in the workflow, or delete the cache
+  with `gh cache delete` (or the repository's Actions → Caches UI), then
+  dispatch a run.
+- **Warm cache** (reused provisioned disk): re-run after a green run. The disk
+  cache saves only when the job succeeds, so no warm cache exists until the
+  suite first passes end-to-end; a re-run of that green run then boots the
+  cached disk.
+
 ## References
 
 - `t/openhap/integration/CLAUDE.md` — test philosophy and how to write new

--- a/.claude/skills/integration-tests/SKILL.md
+++ b/.claude/skills/integration-tests/SKILL.md
@@ -51,7 +51,12 @@ Common causes:
   user exists, and `/var/db/openhapd` permissions.
 - MQTT tests fail — mosquitto not installed or not started
   (`rcctl start mosquitto`).
-- mDNS tests fail — mdnsd not installed or not started (`rcctl start mdnsd`).
+- mDNS tests fail — mdnsd not installed, not started, or its flags name a
+  nonexistent interface (the openmdns package defaults to `em0`; mdnsd exits
+  fatally on an unknown interface). Check `rcctl get mdnsd` and set the flags to
+  the guest's real interface — `rcctl enable mdnsd` first, since rcctl refuses
+  to set flags on a disabled daemon. The test helpers emit captured rcctl/syslog
+  diagnostics when mdnsd will not stay up.
 
 ## CI verification procedure
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,9 @@ on:
   # Manual runs against any branch, e.g. to test workflow changes
   # before merging
   workflow_dispatch:
+  # Weekly run so regressions surface between pushes
+  schedule:
+    - cron: "30 5 * * 1"
 
 concurrency:
   group: integration-${{ github.ref }}
@@ -65,14 +68,17 @@ jobs:
           key: openhvf-image-${{ hashFiles('.openhvfrc') }}
 
       - name: Cache provisioned VM disk
-        # Saved only after a clean shutdown (see the last step), so a
-        # cache hit boots the already-installed OpenBSD system instead
-        # of reinstalling it from the miniroot on every run.
+        # The cache post-step saves only when the job succeeds; the
+        # clean-shutdown step below keeps the archived qcow2 consistent.
+        # A cache hit boots the already-installed OpenBSD system instead
+        # of reinstalling it from the miniroot on every run. Bump the
+        # v<N> suffix in the key to force a cold-cache run (see the
+        # integration-tests skill).
         uses: actions/cache@v4
         with:
           path: .openhvf
           key:
-            openhvf-state-${{ runner.arch }}-${{ hashFiles('.openhvfrc',
+            openhvf-state-v1-${{ runner.arch }}-${{ hashFiles('.openhvfrc',
             'deps/OpenBSD.txt', 'scripts/vm_provision.sh') }}
 
       - name: Generate ephemeral SSH key for the VM
@@ -102,7 +108,9 @@ jobs:
           make integration
 
       - name: Show VM diagnostics on failure
-        if: failure()
+        # Not plain failure(): a timeout-minutes cancellation must
+        # still show the diagnostics
+        if: always() && !success()
         run: |
           echo "==> openhvf status"
           ./bin/openhvf status || true

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,16 @@ install: install-man
 	install -m 644 lib/OpenHAP/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/
 	install -m 644 lib/OpenHAP/Tasmota/*.pm $(DESTDIR)$(LIBDIR)/OpenHAP/Tasmota/
 	install -m 644 lib/OpenHAP/Tasmota/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/Tasmota/
-	[ ! -e lib/OpenHAP/Test/*.pm ] || install -m 644 lib/OpenHAP/Test/*.pm $(DESTDIR)$(LIBDIR)/OpenHAP/Test/
-	[ ! -e lib/OpenHAP/Test/*.pod ] || install -m 644 lib/OpenHAP/Test/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/Test/
-	[ ! -e lib/OpenHAP/Test/Controller/*.pm ] || install -m 644 lib/OpenHAP/Test/Controller/*.pm $(DESTDIR)$(LIBDIR)/OpenHAP/Test/Controller/
-	[ ! -e lib/OpenHAP/Test/Controller/*.pod ] || install -m 644 lib/OpenHAP/Test/Controller/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/Test/Controller/
+	# Test helper modules ship only in the packaged tree; the glob
+	# loops handle zero, one, or many matches without stderr noise
+	for f in lib/OpenHAP/Test/*.pm lib/OpenHAP/Test/*.pod; do \
+		[ -e "$$f" ] || continue; \
+		install -m 644 "$$f" $(DESTDIR)$(LIBDIR)/OpenHAP/Test/; \
+	done
+	for f in lib/OpenHAP/Test/Controller/*.pm lib/OpenHAP/Test/Controller/*.pod; do \
+		[ -e "$$f" ] || continue; \
+		install -m 644 "$$f" $(DESTDIR)$(LIBDIR)/OpenHAP/Test/Controller/; \
+	done
 	install -m 644 lib/FuguLib/*.pm $(DESTDIR)$(LIBDIR)/FuguLib/
 	install -m 644 lib/FuguLib/*.pod $(DESTDIR)$(LIBDIR)/FuguLib/
 	# Install rc.d script

--- a/lib/OpenHAP/Bridge.pm
+++ b/lib/OpenHAP/Bridge.pm
@@ -53,10 +53,12 @@ sub add_bridged_accessory ( $self, $accessory )
 		$accessory->{aid}, $accessory->{name} );
 	push @{ $self->{bridged_accessories} }, $accessory;
 
-	# Forward event callbacks
+	# Forward event callbacks, preserving the device aid
 	$accessory->add_event_callback(
 		sub ( $aid, $iid ) {
-			$self->notify_change($iid);
+			for my $callback ( @{ $self->{event_callbacks} } ) {
+				$callback->( $aid, $iid );
+			}
 		} );
 }
 

--- a/lib/OpenHAP/Bridge.pod
+++ b/lib/OpenHAP/Bridge.pod
@@ -19,6 +19,11 @@ bridged accessories. The bridge accessory carries the mandatory
 AccessoryInformation and ProtocolInformation services; bridged
 accessories carry only AccessoryInformation.
 
+Change notifications from bridged accessories are forwarded to the
+bridge's own event callbacks with the originating accessory's aid
+preserved, so the server can deliver EVENT/1.0 notifications for
+device-side changes.
+
 =head1 SEE ALSO
 
 L<OpenHAP::Accessory>, F<spec/HAP.md>, F<spec/HAP-Categories.md>

--- a/lib/OpenHAP/HAP.pm
+++ b/lib/OpenHAP/HAP.pm
@@ -14,6 +14,7 @@ use OpenHAP::Pairing;
 use OpenHAP::Storage;
 use OpenHAP::Crypto;
 use OpenHAP::Bridge;
+use OpenHAP::Characteristic;
 use OpenHAP::PIN qw(normalize_pin);
 
 sub new ( $class, %args )
@@ -73,6 +74,29 @@ sub _initialize ($self)
 
 	# Initialize bridge
 	$self->{bridge} = OpenHAP::Bridge->new( name => $self->{name}, );
+
+	# Deliver device-side changes as EVENT/1.0 notifications: the
+	# bridge forwards each bridged accessory's notify_change with
+	# the device aid preserved (HAP-HTTP.md §14)
+	$self->{bridge}->add_event_callback(
+		sub ( $aid, $iid ) {
+			$self->_queue_change_event( $aid, $iid );
+		} );
+}
+
+# $self->_queue_change_event($aid, $iid):
+#	Queue an event carrying the characteristic's current value
+sub _queue_change_event ( $self, $aid, $iid )
+{
+	my $accessory = $self->{bridge}->get_accessory($aid);
+	return unless $accessory;
+
+	my $char = $accessory->get_characteristic($iid);
+	return unless $char;
+
+	$self->queue_event( $aid, $iid, $char->json_value );
+
+	return;
 }
 
 sub add_accessory ( $self, $accessory )
@@ -229,6 +253,7 @@ sub _handle_client ( $self, $sock, $select )
 		# session held it, so an aborted pair-setup cannot lock
 		# out pairing until restart
 		OpenHAP::Pairing->clear_pairing_state($session);
+		$self->_purge_event_subscriptions($session);
 		$OpenHAP::logger->info( 'Client disconnected from %s',
 			$sock->peerhost );
 		$select->remove($sock);
@@ -247,6 +272,7 @@ sub _handle_client ( $self, $sock, $select )
 			$OpenHAP::logger->warning(
 				'Decryption failed for client session');
 			OpenHAP::Pairing->clear_pairing_state($session);
+			$self->_purge_event_subscriptions($session);
 			$select->remove($sock);
 			delete $self->{sessions}{$sock};
 			$sock->close();
@@ -539,6 +565,11 @@ sub _handle_characteristics_put ( $self, $request, $session )
 				$has_errors = 1;
 				next;
 			}
+
+			# Notify subscribers on other connections; the
+			# originating session is excluded (HAP-HTTP.md §14)
+			$self->queue_event( $aid, $iid, $char->json_value,
+				$session );
 		}
 
 		# Enable/disable events
@@ -876,18 +907,36 @@ sub _unregister_event_subscription ( $self, $session, $aid, $iid )
 		$key );
 }
 
-# Characteristic UUIDs for button events (require immediate delivery)
-# ProgrammableSwitchEvent (0x73), ButtonEvent (0x126)
+# $self->_purge_event_subscriptions($session):
+#	Drop every subscription held by a disconnecting session -
+#	subscriptions are per-connection (HAP-HTTP.md §14)
+sub _purge_event_subscriptions ( $self, $session )
+{
+	for my $subs ( values %{ $self->{event_subscriptions} } ) {
+		delete $subs->{$session};
+	}
+
+	return;
+}
+
+# Characteristic types exempt from coalescing (HAP-HTTP.md §14):
+# ProgrammableSwitchEvent (0x73), ButtonEvent (0x126),
+# MotionDetected (0x22), ContactSensorState (0x6A)
 use constant IMMEDIATE_EVENT_TYPES => {
 	'73'  => 1,
 	'126' => 1,
+	'22'  => 1,
+	'6A'  => 1,
 };
 
 # Event coalescing delay in seconds (HAP-HTTP.md §14)
 use constant EVENT_COALESCE_DELAY => 0.250;
 
-# Queue an event for delivery, with coalescing for non-button events
-sub queue_event ( $self, $aid, $iid, $value )
+# Queue an event for delivery, with coalescing for all but the
+# immediate-delivery characteristic types. The optional $originator is
+# the session whose request caused the change; it never receives the
+# event (HAP-HTTP.md §14)
+sub queue_event ( $self, $aid, $iid, $value, $originator = undef )
 {
 	my $accessory = $self->{bridge}->get_accessory($aid);
 	return unless $accessory;
@@ -895,23 +944,22 @@ sub queue_event ( $self, $aid, $iid, $value )
 	my $char = $accessory->get_characteristic($iid);
 	return unless $char;
 
-	# Get characteristic type (short form UUID)
-	my $char_type = $char->{type} // '';
-	$char_type =~ s/^0+//;    # Strip leading zeros
-
-	# Button events get immediate delivery
+	# Immediate types bypass coalescing
+	my $char_type =
+	    OpenHAP::Characteristic::_uuid_to_short( $char->{type} // '' );
 	if ( IMMEDIATE_EVENT_TYPES->{$char_type} ) {
-		$self->send_event( $aid, $iid, $value );
+		$self->send_event( $aid, $iid, $value, $originator );
 		return;
 	}
 
 	# Queue event for coalescing
 	my $key = "$aid.$iid";
 	$self->{event_queue}{$key} = {
-		aid       => $aid,
-		iid       => $iid,
-		value     => $value,
-		timestamp => Time::HiRes::time(),
+		aid        => $aid,
+		iid        => $iid,
+		value      => $value,
+		originator => $originator,
+		timestamp  => Time::HiRes::time(),
 	};
 
 	# Schedule flush if not already scheduled
@@ -931,8 +979,9 @@ sub flush_events ($self)
 
 	# Send all queued events
 	for my $event ( values %{ $self->{event_queue} } ) {
-		$self->send_event( $event->{aid}, $event->{iid},
-			$event->{value} );
+		$self->send_event(
+			$event->{aid},   $event->{iid},
+			$event->{value}, $event->{originator} );
 	}
 
 	# Clear queue
@@ -940,8 +989,9 @@ sub flush_events ($self)
 	$self->{event_flush_scheduled} = undef;
 }
 
-# Send EVENT/1.0 notification to subscribed sessions
-sub send_event ( $self, $aid, $iid, $value )
+# Send EVENT/1.0 notification to subscribed sessions, excluding the
+# originating session if one is given (HAP-HTTP.md §14)
+sub send_event ( $self, $aid, $iid, $value, $originator = undef )
 {
 	my $key  = "$aid.$iid";
 	my $subs = $self->{event_subscriptions}{$key} // {};
@@ -960,6 +1010,7 @@ sub send_event ( $self, $aid, $iid, $value )
 
 	for my $session ( values %$subs ) {
 		next unless $session && $session->is_encrypted();
+		next if defined $originator && $session == $originator;
 
 		my $encrypted = $session->encrypt($event_msg);
 		my $socket    = $session->{socket};

--- a/lib/OpenHAP/HAP.pod
+++ b/lib/OpenHAP/HAP.pod
@@ -20,6 +20,14 @@ OpenHAP::HAP - Main HAP server
 This module implements the main HAP server with HTTP endpoints,
 pairing, and accessory management.
 
+Characteristic changes - whether written over HTTP or reported by a
+device - are delivered to subscribed connections as EVENT/1.0
+notifications, coalesced over a 250 ms window except for the
+immediate-delivery characteristic types (see F<spec/HAP-HTTP.md>
+section 14). The connection whose request caused a change never
+receives an event for its own write, and a connection's subscriptions
+end when it closes.
+
 =head1 SEE ALSO
 
 F<spec/HAP.md>, F<spec/HAP-HTTP.md>

--- a/lib/OpenHAP/MQTT.pm
+++ b/lib/OpenHAP/MQTT.pm
@@ -102,11 +102,13 @@ sub subscribe ( $self, $topic, $callback )
 	return unless $self->{connected} && $self->{client};
 
 	# Net::MQTT::Simple uses a different subscription model
-	# We register topics and poll for messages in tick()
+	# We register topics and poll for messages in tick().
+	# Since 1.33 it passes a retain flag as a third argument;
+	# accept and ignore any extra arguments.
 	eval {
 		$self->{client}->subscribe(
 			$topic,
-			sub ( $topic_received, $payload ) {
+			sub ( $topic_received, $payload, @ ) {
 				push @{ $self->{pending_messages} },
 				    [ $topic_received, $payload ];
 			} );
@@ -275,7 +277,7 @@ sub resubscribe ($self)
 		eval {
 			$self->{client}->subscribe(
 				$topic,
-				sub ( $topic_received, $payload ) {
+				sub ( $topic_received, $payload, @ ) {
 					push @{ $self->{pending_messages} },
 					    [ $topic_received, $payload ];
 				} );

--- a/lib/OpenHAP/Test/Controller.pm
+++ b/lib/OpenHAP/Test/Controller.pm
@@ -66,6 +66,7 @@ sub new ( $class, %args )
 
 		socket     => undef,
 		inbuf      => '',
+		rawbuf     => '',
 		last_error => undef,
 	}, $class;
 
@@ -116,6 +117,7 @@ sub close ($self)
 	}
 	$self->{encrypted} = 0;
 	$self->{inbuf}     = '';
+	$self->{rawbuf}    = '';
 	return 1;
 }
 
@@ -622,13 +624,18 @@ sub list_pairings ($self)
 
 # --- events -------------------------------------------------------------
 
-# $self->next_event($timeout):
+# $self->next_event($timeout?):
 #	Wait for an EVENT/1.0 message on the socket, decrypt and parse
 #	it. Returns { status, headers, body } or undef on timeout.
-#	Requires a socket connection (not an injected transport).
-sub next_event ( $self, $timeout = 5 )
+#	Without an explicit $timeout the wait is bounded by the session
+#	timeout (which honors OPENHAP_TEST_TIMEOUT); pass a literal only
+#	for short negative probes. Requires a socket connection (not an
+#	injected transport).
+sub next_event ( $self, $timeout = undef )
 {
 	return unless $self->{socket};
+
+	$timeout //= $self->{timeout};
 
 	my $select = IO::Select->new( $self->{socket} );
 	my $end    = time + $timeout;
@@ -663,11 +670,48 @@ sub next_event ( $self, $timeout = 5 )
 		my $bytes = $self->{socket}->sysread( my $chunk, 65535 );
 		return unless $bytes;
 
-		my $plain =
-		    $self->{encrypted} ? $self->_decrypt($chunk) : $chunk;
+		unless ( $self->{encrypted} ) {
+			$self->{inbuf} .= $chunk;
+			next;
+		}
+
+		# A frame may arrive split across reads: accumulate raw
+		# bytes and decrypt only complete frames, leaving a
+		# partial tail buffered so the nonce counter stays in
+		# sync with the accessory
+		$self->{rawbuf} .= $chunk;
+		my $plain = $self->_drain_frames;
 		return unless defined $plain;
 		$self->{inbuf} .= $plain;
 	}
+}
+
+# $self->_drain_frames():
+#	Decrypt and consume every complete frame at the front of the
+#	raw receive buffer; a trailing partial frame stays buffered for
+#	the next read. Returns the decrypted plaintext (possibly
+#	empty), or undef on an authentication failure.
+sub _drain_frames ($self)
+{
+	my $out = '';
+	while ( length( $self->{rawbuf} ) >= 2 ) {
+		my $length = unpack( 'v', substr( $self->{rawbuf}, 0, 2 ) );
+		return if $length > MAX_FRAME;
+		last   if length( $self->{rawbuf} ) < 2 + $length + 16;
+
+		my $frame = substr( $self->{rawbuf}, 0, 2 + $length + 16, '' );
+		my $aad        = substr( $frame, 0,           2 );
+		my $ciphertext = substr( $frame, 2,           $length );
+		my $tag        = substr( $frame, 2 + $length, 16 );
+
+		my $nonce = pack( 'x[4]Q<', $self->{decrypt_count}++ );
+		my $plain =
+		    OpenHAP::Crypto::chacha20_poly1305_decrypt(
+			$self->{decrypt_key}, $nonce, $ciphertext, $tag, $aad );
+		return unless defined $plain;
+		$out .= $plain;
+	}
+	return $out;
 }
 
 1;

--- a/lib/OpenHAP/Test/Controller.pod
+++ b/lib/OpenHAP/Test/Controller.pod
@@ -20,7 +20,7 @@ OpenHAP::Test::Controller - minimal HomeKit controller for tests
         '{"characteristics":[{"aid":2,"iid":11,"value":true}]}',
         { 'Content-Type' => 'application/hap+json' });
 
-    my $event = $c->next_event(5);
+    my $event = $c->next_event;
 
     $c->remove_pairing;    # cleanup for test teardown
 
@@ -70,11 +70,15 @@ Perform one HTTP request over the session, encrypted once pair-verify
 has completed. Returns a hash ref with C<status>, C<headers> (lower
 cased names) and C<body>.
 
-=head2 next_event($timeout)
+=head2 next_event($timeout?)
 
-Wait up to $timeout seconds for an EVENT/1.0 message, decrypt and
-parse it. Returns a hash ref with C<status>, C<headers> and C<body>,
-or undef on timeout. Requires a socket connection.
+Wait for an EVENT/1.0 message, decrypt and parse it. Returns a hash
+ref with C<status>, C<headers> and C<body>, or undef on timeout.
+Without an explicit $timeout the wait is bounded by the session
+timeout, which honors OPENHAP_TEST_TIMEOUT - pass a literal only for
+short negative probes ("no event arrives"). Event frames split across
+socket reads are reassembled without desynchronizing the session nonce
+counter. Requires a socket connection.
 
 =head2 add_pairing($identifier, $ltpk, $permissions)
 

--- a/lib/OpenHAP/Test/Integration.pm
+++ b/lib/OpenHAP/Test/Integration.pm
@@ -46,6 +46,8 @@ use constant {
 	DB_PATH           => '/var/db/openhapd',
 };
 
+use constant PAIRINGS_FILE => DB_PATH . '/pairings.db';
+
 sub new ( $class, %options )
 {
 	my $self = bless {
@@ -102,10 +104,7 @@ sub teardown ($self)
 	$self->{controllers} = [];
 
 	# Close any open sockets
-	for my $socket ( @{ $self->{sockets} } ) {
-		$socket->close if defined $socket;
-	}
-	$self->{sockets} = [];
+	$self->close_sockets;
 
 	# Disconnect MQTT if connected
 	if ( defined $self->{mqtt} ) {
@@ -135,21 +134,86 @@ sub get_controller ( $self, %args )
 }
 
 # $self->ensure_unpaired():
-#	Guarantee the daemon starts unpaired: when stored pairings
-#	exist, stop the daemon, wipe the pairing state (keeping the
-#	accessory identity), and start it again.
+#	Guarantee the daemon is verifiably unpaired: when stored
+#	pairings exist, stop the daemon, wipe the pairing state
+#	(keeping the accessory identity), and start it again. The
+#	post-condition is probed with POST /identify, which succeeds
+#	only while unpaired (HAP-HTTP.md §3).
 sub ensure_unpaired ($self)
 {
-	my $pairings_file = DB_PATH . '/pairings';
-	return 1 unless -s $pairings_file;
+	if ( $self->_has_pairings ) {
+		$self->ensure_daemon_stopped or return;
 
-	$self->ensure_daemon_stopped or return;
+		for my $file ( PAIRINGS_FILE, DB_PATH . '/auth_attempts' ) {
+			next unless -e $file;
+			unlink $file or do {
+				warn "Cannot remove $file: $!\n";
+				return;
+			};
+		}
 
-	unlink $pairings_file
-	    or do { warn "Cannot remove $pairings_file: $!\n"; return; };
-	unlink DB_PATH . '/auth_attempts';
+		$self->ensure_daemon_running or return;
+	}
 
-	$self->ensure_daemon_running or return;
+	return $self->_verify_unpaired;
+}
+
+# $self->_has_pairings():
+#	True when the pairings database holds at least one entry. The
+#	daemon leaves comment headers in the file after its first save,
+#	so a size check cannot tell paired from unpaired - parse for
+#	non-comment lines instead.
+sub _has_pairings ($self)
+{
+	open my $fh, '<', PAIRINGS_FILE or return 0;
+	while (<$fh>) {
+		next if /^#/ || /^\s*$/;
+		close $fh;
+		return 1;
+	}
+	close $fh;
+
+	return 0;
+}
+
+# $self->_verify_unpaired():
+#	Probe the pairing state with POST /identify: 204 only when
+#	unpaired, 400 with {"status":-70401} when still paired
+#	(HAP-HTTP.md §3). Fails loudly on the paired answer. The probe
+#	socket is closed immediately rather than left registered with
+#	the daemon until teardown.
+sub _verify_unpaired ($self)
+{
+	my $before   = scalar @{ $self->{sockets} };
+	my $response = $self->http_request( 'POST', '/identify' );
+	for my $socket ( splice @{ $self->{sockets} }, $before ) {
+		$socket->close if defined $socket;
+	}
+
+	unless ( defined $response ) {
+		warn "No response to identify probe\n";
+		return;
+	}
+
+	my ($status) = parse_http_response($response);
+	return 1 if defined $status && $status == 204;
+
+	warn sprintf "Daemon not unpaired: identify returned %s\n",
+	    $status // 'no status';
+
+	return;
+}
+
+# $self->close_sockets():
+#	Close and forget every raw socket opened by http_request, so a
+#	probe connection is not left registered with the daemon until
+#	teardown.
+sub close_sockets ($self)
+{
+	for my $socket ( @{ $self->{sockets} } ) {
+		$socket->close if defined $socket;
+	}
+	$self->{sockets} = [];
 
 	return 1;
 }

--- a/lib/OpenHAP/Test/Integration.pm
+++ b/lib/OpenHAP/Test/Integration.pm
@@ -325,6 +325,52 @@ sub ensure_daemon_stopped ($self)
 	return system('rcctl check openhapd >/dev/null 2>&1') != 0;
 }
 
+# $self->ensure_mdnsd_running():
+#	Ensure mdnsd is running and stays running: start it if needed,
+#	then re-check across a settle window, because a point-in-time
+#	probe races green when mdnsd starts and then exits shortly
+#	after. On failure, captured diagnostics are emitted so a dead
+#	mdnsd is diagnosable from the test output instead of failing
+#	bare.
+sub ensure_mdnsd_running ($self)
+{
+	my $check = 'rcctl check mdnsd >/dev/null 2>&1';
+
+	unless ( system($check) == 0 ) {
+		system('rcctl enable mdnsd >/dev/null 2>&1');
+		system('rcctl start mdnsd >/dev/null 2>&1');
+	}
+
+	for my $probe ( 1 .. 3 ) {
+		sleep 1;
+		next if system($check) == 0;
+		$self->_warn_mdnsd_diagnostics(
+			"mdnsd not running at settle probe $probe/3");
+		return;
+	}
+
+	return 1;
+}
+
+# $self->_warn_mdnsd_diagnostics($reason):
+#	Emit captured mdnsd state - rcctl views, the process list, and
+#	recent syslog lines - as warnings for the failure diagnostics.
+sub _warn_mdnsd_diagnostics ( $self, $reason )
+{
+	my $syslog = SYSLOG_FILE;
+
+	warn "$reason\n";
+	warn 'rcctl get mdnsd: ' . `rcctl get mdnsd 2>&1`;
+	warn 'mdnsd processes: '
+	    . ( `ps -axo pid,command 2>/dev/null | grep -w mdnsd | grep -v grep`
+		    || "none\n" );
+	warn "recent mdnsd syslog lines:\n"
+	    . (        `tail -200 $syslog 2>/dev/null | grep mdnsd | tail -20`
+		    || "none\n" );
+
+	return;
+}
+
 sub ensure_mqtt_running ($self)
 {
 	# Check if already running

--- a/lib/OpenHAP/Test/Integration.pod
+++ b/lib/OpenHAP/Test/Integration.pod
@@ -93,16 +93,28 @@ passed through to the controller constructor.
 
     $env->ensure_unpaired or die 'cannot unpair';
 
-Guarantee the daemon starts unpaired. When stored pairings exist, the
-daemon is stopped, the pairing state under /var/db/openhapd is wiped
-(the accessory identity is kept), and the daemon is started again.
-Every integration test file starts unpaired unless it pairs itself.
+Guarantee the daemon is verifiably unpaired. When the pairings database
+(/var/db/openhapd/pairings.db) holds any entry, the daemon is stopped,
+the pairing state is wiped - pairings.db and auth_attempts, keeping the
+accessory identity - and the daemon is started again. The post-condition
+is then probed with POST /identify, which returns 204 only while
+unpaired; a paired answer fails the call. Returns true on a verified
+unpaired daemon, false otherwise. Every integration test file starts
+unpaired unless it pairs itself.
 
 =head2 http_request
 
     my $response = $env->http_request($method, $path, $body, $headers);
 
-Make an HTTP request to the HAP server.
+Make an HTTP request to the HAP server. The connection stays open and
+registered until C<teardown> (or C<close_sockets>).
+
+=head2 close_sockets
+
+    $env->close_sockets;
+
+Close and forget every raw socket opened by C<http_request>, so a probe
+connection is not left registered with the daemon until teardown.
 
 =head2 parse_http_response
 

--- a/lib/OpenHAP/Test/Integration.pod
+++ b/lib/OpenHAP/Test/Integration.pod
@@ -44,6 +44,11 @@ Integration tests require:
 
 =item * Data directory /var/db/openhapd
 
+=item * mosquitto(8) installed and startable via rcctl (MQTT tests)
+
+=item * mdnsd(8) and mdnsctl(8) installed, with mdnsd's flags set to a
+usable network interface and startable via rcctl (mDNS tests)
+
 =back
 
 =head1 METHODS
@@ -159,6 +164,16 @@ Ensure openhapd is stopped.
     $env->ensure_mqtt_running or die "MQTT required";
 
 Ensure MQTT broker is running.
+
+=head2 ensure_mdnsd_running
+
+    $env->ensure_mdnsd_running or die "mdnsd required";
+
+Ensure mdnsd is running and stays running: start it if needed, then
+re-check across a settle window, because a point-in-time probe races
+green when mdnsd starts and then exits shortly after. On failure,
+captured diagnostics (rcctl state, process list, recent syslog lines)
+are emitted as warnings.
 
 =head2 get_log_lines
 

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -31,8 +31,14 @@ cd /tmp && tar xzf tests.tar.gz
 # shared mocks in t/lib) over the installed copies
 cp -R lib/OpenHAP/Test /usr/local/libdata/perl5/site_perl/OpenHAP/
 
-# Clean up any orphaned processes from previous test runs
-# This ensures a known-good state before running tests
+# Clean up any orphaned processes from previous test runs, gracefully:
+# a SIGKILLed mdnsctl leaves mdnsd holding a dead client socket, which
+# is a suspected cause of mdnsd exiting under client churn. TERM first,
+# KILL only stragglers.
+rcctl stop openhapd >/dev/null 2>&1 || true
+pkill -f 'perl.*openhapd' 2>/dev/null || true
+pkill mdnsctl 2>/dev/null || true
+sleep 2
 pkill -9 -f 'perl.*openhapd' 2>/dev/null || true
 pkill -9 mdnsctl 2>/dev/null || true
 sleep 1

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -24,7 +24,13 @@ vm_scp "${TARBALL}" "root@127.0.0.1:/tmp/tests.tar.gz"
 rm -f "${TARBALL}"
 
 echo "==> Running integration tests..."
+# The heredoc runs under its own set -e so a broken guest setup step
+# fails the run loudly instead of reporting a half-prepared suite; the
+# host-side set -e is suspended so the failure diagnostics below stay
+# reachable when vm_run fails.
+set +e
 vm_run <<'EOF'
+set -e
 cd /tmp && tar xzf tests.tar.gz
 
 # Refresh the shipped test helper modules (Test::Controller and the
@@ -62,11 +68,10 @@ for test in t/openhap/integration/*.t; do
 	TESTS="$TESTS $test"
 done
 
+result=0
 if command -v prove >/dev/null 2>&1; then
-	prove -I/usr/local/libdata/perl5/site_perl -It/lib -v $TESTS
-	result=$?
+	prove -I/usr/local/libdata/perl5/site_perl -It/lib -v $TESTS || result=$?
 else
-	result=0
 	for test in $TESTS; do
 		[ -f "$test" ] || continue
 		echo "Running $test..."
@@ -77,13 +82,21 @@ fi
 rm -rf /tmp/t /tmp/lib /tmp/tests.tar.gz
 exit $result
 EOF
-
 result=$?
+set -e
 
 if [ ${result} -ne 0 ]; then
-	echo "==> Capturing logs..."
+	echo "==> Capturing failure diagnostics..."
+	echo "-- daemon log --"
 	vm_run 'cat /var/log/openhapd.log 2>/dev/null' || true
-	vm_run 'tail -50 /var/log/daemon 2>/dev/null | grep openhap' || true
+	vm_run 'tail -80 /var/log/daemon 2>/dev/null | grep -e openhap -e mdnsd' || true
+	echo "-- pairing state (/var/db/openhapd) --"
+	vm_run 'ls -l /var/db/openhapd 2>/dev/null;
+		cat /var/db/openhapd/pairings.db 2>/dev/null' || true
+	echo "-- service status --"
+	vm_run 'rcctl check openhapd; rcctl check mdnsd; rcctl get mdnsd;
+		ps -axo pid,command | grep -e mdnsd -e mdnsctl |
+		grep -v grep' || true
 fi
 
 exit ${result}

--- a/scripts/vm_provision.sh
+++ b/scripts/vm_provision.sh
@@ -94,12 +94,16 @@ cd /tmp && rm -rf openhap-* openhap.tar.gz
 rcctl enable mosquitto
 rcctl check mosquitto >/dev/null || rcctl start mosquitto
 
-# Configure and start mdnsd on the primary network interface. mdnsd
-# needs an interface for multicast DNS; started without one it exits
-# immediately, which later surfaces as failing mDNS integration tests.
+# Configure and start mdnsd on the primary network interface. The
+# openmdns package ships an rc script whose default flags name an
+# interface this guest does not have (em0), and mdnsd exits fatally
+# on an unknown interface - so the flags must always be set to a real
+# interface here. Guard on the rc script, NOT on 'rcctl get': its exit
+# status reflects whether the service is enabled, which is false on
+# every fresh disk and silently skipped this whole block.
 # Prefer the default-route interface, fall back to the first UP, non
 # loopback interface, and verify the daemon actually came up.
-if rcctl get mdnsd >/dev/null 2>&1; then
+if [ -x /etc/rc.d/mdnsd ]; then
 	IFACE=$(route -n show -inet 2>/dev/null |
 		awk '/^default/ { print $NF; exit }')
 	[ -n "${IFACE}" ] || IFACE=$(ifconfig -a |

--- a/scripts/vm_provision.sh
+++ b/scripts/vm_provision.sh
@@ -110,8 +110,10 @@ if [ -x /etc/rc.d/mdnsd ]; then
 		awk -F: '/^[a-z].*<UP,/ && !/^(lo|enc|pflog)/ { print $1; exit }')
 
 	if [ -n "${IFACE}" ]; then
-		rcctl set mdnsd flags "${IFACE}"
+		# Enable first: rcctl refuses to set flags on a
+		# disabled daemon ("rcctl: mdnsd is not enabled")
 		rcctl enable mdnsd
+		rcctl set mdnsd flags "${IFACE}"
 		rcctl restart mdnsd || true
 		# Settle-then-verify: an immediate point-in-time check
 		# races green when mdnsd starts and then exits shortly

--- a/scripts/vm_provision.sh
+++ b/scripts/vm_provision.sh
@@ -104,13 +104,25 @@ if rcctl get mdnsd >/dev/null 2>&1; then
 		rcctl set mdnsd flags "${IFACE}"
 		rcctl enable mdnsd
 		rcctl restart mdnsd || true
-		if ! rcctl check mdnsd; then
+		# Settle-then-verify: an immediate point-in-time check
+		# races green when mdnsd starts and then exits shortly
+		# after. Require it to stay up across the window.
+		mdnsd_up=1
+		for probe in 1 2 3; do
+			sleep 2
+			if ! rcctl check mdnsd >/dev/null; then
+				mdnsd_up=0
+				break
+			fi
+		done
+		if [ "${mdnsd_up}" -ne 1 ]; then
 			# Surface why mdnsd would not stay up so the mDNS
 			# integration tests are diagnosable from CI logs
 			# instead of just reporting a missing daemon.
-			echo "WARNING: mdnsd did not start on ${IFACE}; diagnostics:"
+			echo "WARNING: mdnsd did not stay up on ${IFACE}; diagnostics:"
 			rcctl get mdnsd || true
 			ifconfig "${IFACE}" || true
+			tail -100 /var/log/daemon | grep mdnsd | tail -20 || true
 			echo "-- mdnsd foreground start (2s) --"
 			timeout 2 /usr/local/sbin/mdnsd -d "${IFACE}" 2>&1 |
 				head -n 20 || true

--- a/scripts/vm_provision.sh
+++ b/scripts/vm_provision.sh
@@ -78,6 +78,10 @@ chown _openhap:_openhap /var/db/openhapd
 # Copy example config if no config exists
 [ -f /etc/openhapd.conf ] || cp /etc/examples/openhapd.conf /etc/openhapd.conf
 
+# Start every run unpaired, even on a reused (cached) disk that carries
+# the previous run's pairing state. Keep the accessory identity keys.
+rm -f /var/db/openhapd/pairings.db /var/db/openhapd/auth_attempts
+
 # Clean up
 cd /tmp && rm -rf openhap-* openhap.tar.gz
 

--- a/scripts/vm_provision.sh
+++ b/scripts/vm_provision.sh
@@ -29,7 +29,10 @@ fi
 echo "Using tarball: ${TARBALL}"
 
 echo "==> Installing cpanm..."
+# Guest heredocs run under set -e so a failed pkg_add/cpan/make cannot
+# report a provisioned guest.
 vm_run <<'EOF'
+set -e
 pkg_add -u 2>/dev/null || true
 
 # Install cpanm if not already present
@@ -44,6 +47,7 @@ vm_scp "${TARBALL}" "root@127.0.0.1:/tmp/openhap.tar.gz"
 
 echo "==> Installing OpenHAP..."
 vm_run <<'EOF'
+set -e
 cd /tmp && rm -rf openhap && tar xzf openhap.tar.gz
 
 # Uninstall existing version if present
@@ -85,9 +89,10 @@ rm -f /var/db/openhapd/pairings.db /var/db/openhapd/auth_attempts
 # Clean up
 cd /tmp && rm -rf openhap-* openhap.tar.gz
 
-# Enable and start services
+# Enable and start services (start fails when already running, e.g.
+# on a warm-cached disk where rc started it at boot)
 rcctl enable mosquitto
-rcctl start mosquitto
+rcctl check mosquitto >/dev/null || rcctl start mosquitto
 
 # Configure and start mdnsd on the primary network interface. mdnsd
 # needs an interface for multicast DNS; started without one it exits
@@ -135,7 +140,7 @@ fi
 
 if [ -x /etc/rc.d/openhapd ]; then
 	rcctl enable openhapd
-	rcctl start openhapd
+	rcctl check openhapd >/dev/null || rcctl start openhapd
 fi
 
 sleep 2

--- a/spec/HAP-HTTP.md
+++ b/spec/HAP-HTTP.md
@@ -515,6 +515,15 @@ Exceptions (immediate delivery):
 
 From `Accessory.ts` (`handleCharacteristicChangeEvent`).
 
+**Delivery Scope:**
+
+An event is broadcast to every connection subscribed to the characteristic
+except the connection whose request caused the change — the originator never
+receives an event for its own write. The reference implementations agree:
+HAP-NodeJS excludes the `originator` connection from the broadcast
+(`eventedhttp.ts:215-218`), and HAP-python skips `sender_client_addr` when
+publishing an event (`accessory_driver.py:580`).
+
 **Subscription Persistence:**
 
 Subscriptions are per-connection. When the connection closes, all subscriptions

--- a/t/conformance/hap-http.t
+++ b/t/conformance/hap-http.t
@@ -522,63 +522,169 @@ subtest '[HAP-HTTP §16][HAP-HTTP §16.3] event subscription via ev:true' =>
 		'[HAP-HTTP §12] notification-not-supported is -70406' );
 };
 
-subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
-	my $hap = make_hap();
+# encrypted_session($sock, $id): verified session with test session keys
+my $EVENT_KEY = pack( 'H*', '11' x 32 );
 
-	# Two encrypted sessions with mock sockets; only one subscribes
-	my $key_a = pack( 'H*', '11' x 32 );
-	my $key_b = pack( 'H*', '22' x 32 );
+sub encrypted_session ( $sock, $id )
+{
+	my $session = OpenHAP::Session->new( socket => $sock );
+	$session->set_verified($id);
+	$session->set_encryption( $EVENT_KEY, pack( 'H*', '22' x 32 ) );
+	return $session;
+}
 
-	my $sub_sock = MockSocket->new;
-	my $sub_sess = OpenHAP::Session->new( socket => $sub_sock );
-	$sub_sess->set_verified('subscriber');
-	$sub_sess->set_encryption( $key_a, $key_b );
-
-	my $other_sock = MockSocket->new;
-	my $other_sess = OpenHAP::Session->new( socket => $other_sock );
-	$other_sess->set_verified('bystander');
-	$other_sess->set_encryption( $key_a, $key_b );
-
-	$hap->_register_event_subscription( $sub_sess, 2, 10 );
-	$hap->send_event( 2, 10, 1 );
-
-	ok( length( $sub_sock->{written} ) > 0,
-		'subscribed session receives event' );
-	is( $other_sock->{written}, '',
-		'subscriptions are per-connection: bystander receives nothing'
-	);
-
-	# Decrypt the frame and check the EVENT/1.0 message format
-	my $frame  = $sub_sock->{written};
+# decrypt_event($sock, $counter): decrypt one event frame written to a
+# mock socket and return the plaintext EVENT/1.0 message
+sub decrypt_event ( $sock, $counter = 0 )
+{
+	my $frame  = $sock->{written};
 	my $aad    = substr( $frame, 0, 2 );
 	my $length = unpack( 'v', $aad );
 	require OpenHAP::Crypto;
-	my $plain = OpenHAP::Crypto::chacha20_poly1305_decrypt(
-		$key_a,
-		pack( 'x[4]Q<', 0 ),
+	return OpenHAP::Crypto::chacha20_poly1305_decrypt(
+		$EVENT_KEY,
+		pack( 'x[4]Q<', $counter ),
 		substr( $frame, 2, $length ),
 		substr( $frame, 2 + $length, 16 ), $aad
 	);
+}
+
+# flush_until($hap, $sock): run the coalescing flush until the socket
+# has data or the deadline passes (resilient to timing variations)
+sub flush_until ( $hap, $sock )
+{
+	require Time::HiRes;
+	my $deadline = Time::HiRes::time() + 5;
+	while ( !length( $sock->{written} )
+		&& Time::HiRes::time() < $deadline )
+	{
+		Time::HiRes::sleep(0.05);
+		$hap->flush_events;
+	}
+	return;
+}
+
+subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
+	my $hap = make_hap();
+	my ( undef, undef, $acc_body ) =
+	    dispatch( $hap, 'GET', '/accessories' );
+	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
+
+	# Three encrypted sessions: a subscriber, the writer (also
+	# subscribed), and a bystander that never subscribes
+	my $sub_sock    = MockSocket->new;
+	my $sub_sess    = encrypted_session( $sub_sock, 'subscriber' );
+	my $writer_sock = MockSocket->new;
+	my $writer_sess = encrypted_session( $writer_sock, 'writer' );
+	my $other_sock  = MockSocket->new;
+	my $other_sess  = encrypted_session( $other_sock, 'bystander' );
+
+	my $subscribe = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $iid, ev => \1 } ] } );
+	for my $sess ( $sub_sess, $writer_sess ) {
+		my ( $status, undef, undef ) = dispatch( $hap, 'PUT',
+			'/characteristics', $subscribe, $sess );
+		is( $status, 204, 'subscription accepted' );
+	}
+
+	# A write through the PUT handler queues an event; the On type
+	# is not exempt from coalescing, so delivery happens on the
+	# post-window flush
+	my $put = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $iid, value => \1 } ] } );
+	my ( $status, undef, undef ) =
+	    dispatch( $hap, 'PUT', '/characteristics', $put, $writer_sess );
+	is( $status, 204, 'value write accepted' );
+	flush_until( $hap, $sub_sock );
+
+	ok( length( $sub_sock->{written} ) > 0,
+		'write via PUT handler delivers an event to the subscriber' );
+	is( $other_sock->{written}, '',
+		'subscriptions are per-connection: bystander receives nothing'
+	);
+	is( $writer_sock->{written}, '',
+		'originating connection receives no event for its own write' );
+
+	# Decrypt the frame and check the EVENT/1.0 message format
+	my $plain = decrypt_event($sub_sock);
 	like( $plain, qr{^EVENT/1\.0 200 OK\r\n},
 		'event starts with EVENT/1.0 200 OK' );
 	like( $plain, qr{Content-Type: application/hap\+json\r\n},
 		'event content type is application/hap+json' );
 	my ($event_body) = $plain =~ /\r\n\r\n(.*)$/s;
 	my $data = $json->decode($event_body);
-	is( $data->{characteristics}[0]{aid}, 2, 'event has aid' );
-	is( $data->{characteristics}[0]{iid}, 10, 'event has iid' );
-	is( $data->{characteristics}[0]{value}, 1, 'event has new value' );
+	is( $data->{characteristics}[0]{aid}, $aid, 'event has aid' );
+	is( $data->{characteristics}[0]{iid}, $iid, 'event has iid' );
+	ok( $data->{characteristics}[0]{value},
+		'event carries the new value (true)' );
 
-	# Unsubscribe stops delivery
+	# Unsubscribing via ev:false stops delivery
 	$sub_sock->{written} = '';
-	$hap->_unregister_event_subscription( $sub_sess, 2, 10 );
-	$hap->send_event( 2, 10, 0 );
+	my $unsubscribe = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $iid, ev => \0 } ] } );
+	dispatch( $hap, 'PUT', '/characteristics', $unsubscribe, $sub_sess );
+	$put = $json->encode( { characteristics =>
+		    [ { aid => $aid, iid => $iid, value => \0 } ] } );
+	dispatch( $hap, 'PUT', '/characteristics', $put, $writer_sess );
+	$hap->flush_events;
+	require Time::HiRes;
+	Time::HiRes::sleep( 2 * OpenHAP::HAP::EVENT_COALESCE_DELAY() );
+	$hap->flush_events;
 	is( $sub_sock->{written}, '',
 		'unsubscribed session receives nothing' );
+
+	# A disconnecting session loses all its subscriptions
+	dispatch( $hap, 'PUT', '/characteristics', $subscribe, $sub_sess );
+	ok( exists $hap->{event_subscriptions}{"$aid.$iid"}{$sub_sess},
+		'session re-subscribed' );
+	$hap->_purge_event_subscriptions($sub_sess);
+	ok( !exists $hap->{event_subscriptions}{"$aid.$iid"}{$sub_sess},
+		'subscriptions purged on disconnect' );
 
 	# Event coalescing delay is 250ms
 	is( OpenHAP::HAP::EVENT_COALESCE_DELAY(),
 		0.250, 'coalescing delay is 250ms' );
+};
+
+subtest '[HAP-HTTP §14] device-side change delivers event with device aid'
+    => sub {
+	my $hap  = OpenHAP::HAP->new(
+		port         => 51827,
+		pin          => '123-45-678',
+		name         => 'Conformance Bridge',
+		storage_path => tempdir( CLEANUP => 1 ),
+	);
+	my $mqtt   = OpenHAP::TestMock::MQTT->new;
+	my $heater = OpenHAP::Tasmota::Heater->new(
+		aid         => 2,
+		name        => 'Test Heater',
+		mqtt_topic  => 'heater',
+		mqtt_client => $mqtt,
+	);
+	$hap->add_accessory($heater);
+	$heater->subscribe_mqtt;
+
+	my $sub_sock = MockSocket->new;
+	my $sub_sess = encrypted_session( $sub_sock, 'subscriber' );
+	my $subscribe = $json->encode( { characteristics =>
+		    [ { aid => 2, iid => 11, ev => \1 } ] } );
+	dispatch( $hap, 'PUT', '/characteristics', $subscribe, $sub_sess );
+
+	# A Tasmota state report reaches the subscriber as an event
+	# carrying the device aid, not the bridge's
+	$mqtt->simulate_message( 'stat/heater/POWER', 'ON' );
+	flush_until( $hap, $sub_sock );
+
+	ok( length( $sub_sock->{written} ) > 0,
+		'MQTT state change delivers an event' );
+	my $plain = decrypt_event($sub_sock);
+	my ($event_body) = ( $plain // '' ) =~ /\r\n\r\n(.*)$/s;
+	my $data = $json->decode( $event_body // '{}' );
+	is( $data->{characteristics}[0]{aid}, 2,
+		'event carries the device aid' );
+	is( $data->{characteristics}[0]{iid}, 11,
+		'event carries the changed iid' );
+	ok( $data->{characteristics}[0]{value}, 'event value is true' );
 };
 
 done_testing();

--- a/t/openhap/hap.t
+++ b/t/openhap/hap.t
@@ -189,20 +189,8 @@ use_ok('OpenHAP::Pairing');
         '[HAP-mDNS §8] advertised sf=1 when pairing removed');
 }
 
-# Test IMMEDIATE_EVENT_TYPES constant ([HAP-HTTP §14] event coalescing)
-{
-    # Constants are defined in the package, access via method
-    my $temp_dir = tempdir(CLEANUP => 1);
-    my $hap = OpenHAP::HAP->new(
-        port         => 51833,
-        pin          => '123-45-678',
-        storage_path => $temp_dir,
-    );
-
-    # Test that queue_event method exists (uses the constants internally)
-    ok($hap->can('queue_event'), '[HAP-HTTP §14] queue_event method exists');
-    ok($hap->can('flush_events'), 'flush_events method exists');
-    ok($hap->can('send_event'), 'send_event method exists');
-}
+# Event emission behavior ([HAP-HTTP §14]) is covered end-to-end by
+# t/conformance/hap-http.t, which drives the PUT handler and the MQTT
+# device path against subscribed mock sessions.
 
 done_testing();

--- a/t/openhap/integration/environment.t
+++ b/t/openhap/integration/environment.t
@@ -3,7 +3,7 @@
 # Integration test: System prerequisites and environment validation
 
 use v5.36;
-use Test::More tests => 10;
+use Test::More tests => 11;
 use FindBin qw($RealBin);
 use lib "$RealBin/../../../lib";
 
@@ -41,3 +41,11 @@ ok(-d '/var/db/openhapd', 'data directory exists');
 
 # Test 10: rc.d script installed
 ok(-f '/etc/rc.d/openhapd', 'rc.d script installed');
+
+# Test 11: SRP obtains the GMP Math::BigInt backend. The try => 'GMP'
+# selection falls back silently to pure Perl, which reintroduces
+# multi-minute pair-setups under TCG emulation - a missing backend
+# must be a hard, visible failure here, not a slow-but-green run.
+require OpenHAP::SRP;
+is(Math::BigInt->config->{lib}, 'Math::BigInt::GMP',
+   'Math::BigInt uses the GMP backend');

--- a/t/openhap/integration/events.t
+++ b/t/openhap/integration/events.t
@@ -67,13 +67,21 @@ $result = $bystander->request('PUT', '/characteristics',
 	{ 'Content-Type' => 'application/hap+json' });
 is($result->{status}, 204, 'value changed from the second connection');
 
-my $event = $subscriber->next_event(5);
-ok(defined $event, '[HAP-HTTP §14] EVENT/1.0 message received');
-is($event->{headers}{'content-type'}, 'application/hap+json',
-   '[HAP-HTTP §14] event content type');
-my $payload = decode_json($event->{body});
+# Positive wait: bounded by the session timeout (OPENHAP_TEST_TIMEOUT)
+my $event = $subscriber->next_event;
+ok(defined $event, '[HAP-HTTP §14] EVENT/1.0 message received')
+    or diag('no event; buffered plaintext: '
+	. unpack('H*', $subscriber->{inbuf} // '')
+	. ' raw: ' . unpack('H*', $subscriber->{rawbuf} // ''));
+
+# Decode only a received event so a miss stays a normal failure and the
+# unpair teardown below still runs
+is($event ? $event->{headers}{'content-type'} : undef,
+   'application/hap+json', '[HAP-HTTP §14] event content type');
+my $payload = $event ? eval { decode_json($event->{body}) } : undef;
+diag("event body undecodable: $@") if $event && !$payload;
 my ($change) = grep { $_->{aid} == $aid && $_->{iid} == $iid }
-    @{ $payload->{characteristics} };
+    @{ $payload ? $payload->{characteristics} : [] };
 ok($change, '[HAP-HTTP §14] event carries the changed characteristic');
 
 # Test 3: Subscriptions are per-connection - the unsubscribed

--- a/t/openhap/integration/mdns-cleanup.t
+++ b/t/openhap/integration/mdns-cleanup.t
@@ -14,13 +14,9 @@ my $env = OpenHAP::Test::Integration->new;
 $env->setup;
 
 # mdnsd must be running for openhapd to spawn mdnsctl publishers
-unless (system('rcctl check mdnsd >/dev/null 2>&1') == 0) {
-	system('rcctl enable mdnsd >/dev/null 2>&1');
-	system('rcctl start mdnsd >/dev/null 2>&1');
-	sleep 1;
-}
+# (started if needed; failure emits captured diagnostics)
 die "mdnsd required for mDNS cleanup tests\n"
-    unless system('rcctl check mdnsd >/dev/null 2>&1') == 0;
+    unless $env->ensure_mdnsd_running;
 
 # Restart openhapd so it registers with the running mdnsd
 system('rcctl restart openhapd >/dev/null 2>&1');

--- a/t/openhap/integration/mdns.t
+++ b/t/openhap/integration/mdns.t
@@ -25,13 +25,9 @@ die "mdnsctl required for mDNS integration tests\n" unless $mdnsctl_available;
 my $daemon_running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
 ok($daemon_running, 'OpenHAP daemon is running');
 
-# Test 3: mdnsd daemon is running (start it if needed)
-unless (system('rcctl check mdnsd >/dev/null 2>&1') == 0) {
-	system('rcctl enable mdnsd >/dev/null 2>&1');
-	system('rcctl start mdnsd >/dev/null 2>&1');
-	sleep 1;
-}
-my $mdnsd_available = system('rcctl check mdnsd >/dev/null 2>&1') == 0;
+# Test 3: mdnsd daemon is running and stays running (started if
+# needed; failure emits captured diagnostics)
+my $mdnsd_available = $env->ensure_mdnsd_running;
 ok($mdnsd_available, 'mdnsd daemon is running');
 
 die "mdnsd required for mDNS integration tests\n" unless $mdnsd_available;

--- a/t/openhap/integration/pairing.t
+++ b/t/openhap/integration/pairing.t
@@ -31,6 +31,10 @@ my $hex = unpack('H*', $body);
 unlike($hex, qr/03..0130783078/,
     '[HAP-Pairing §2.4] M2 public key does not contain ASCII "0x" prefix');
 
+# Close the raw M1 probe's connection now instead of leaving it
+# registered with the daemon until teardown
+$env->close_sockets;
+
 # Restart cleanly so the M1 probe above does not hold the pairing lock
 $env->ensure_daemon_stopped or die "Cannot stop daemon\n";
 $env->ensure_daemon_running or die "Cannot start daemon\n";

--- a/t/openhap/mqtt.t
+++ b/t/openhap/mqtt.t
@@ -228,9 +228,51 @@ SKIP: {
 # Test tick when not connected
 {
     my $mqtt = OpenHAP::MQTT->new();
-    
+
     my $result = $mqtt->tick();
     is($result, 0, 'tick returns 0 when not connected');
+}
+
+# The internal buffer callback registered with Net::MQTT::Simple must
+# tolerate extra arguments: since 1.33 the library passes a retain flag
+# as a third argument, and a two-argument signature dies on every
+# incoming message (regression from the integration suite)
+{
+    package StubMQTTClient;
+
+    sub new($class) { bless { callbacks => {} }, $class }
+
+    sub subscribe($self, $topic, $callback)
+    {
+        $self->{callbacks}{$topic} = $callback;
+    }
+
+    package main;
+
+    my $mqtt = OpenHAP::MQTT->new();
+    my $stub = StubMQTTClient->new;
+    $mqtt->{client}    = $stub;
+    $mqtt->{connected} = 1;
+
+    $mqtt->subscribe('stat/device/POWER', sub($topic, $payload) { });
+    my $internal = $stub->{callbacks}{'stat/device/POWER'};
+    ok(defined $internal, 'internal callback registered with the client');
+
+    my $lived = eval { $internal->('stat/device/POWER', 'ON', 1); 1 };
+    ok($lived, 'internal callback accepts a third (retain) argument')
+        or diag($@);
+    is_deeply($mqtt->{pending_messages},
+        [['stat/device/POWER', 'ON']],
+        'message buffered without the retain flag');
+
+    # resubscribe re-registers callbacks with the same tolerance
+    $mqtt->{pending_messages} = [];
+    $stub->{callbacks}        = {};
+    $mqtt->resubscribe();
+    $internal = $stub->{callbacks}{'stat/device/POWER'};
+    $lived = eval { $internal->('stat/device/POWER', 'OFF', 0); 1 };
+    ok($lived, 'resubscribed callback accepts a third argument')
+        or diag($@);
 }
 
 # Test disconnect clears pending messages


### PR DESCRIPTION
Implements all four phases of `plans/002-integration-ci-green/`, one commit per phase.

## Phase 1 — Pairing state isolation (`c126280`)

Root cause confirmed in code: `ensure_unpaired` checked/unlinked `/var/db/openhapd/pairings` while the daemon persists to `pairings.db` (`OpenHAP::Storage`), so the helper was a lifelong no-op, and the pairing leaked by `events.t` (which died before its teardown) made every later `method=0` M1 return `kTLVError_Unavailable` (6).

- `ensure_unpaired` now targets `pairings.db` with a content-based check (the daemon always leaves comment headers, so a size check would bounce the daemon on every call), wipes `pairings.db` + `auth_attempts` with checked unlinks around a verified stop/start, and probes the post-condition with `POST /identify` — 204 only while unpaired (HAP-HTTP §3).
- Provisioning removes pairing state so warm-cached disks start unpaired; `pairing.t` closes its raw M1 probe socket immediately (new `close_sockets` helper).

## Phase 2 — Event delivery (`2dacb51`)

The daemon never emitted events: `queue_event` had no callers, and the bridge forwarder discarded the device `aid` into an empty callback list.

- The `/characteristics` PUT handler queues an event after each successful write; device `notify_change` now flows through the bridge into `queue_event` with the device `aid` preserved.
- Delivery-scope spec gap resolved: both references exclude the originator (HAP-NodeJS `eventedhttp.ts:215-218`, HAP-python `accessory_driver.py:580`); recorded in `spec/HAP-HTTP.md` §14 with those citations and implemented.
- `IMMEDIATE_EVENT_TYPES` aligned with §14's four types, and the type lookup fixed (the full UUID never matched the short-form keys); subscriptions purged on disconnect.
- Conformance (`t/conformance/hap-http.t`) drives the PUT handler and the MQTT device path on subscribed, encrypted mock sessions and asserts decryptable `EVENT/1.0` frames — replacing the vacuous `can('queue_event')` assertions in `t/openhap/hap.t`.
- Controller: `next_event` without a literal is bounded by the session timeout (`OPENHAP_TEST_TIMEOUT`); event frames split across reads are reassembled without desyncing the nonce counter. `events.t` fails cleanly on a missed event so its unpair teardown always runs.

## Phase 3 — mDNS lifecycle (`10ae2d5`)

Task 3.1's live diagnosis needs a VM run this environment could not provide, so this phase makes the next red run yield the discriminating evidence while fixing the top-ranked hypotheses:

- New `ensure_mdnsd_running` helper: settle-then-verify over a 3 s window (catches "starts, then exits" that a point-in-time probe races past), with captured rcctl/process/syslog diagnostics on failure. Both mDNS test files use it instead of dying bare; provisioning verifies the same way.
- `integration.sh` cleans up orphans gracefully (rcctl stop + TERM first, KILL only stragglers) so mdnsd never sees clients vanish with dirty sockets. `OpenHAP::MDNS` already withdraws via SIGTERM with grace, so no client change was needed.
- No SKIP blocks added. `Integration.pod` ENVIRONMENT now lists the mosquitto/mdnsd prerequisites.

## Phase 4 — Cleanup, guards, verification (`f4f1237`)

- `make install` glob guards rewritten as for-loops (verified locally: zero stderr, all `Test/` and `Test/Controller/` modules install).
- `environment.t` hard-asserts the GMP `Math::BigInt` backend (10 → 11 tests) so the silent pure-Perl fallback fails the suite loudly instead of reintroducing multi-minute pair-setups under TCG.
- Guest heredocs run under `set -e`; rcctl starts guarded for already-running services on warm-cached disks.
- The failure log-capture in `integration.sh` was unreachable (host `set -e` aborted at the failing `vm_run`); it now executes and includes pairing state and mdnsd/rcctl status.
- Workflow: diagnostics step gated on `always() && !success()`, corrected disk-cache comment plus a `v1` cache-key suffix as the cold-cache lever, and a weekly `schedule:` trigger. Cold/warm-cache verification procedure documented in the `integration-tests` skill.

## Verification

- `make check` (tidy + lint + 170 host tests), `make prettier`, and `make spec-coverage` pass locally (Linux, x86_64).
- A local `make integration` run was not possible in this environment (no KVM/HVF, no OpenBSD VM); the Integration workflow on this PR is the first end-to-end exercise of phases 1–3. Per the plan's acceptance criteria, "green" means three consecutive green runs including one cold-cache (the `v1` key bump forces this) and one warm-cache run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NUiuPMUeBqNccTnAmazy7M

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUiuPMUeBqNccTnAmazy7M)_