### PR TITLE
docs(vm): add plan 003 for native openhvf installed-image caching

### DIFF
--- a/plans/003-openhvf-image-caching/design.md
+++ b/plans/003-openhvf-image-caching/design.md
@@ -1,0 +1,180 @@
+# OpenHVF installed-image caching — Design
+
+## Problem
+
+`openhvf up` on a fresh checkout performs a full OpenBSD installation: it
+downloads the miniroot, boots QEMU with it, and drives the installer over the
+serial console (`share/openhvf/expect/install.exp`). Under TCG emulation — the
+only mode available on CI runners without `/dev/kvm` — this takes tens of
+minutes, and the guest-side provisioning that follows (`make deps` running
+`pkg_add` in the VM) costs a comparable amount again.
+
+Caching exists today, but only at the workflow layer:
+`.github/workflows/integration.yml` archives the whole `.openhvf` state
+directory with `actions/cache`, keyed on a hand-maintained `hashFiles(...)`
+list. That approach has structural weaknesses:
+
+- **The invalidation knowledge lives in the wrong place.** The key is maintained
+  by hand in the workflow and is already incomplete: `install.exp` and the
+  install driver in `lib/OpenHVF/{VM,Expect}.pm` are not hashed, so changing how
+  the OS is installed does not invalidate the cached disk.
+- **The cached artifact is dirty.** `actions/cache` saves only on key miss, so
+  what gets frozen is the disk after a full provision-and-test run — test
+  artifacts, logs, and the generated root password in `status` included — not a
+  pristine installed system.
+- **Nothing outside GitHub Actions benefits.** Local developers pay the full
+  install on every `openhvf destroy`, and any other CI system would have to
+  reimplement the choreography (clean shutdown, socket deletion, key list).
+
+The goal is to move installed-image caching into openhvf itself, so any consumer
+— developer machine or CI — gets it natively, with openhvf owning the
+invalidation logic.
+
+## Goals
+
+1. A warm `openhvf up` on a fresh checkout boots a cached installed system
+   without downloading the miniroot or running the installer.
+2. openhvf derives the cache key from the inputs that actually determine an
+   installed image; consumers never hand-maintain invalidation lists for the
+   base OS install.
+3. Cached bases are pristine and immutable: written once at a known-clean point,
+   never mutated by later runs, shared by any number of VMs.
+4. `openhvf destroy && openhvf up` becomes a cheap factory reset.
+5. A generic, named snapshot layer lets scripts (e.g. `vm_provision.sh`) cache
+   states openhvf knows nothing about, such as "guest packages installed".
+6. The Integration workflow shrinks to one `actions/cache` step over
+   `~/.cache/openhvf` and stops archiving `.openhvf` entirely.
+
+## Non-goals
+
+- QEMU internal snapshots (`savevm`): they live inside a single qcow2, make
+  nothing smaller or more shareable, and are slow to write under TCG.
+- Making the first (cold) installation faster; TCG cost stands.
+- Cross-machine or content-addressed image distribution beyond what
+  `actions/cache` already provides.
+- Caching OpenHAP provisioning policy inside openhvf; the snapshot verb is the
+  mechanism, `scripts/vm_provision.sh` keeps the policy.
+- Multi-architecture images (`OpenHVF::Image::ARCH` stays `arm64`).
+
+## Architecture
+
+### Cache layout
+
+Everything lives under the existing `cache_dir` (`~/.cache/openhvf`), next to
+the proxy cache that already holds the miniroot and install sets:
+
+```
+~/.cache/openhvf/
+  proxy/...                          # existing: miniroot, install sets
+  installed/<key>/
+    base.qcow2                       # read-only (0400), compacted
+    meta.json                        # 0600: root password, inputs, created_at
+    snapshots/<name>.qcow2           # phase 3: named overlay layers
+    snapshots/<name>.json
+```
+
+`<key>` is `<version>-<arch>-<hash8>`, where `hash8` is a truncated SHA-256
+(`Digest::SHA`, core Perl) over the install-determining inputs: OpenBSD version,
+architecture, `disk_size`, the content of the `install.exp` script Expect.pm
+resolves, and a bumpable `CACHE_GENERATION` constant for driver changes the file
+hash cannot see. Memory and port settings do not shape the disk and are
+excluded.
+
+### Backing chains
+
+The mechanism is qcow2 backing files — `OpenHVF::Disk::create` already accepts a
+backing image (today unused, and hardwired to `-F raw`, which phase 1
+parameterizes):
+
+```mermaid
+graph LR
+    B["installed/&lt;key&gt;/base.qcow2<br/>(immutable)"]
+    S["snapshots/&lt;name&gt;.qcow2<br/>(immutable, phase 3)"]
+    W[".openhvf/state/&lt;vm&gt;/disk.qcow2<br/>(working overlay)"]
+    W -- backed by --> S -- backed by --> B
+```
+
+Backing references use absolute paths into `cache_dir`. Bases and snapshots are
+immutable per key, published atomically (write to a temp file in the same
+directory, then rename), so an overlay either finds the exact file it was
+created against or fails loudly.
+
+### Lifecycle integration (`OpenHVF::VM::up`)
+
+- **Save.** `up` already stops the freshly installed VM before rebooting it
+  without install media. At that point the disk is clean, pristine, and minimal
+  (the SSH key is installed per-checkout afterwards). There, `up` compacts the
+  disk into the cache (`qemu-img convert -O qcow2`), writes `meta.json`
+  (including the generated root password, which is baked into the installed OS
+  and required later by `_needs_ssh_key_update`), replaces the working disk with
+  an overlay backed by the new base, and continues. Caching is best-effort: a
+  failed save warns and continues with the standalone disk; `up` never fails
+  because caching failed.
+- **Restore.** When no disk exists and the cache holds a matching key, `up`
+  creates the overlay, seeds the state JSON from `meta.json` (`mark_installed`,
+  `set_root_password`), and boots straight to "waiting for SSH". The miniroot
+  download and proxy-assisted installation are skipped entirely; the existing
+  SSH-key update path installs the checkout's key.
+- **Integrity.** When a disk exists, `up` verifies its backing chain resolves
+  (`qemu-img info`) and fails with a `openhvf destroy` remedy when it does not,
+  rather than surfacing an opaque QEMU open error.
+
+### New components
+
+- `OpenHVF::ImageCache` (+ `.pod`, `t/openhvf/imagecache.t`): key derivation,
+  lookup, atomic store, metadata, listing, removal. `OpenHVF::Image` keeps its
+  present job (miniroot download); it is not extended.
+- `openhvf cache list|clear [--stale]`: operator visibility and pruning;
+  `--stale` keeps only the key the current configuration derives.
+- `openhvf snapshot save|restore|list|rm <name>` (phase 3): copies the working
+  overlay into the current base's `snapshots/` (VM stopped), or replaces the
+  working disk with a fresh overlay backed by a named snapshot. Snapshot
+  metadata records the state fields the disk embodies (installed SSH key, root
+  password) so restore can reseed the state JSON.
+- Config directive `image_cache yes|no` (default `yes`) and an `up --no-cache`
+  escape hatch for debugging.
+
+The originally floated `--cache P` flag is subsumed: `cache_dir` already names
+the location, and openhvf deriving the key natively is the point — a
+caller-supplied path would move the invalidation problem back to the caller.
+
+### CI target state
+
+One cache step over `~/.cache/openhvf`, keyed on the same inputs openhvf hashes
+plus the provisioning inputs (`deps/OpenBSD.txt`, `scripts/vm_provision.sh`),
+with a `restore-keys` prefix fallback so a key rotation still restores the
+still-valid miniroot and any still-matching bases; `openhvf cache clear --stale`
+bounds growth before the post-job save. The `.openhvf` cache step, its socket
+cleanup, and the password-bearing archived state all disappear.
+`vm_provision.sh` caches its expensive `make deps` result as snapshot
+`deps-<hash>` via the snapshot verb.
+
+## Contracts
+
+- A cached base is bit-identical to a just-installed, cleanly shut-down disk; no
+  test or provisioning artifact can enter it.
+- Same configuration and installer ⇒ same key ⇒ cache hit; any change to
+  version, arch, `disk_size`, `install.exp`, or `CACHE_GENERATION` ⇒ new key.
+- `meta.json` is mode 0600 and carries the root password; the same secret
+  already lives in `.openhvf/state/<vm>/status` today, and these are throwaway,
+  localhost-only test VMs — documented in `openhvf.1`.
+- Cache failures degrade to today's behavior (full install, standalone disk);
+  they are warnings, never errors.
+- A broken backing chain is a hard, diagnosed failure with a stated remedy.
+
+## Strategy
+
+Four independently shippable phases:
+
+1. **Core base-image cache** — `OpenHVF::ImageCache`, the `Disk` backing-format
+   fix, save/restore wiring in `VM::up`, chain verification, and coupling the
+   existing CI cache keys so the two workflow caches rotate together.
+2. **Operability** — `openhvf cache` subcommand, `image_cache` directive,
+   `up --no-cache`, and documentation in `openhvf.1`.
+3. **Named snapshots** — the generic `openhvf snapshot` verb over the same
+   backing-chain mechanism.
+4. **CI adoption** — single-cache workflow, `.openhvf` never archived,
+   `vm_provision.sh` snapshots its `make deps` result.
+
+Once a phase lands, the code, tests, and man page are the source of truth; this
+document records intent at the time of writing.

--- a/plans/003-openhvf-image-caching/plan-1.md
+++ b/plans/003-openhvf-image-caching/plan-1.md
@@ -1,0 +1,87 @@
+# Phase 1 — Core base-image cache
+
+Introduce the native installed-image cache: a new `OpenHVF::ImageCache` module,
+backing-file support actually used by `OpenHVF::Disk`, and save/restore wiring
+in `OpenHVF::VM::up`. After this phase, any machine with a warm `cache_dir`
+boots an installed VM without downloading the miniroot or running the installer.
+
+## Tasks
+
+### 1.1 `Disk::create` backing format
+
+- `OpenHVF::Disk::create` already accepts `$backing_image` but hardwires
+  `-F raw` (`lib/OpenHVF/Disk.pm`). Add a backing-format parameter (the cache
+  passes `qcow2`) and keep the current default for compatibility.
+- Overlays are created without an explicit size so they inherit the backing
+  image's virtual size; verify `create` handles the size argument being optional
+  when a backing image is given.
+
+### 1.2 `OpenHVF::ImageCache`
+
+New module (plus `.pod` sidecar and `t/openhvf/imagecache.t`):
+
+- `new($cache_dir)` — expands `~` like `OpenHVF::Image` does.
+- `key($vm_config)` — returns `<version>-<arch>-<hash8>`; `hash8` is a truncated
+  `Digest::SHA` SHA-256 over version, `OpenHVF::Image::ARCH`, `disk_size`, the
+  bytes of the `install.exp` that `OpenHVF::Expect` resolves, and a
+  `CACHE_GENERATION` constant (bump when install-driver behavior changes outside
+  `install.exp`). Expose the script path from `OpenHVF::Expect` via a small
+  public method instead of duplicating its search logic.
+- `lookup($key)` — returns `{base => $path, meta => $hashref}` when both
+  `base.qcow2` and a parseable `meta.json` exist, else undef (a half-written
+  entry is a miss, not an error).
+- `store($key, $disk_path, $meta)` — `qemu-img convert -O qcow2` into a temp
+  file inside `installed/<key>/`, write `meta.json` (0600) with the root
+  password, creation time, and the key inputs echoed for diagnostics, then
+  atomically rename both and chmod the base 0400. Returns the base path, undef
+  on any failure.
+- `list` / `remove($key)` — enumeration and deletion for later phases.
+
+### 1.3 Save and restore in `VM::up`
+
+- **Restore:** in the no-disk path, consult
+  `ImageCache->lookup(ImageCache->key($config))` before creating a blank disk.
+  On a hit, create the working disk as an overlay backed by the base, seed state
+  from `meta.json` (`mark_installed`, `set_root_password`, plus a `cached_from`
+  key for diagnostics), and skip `OpenHVF::Image->ensure` entirely — only the
+  install path needs the miniroot. The existing `_needs_ssh_key_update` flow
+  then installs the checkout's SSH key using the seeded password.
+- **Save:** in the just-installed path, after the installer VM is stopped and
+  `clear_vm_pid` has run, call `store`; on success delete the standalone disk
+  and recreate it as an overlay backed by the new base before restarting. On
+  failure, log a warning and continue with the standalone disk — `up` must never
+  fail because caching failed.
+- **Chain check:** when a disk already exists, verify with `qemu-img info` that
+  its backing file (if any) resolves; if not, error with the remedy "backing
+  image missing from cache; run `openhvf destroy` and `openhvf up`" instead of
+  letting QEMU fail opaquely at boot.
+
+### 1.4 Keep the two CI caches rotating together
+
+Phase 4 removes the `.openhvf` cache step, but until then a cached `.openhvf`
+may contain an overlay referencing `~/.cache/openhvf/installed/<key>/...`. Add
+`share/openhvf/expect/install.exp` to **both** `actions/cache` keys in
+`.github/workflows/integration.yml` so a base-key rotation also rotates the
+state cache, and note the coupling in a comment.
+
+## Deliverables
+
+- `lib/OpenHVF/ImageCache.pm` + `lib/OpenHVF/ImageCache.pod`
+- Changes to `lib/OpenHVF/Disk.pm`, `lib/OpenHVF/VM.pm`, `lib/OpenHVF/Expect.pm`
+  (script-path accessor)
+- `t/openhvf/imagecache.t`; extended `t/openhvf/disk.t` and `t/openhvf/vm.t`
+- Key-coupling edit to `.github/workflows/integration.yml`
+
+## Acceptance criteria
+
+- Unit tests cover: key stability and rotation (each input changes the key),
+  lookup miss on empty/partial entries, store/lookup round-trip including
+  metadata and permissions, and overlay creation with a qcow2 backing file.
+  Tests skip gracefully when `qemu-img` is unavailable, per `t/` conventions.
+- On a host with QEMU: `openhvf up` (cold) installs and populates
+  `installed/<key>/`; `openhvf destroy && openhvf up` (warm) reaches "VM ready"
+  with no installer run and no miniroot download, and `openhvf ssh` works —
+  key-installed via the seeded root password.
+- Disabling or corrupting the cache entry degrades to a full install with a
+  warning, not a failure.
+- `make check` stays green.

--- a/plans/003-openhvf-image-caching/plan-2.md
+++ b/plans/003-openhvf-image-caching/plan-2.md
@@ -1,0 +1,59 @@
+# Phase 2 — Operability: cache subcommand, config knob, docs
+
+Phase 1 makes the cache work; this phase makes it observable, controllable, and
+documented. Independently shippable on top of phase 1.
+
+## Tasks
+
+### 2.1 `openhvf cache` subcommand
+
+Add to `OpenHVF::CLI` alongside the existing `image` subcommand:
+
+- `cache list` — one line per `installed/<key>/` entry: key, on-disk size,
+  creation time (from `meta.json`), snapshot count (0 until phase 3), and a
+  marker on the entry matching the current configuration's derived key. Nothing
+  cached prints "No cached images", mirroring `image list`.
+- `cache clear [--stale]` — removes cached entries. Bare `clear` removes all of
+  `installed/`; `--stale` keeps only the entry whose key matches the current
+  configuration. Refuse to remove the entry backing a currently existing working
+  disk while the VM is running (check via state), and warn when removal orphans
+  an existing stopped disk's backing chain — the phase 1 chain check makes the
+  consequence loud, this makes it predictable.
+
+### 2.2 Cache on/off control
+
+- New config directive `image_cache yes|no` (project or global `.openhvfrc`),
+  default `yes`, parsed and exposed by `OpenHVF::Config` like `cache_dir`.
+- New `up` option `--no-cache`: skip both restore (force a fresh install) and
+  save for this invocation. Useful when debugging the installer itself and for
+  `robustness-openhvf` runs.
+- Precedence: CLI flag over project config over global config.
+
+### 2.3 Documentation
+
+- `man/openhvf/openhvf.1`: document the `cache` subcommand, the `--no-cache`
+  option, the `image_cache` directive, the cache layout under `cache_dir`, and a
+  SECURITY note that `meta.json` stores the generated root password (mode 0600;
+  same exposure as the state directory today; test VMs are localhost-only).
+- Update `lib/OpenHVF/ImageCache.pod` for any interface additions.
+- Update the `openhvf` skill (`.claude/skills/openhvf/SKILL.md`) only if its
+  procedures change; it must point at the man page, not restate it.
+
+## Deliverables
+
+- Changes to `lib/OpenHVF/CLI.pm`, `lib/OpenHVF/Config.pm`, `lib/OpenHVF/VM.pm`,
+  `lib/OpenHVF/ImageCache.pm` (+ `.pod`)
+- Extended `t/openhvf/cli.t`, `t/openhvf/config.t`, `t/openhvf/imagecache.t`
+- `man/openhvf/openhvf.1` updates
+
+## Acceptance criteria
+
+- `cache list` reflects reality before and after installs and `clear`
+  operations; `cache clear --stale` provably keeps the current key and removes
+  others (unit-tested with synthetic entries).
+- `image_cache no` and `--no-cache` each force a full install and leave the
+  cache untouched; default behavior is unchanged from phase 1.
+- Usage errors (`cache frobnicate`) return `EXIT_INVALID_ARGS` with a usage
+  line, matching the existing subcommand style.
+- `make check` stays green; man page lints with `mandoc -Tlint` if that check
+  exists in the tree, otherwise renders cleanly with `man -l`.

--- a/plans/003-openhvf-image-caching/plan-3.md
+++ b/plans/003-openhvf-image-caching/plan-3.md
@@ -1,0 +1,74 @@
+# Phase 3 — Named snapshots
+
+A generic layer verb over the same backing-chain mechanism, so scripts can cache
+states openhvf knows nothing about — the motivating consumer is
+`vm_provision.sh` caching its `make deps` result (wired up in phase 4).
+Mechanism lives here; policy stays in the scripts.
+
+## Model
+
+A snapshot is an immutable copy of the working overlay, stored under the base it
+was created against:
+
+```
+installed/<key>/snapshots/<name>.qcow2   # 0400, references base.qcow2
+installed/<key>/snapshots/<name>.json    # 0600, state fields + created_at
+```
+
+Chain after a restore: `base.qcow2 ← <name>.qcow2 ← disk.qcow2`. Storing
+snapshots inside `installed/<key>/` means base invalidation (new key,
+`cache clear`) invalidates the snapshots that depend on that exact base file,
+for free.
+
+## Tasks
+
+### 3.1 `OpenHVF::ImageCache` snapshot primitives
+
+- `snapshot_store($key, $name, $disk_path, $meta)` — copy the (stopped) working
+  overlay into `snapshots/`, atomically, 0400. The overlay's absolute backing
+  reference to `base.qcow2` stays valid because bases are immutable. Validate
+  `$name` like VM names (no `/`, no NUL, bounded length).
+- `snapshot_lookup($key, $name)`, `snapshot_list($key)`,
+  `snapshot_remove($key, $name)`.
+- Snapshot metadata records the state fields the disk embodies at save time:
+  `installed`, the installed SSH public key, and the root password (copied from
+  the base's `meta.json`), so restore can reseed `OpenHVF::State` and the
+  existing `_needs_ssh_key_update` path reconciles a different per-checkout key
+  afterwards.
+
+### 3.2 CLI verb
+
+- `openhvf snapshot save <name>` — requires an existing, installed, **stopped**
+  VM (`EXIT_VM_RUNNING` otherwise; a live overlay copy is not consistent).
+  Requires the disk to be an overlay of a cached base (standalone disks from
+  `--no-cache` or pre-phase-1 states are a diagnosed error, not a crash).
+- `openhvf snapshot restore <name>` — VM stopped; replaces the working disk with
+  a fresh overlay backed by the snapshot and reseeds state from snapshot
+  metadata. Missing snapshot returns a distinct, scriptable failure so callers
+  can do `restore || provision-from-scratch`.
+- `openhvf snapshot list` / `openhvf snapshot rm <name>` — scoped to the current
+  configuration's key; `cache list` gains real snapshot counts.
+
+### 3.3 Documentation
+
+- `man/openhvf/openhvf.1`: snapshot subcommand, the consistency rule (VM must be
+  stopped), and the invalidation relationship to the base key.
+- `.pod` updates for the new `ImageCache` methods.
+
+## Deliverables
+
+- Changes to `lib/OpenHVF/ImageCache.pm` (+ `.pod`), `lib/OpenHVF/CLI.pm`
+- Extended `t/openhvf/imagecache.t` and `t/openhvf/cli.t`
+- `man/openhvf/openhvf.1` updates
+
+## Acceptance criteria
+
+- Unit tests cover: name validation, store/lookup/list/remove round-trips,
+  restore reseeding state, the running-VM and standalone-disk refusals, and the
+  scriptable missing-snapshot exit code.
+- On a host with QEMU: `up` (warm base) → mutate guest → `down` →
+  `snapshot save s1` → mutate guest again → `down` → `snapshot restore s1` →
+  `up` shows the first mutation and not the second.
+- `openhvf ssh` works after a restore in a checkout with a different SSH key
+  than the one saved (exercises reseeded password + key reinstall).
+- `make check` stays green.

--- a/plans/003-openhvf-image-caching/plan-4.md
+++ b/plans/003-openhvf-image-caching/plan-4.md
@@ -1,0 +1,73 @@
+# Phase 4 — CI adoption and provisioning snapshots
+
+Move the Integration workflow onto the native cache and retire the
+workflow-level disk archiving. `.openhvf` becomes fully ephemeral in CI; the
+only cached artifact is `~/.cache/openhvf`.
+
+## Tasks
+
+### 4.1 Provisioning snapshot in the scripts
+
+- `scripts/vm_provision.sh` computes a provisioning key — a short SHA-256 over
+  `deps/OpenBSD.txt`, the `cpanfile` if present, and the provisioning sections
+  of the script itself — and splits its guest work:
+  1. **Deps layer (cacheable):** `pkg_add -u`, cpanm bootstrap, `make deps`.
+     Attempted first via `openhvf snapshot restore deps-<hash>`; on a miss, run
+     the deps layer, then `openhvf down`, `openhvf snapshot save deps-<hash>`,
+     `openhvf up`, `openhvf wait`. The stop/start cost is paid only when
+     dependencies actually changed.
+  2. **OpenHAP layer (never cached):** build tarball, scp, `make install`,
+     user/service setup — unchanged, runs every time.
+- Snapshot restore requires a stopped VM, so the restore attempt belongs in
+  `scripts/vm_up.sh` before `openhvf up`, guarded to run only when no working
+  disk exists yet; it exports whether the deps layer was restored so
+  `vm_provision.sh` can skip it. Keep the exact split simple and legible — the
+  scripts own this policy, openhvf only provides the verbs.
+- Prune old provisioning snapshots: after a successful save, remove `deps-*`
+  snapshots other than the current hash.
+
+### 4.2 Workflow simplification
+
+In `.github/workflows/integration.yml`:
+
+- Replace the two cache steps ("Cache OpenBSD miniroot image", "Cache
+  provisioned VM disk") with a single step caching `~/.cache/openhvf`:
+  - `key`: runner arch +
+    `hashFiles('.openhvfrc', 'share/openhvf/expect/install.exp', 'deps/OpenBSD.txt', 'scripts/vm_provision.sh')`
+  - `restore-keys`: the arch-scoped prefix, so a key rotation still restores the
+    miniroot, still-valid bases, and lets openhvf's own keying decide what is
+    reusable. `actions/cache` saves on miss, so a rotated key re-saves the
+    updated cache automatically.
+- Run `./bin/openhvf cache clear --stale` in the post-test cleanup step to bound
+  cache growth before the save.
+- Drop the `.openhvf`-specific choreography that existed only for archiving: the
+  socket `find -delete` and the cache-consistency comments. Keep the
+  `openhvf down` step itself — a clean shutdown is still correct hygiene and
+  keeps the qcow2 consistent for the snapshot machinery.
+- Keep the ephemeral-SSH-key step; note that it now interacts only with the
+  guest, not with any cached artifact, since `.openhvf` is no longer saved.
+
+### 4.3 Documentation
+
+- Update the workflow comments to describe the new single-cache model.
+- Update the `integration-tests` skill only if its operator procedure changes;
+  behavior reference stays in `openhvf.1` and the workflow file.
+
+## Deliverables
+
+- Changes to `scripts/vm_up.sh`, `scripts/vm_provision.sh`,
+  `.github/workflows/integration.yml`
+
+## Acceptance criteria
+
+- Two consecutive Integration runs on the same tree: the first (cold) run
+  installs, provisions, and populates the cache; the second (warm) run performs
+  no OS install and no `make deps` package installation, with a clearly lower
+  job wall-clock, and the full suite stays green on both.
+- A run after touching `deps/OpenBSD.txt` re-runs only the deps layer (new
+  snapshot), not the OS install; a run after touching `install.exp` re-runs the
+  OS install (new base key).
+- `.openhvf` no longer appears in any `actions/cache` path; no run depends on a
+  previous run's state directory.
+- `make integration` still works unchanged on a developer machine with no
+  GitHub-specific assumptions.


### PR DESCRIPTION
Adds `plans/003-openhvf-image-caching/`: a design document and four-phase implementation plan for caching installed OpenBSD images natively in openhvf, instead of relying on the Integration workflow's hand-keyed `actions/cache` steps.

## Design summary

- **Golden base image + qcow2 overlays**: after a fresh install, `openhvf up` compacts the pristine disk into `cache_dir/installed/<key>/base.qcow2` (with `meta.json` carrying the generated root password) and works from an overlay backed by it. A warm `up` skips the miniroot download and the whole installer.
- **Native cache keying**: the key is derived from the inputs that actually determine an installed image (version, arch, `disk_size`, `install.exp` content, a bumpable generation constant), so invalidation logic lives in openhvf, not in workflow YAML.
- **Phases**: (1) core `OpenHVF::ImageCache` + `VM::up` save/restore wiring, (2) `openhvf cache` subcommand and `image_cache`/`--no-cache` controls, (3) generic named-snapshot verb over the same backing-chain mechanism, (4) CI adoption — one cache step over `~/.cache/openhvf`, `.openhvf` never archived, `vm_provision.sh` snapshots its `make deps` layer.

Documentation-only change; no code is touched. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FD2jtRa3kHnuZT3oSXFmbn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FD2jtRa3kHnuZT3oSXFmbn)_