### PR TITLE
docs(vm): correct plan 003 from adversarial review

### DIFF
--- a/plans/003-openhvf-image-caching/design.md
+++ b/plans/003-openhvf-image-caching/design.md
@@ -20,11 +20,10 @@ list. That approach has structural weaknesses:
   the OS is installed does not invalidate the cached disk.
 - **The cached artifact is dirty.** `actions/cache` saves only on key miss, so
   what gets frozen is the disk after a full provision-and-test run — test
-  artifacts, logs, and the generated root password in `status` included — not a
-  pristine installed system.
+  artifacts, logs, and the root password in `status` included.
 - **Nothing outside GitHub Actions benefits.** Local developers pay the full
   install on every `openhvf destroy`, and any other CI system would have to
-  reimplement the choreography (clean shutdown, socket deletion, key list).
+  reimplement the choreography.
 
 The goal is to move installed-image caching into openhvf itself, so any consumer
 — developer machine or CI — gets it natively, with openhvf owning the
@@ -76,9 +75,10 @@ the proxy cache that already holds the miniroot and install sets:
 `<key>` is `<version>-<arch>-<hash8>`, where `hash8` is a truncated SHA-256
 (`Digest::SHA`, core Perl) over the install-determining inputs: OpenBSD version,
 architecture, `disk_size`, the content of the `install.exp` script Expect.pm
-resolves, and a bumpable `CACHE_GENERATION` constant for driver changes the file
-hash cannot see. Memory and port settings do not shape the disk and are
-excluded.
+resolves, and a bumpable generation counter for install-driver changes the file
+hash cannot see. That counter lives in the data file
+`share/openhvf/cache-generation`, not in a `.pm`, so a `hashFiles()` CI key can
+observe it too. Memory and port settings do not shape the disk and are excluded.
 
 ### Backing chains
 
@@ -95,80 +95,99 @@ graph LR
 ```
 
 Backing references use absolute paths into `cache_dir`. Bases and snapshots are
-immutable per key, published atomically (write to a temp file in the same
-directory, then rename), so an overlay either finds the exact file it was
-created against or fails loudly.
+immutable per key and write-once: an entry is built in a sibling temp directory
+and published by renaming that directory, so no reader ever sees one install's
+base beside another install's metadata, and an overlay either finds the exact
+file it was created against or fails loudly.
 
 ### Lifecycle integration (`OpenHVF::VM::up`)
 
 - **Save.** `up` already stops the freshly installed VM before rebooting it
   without install media. At that point the disk is clean, pristine, and minimal
-  (the SSH key is installed per-checkout afterwards). There, `up` compacts the
-  disk into the cache (`qemu-img convert -O qcow2`), writes `meta.json`
-  (including the generated root password, which is baked into the installed OS
-  and required later by `_needs_ssh_key_update`), replaces the working disk with
-  an overlay backed by the new base, and continues. Caching is best-effort: a
-  failed save warns and continues with the standalone disk; `up` never fails
-  because caching failed.
+  (the SSH key is installed per-checkout afterwards). Once QEMU's exit is
+  confirmed, `up` compacts the disk into the cache
+  (`qemu-img convert -O qcow2`), writes `meta.json` (including the generated
+  root password, which is baked into the installed OS and required later by
+  `_needs_ssh_key_update`), replaces the working disk with an overlay backed by
+  the new base, and continues. Caching is best-effort: a failed save warns and
+  continues with the standalone disk; `up` never fails because caching failed.
 - **Restore.** When no disk exists and the cache holds a matching key, `up`
   creates the overlay, seeds the state JSON from `meta.json` (`mark_installed`,
   `set_root_password`), and boots straight to "waiting for SSH". The miniroot
   download and proxy-assisted installation are skipped entirely; the existing
   SSH-key update path installs the checkout's key.
 - **Integrity.** When a disk exists, `up` verifies its backing chain resolves
-  (`qemu-img info`) and fails with a `openhvf destroy` remedy when it does not,
-  rather than surfacing an opaque QEMU open error.
+  (`qemu-img info`) — before the pre-existing unclean-shutdown disk check, which
+  would otherwise misreport a missing base as corruption — and fails with a
+  remedy naming `openhvf destroy`, or `cache clear`/`snapshot rm` when the
+  missing file is under `cache_dir`, rather than an opaque QEMU open error.
 
 ### New components
 
 - `OpenHVF::ImageCache` (+ `.pod`, `t/openhvf/imagecache.t`): key derivation,
-  lookup, atomic store, metadata, listing, removal. `OpenHVF::Image` keeps its
-  present job (miniroot download); it is not extended.
+  lookup, atomic store, metadata, listing, removal. Constructed with the
+  configured `cache_dir`, which phase 1 plumbs through to `VM::up` — it uses a
+  hardcoded `$HOME/.cache/openhvf` today. `OpenHVF::Image` keeps its present job
+  (miniroot download); it is not extended.
 - `openhvf cache list|clear [--stale]`: operator visibility and pruning;
-  `--stale` keeps only the key the current configuration derives.
-- `openhvf snapshot save|restore|list|rm <name>` (phase 3): copies the working
-  overlay into the current base's `snapshots/` (VM stopped), or replaces the
-  working disk with a fresh overlay backed by a named snapshot. Snapshot
-  metadata records the state fields the disk embodies (installed SSH key, root
-  password) so restore can reseed the state JSON.
+  `--stale` keeps only the key the invoked VM's configuration derives.
+- `openhvf snapshot save|restore|list|rm <name>` (phase 3): flattens the working
+  overlay into the current base's `snapshots/` (VM stopped) so every snapshot
+  hangs directly off `base.qcow2` whatever the working disk was backed by, or
+  replaces the working disk with a fresh overlay backed by a named snapshot.
+  Snapshot metadata records the state fields the disk embodies (installed SSH
+  key, root password) so restore can reseed the state JSON.
 - Config directive `image_cache yes|no` (default `yes`) and an `up --no-cache`
   escape hatch for debugging.
 
-The originally floated `--cache P` flag is subsumed: `cache_dir` already names
-the location, and openhvf deriving the key natively is the point — a
-caller-supplied path would move the invalidation problem back to the caller.
+The originally floated `--cache P` flag is subsumed: `cache_dir` names the
+location, and a caller-supplied path would move invalidation back to the caller.
 
 ### CI target state
 
 One cache step over `~/.cache/openhvf`, keyed on the same inputs openhvf hashes
-plus the provisioning inputs (`deps/OpenBSD.txt`, `scripts/vm_provision.sh`),
-with a `restore-keys` prefix fallback so a key rotation still restores the
-still-valid miniroot and any still-matching bases; `openhvf cache clear --stale`
-bounds growth before the post-job save. The `.openhvf` cache step, its socket
-cleanup, and the password-bearing archived state all disappear.
-`vm_provision.sh` caches its expensive `make deps` result as snapshot
-`deps-<hash>` via the snapshot verb.
+(`share/openhvf/cache-generation` included) plus the provisioning inputs
+(`deps/OpenBSD.txt`, `scripts/deps.sh`, `scripts/vm_provision.sh`), with a
+`restore-keys` prefix fallback so a key rotation still restores the still-valid
+miniroot and any still-matching bases; `openhvf cache clear --stale` bounds
+growth before the post-job save. The `.openhvf` cache step and its socket
+cleanup disappear; the archived root password does not, it moves into
+`meta.json` inside the image cache. `vm_provision.sh` caches its expensive
+`make deps` result as snapshot `deps-<hash>` via the snapshot verb.
+
+A working overlay and the base it references must never live in separate cache
+entries: two entries hit, miss and get evicted independently, and a restored
+overlay whose base is absent is a hard failure no CI step can clear. Phase 1
+therefore puts `.openhvf` and `~/.cache/openhvf` in one entry under one key
+until phase 4 stops caching `.openhvf` at all.
 
 ## Contracts
 
 - A cached base is bit-identical to a just-installed, cleanly shut-down disk; no
-  test or provisioning artifact can enter it.
+  test or provisioning artifact can enter it. It is captured only once QEMU is
+  confirmed dead; a force-killed QEMU disqualifies the capture.
 - Same configuration and installer ⇒ same key ⇒ cache hit; any change to
-  version, arch, `disk_size`, `install.exp`, or `CACHE_GENERATION` ⇒ new key.
+  version, arch, `disk_size`, `install.exp`, or the generation counter ⇒ new
+  key.
 - `meta.json` is mode 0600 and carries the root password; the same secret
-  already lives in `.openhvf/state/<vm>/status` today, and these are throwaway,
-  localhost-only test VMs — documented in `openhvf.1`.
+  already lives in `.openhvf/state/<vm>/status` and is already archived by CI.
+  Caching lengthens its life — it survives `destroy` and rotates only with the
+  base key — and it is not a localhost-only secret: the guest permits password
+  root login, and the forwarded SSH and serial ports bind every host interface.
+  `openhvf.1` says so plainly.
 - Cache failures degrade to today's behavior (full install, standalone disk);
   they are warnings, never errors.
 - A broken backing chain is a hard, diagnosed failure with a stated remedy.
+- A `cache_dir` shared between checkouts is pruned per invoked VM; `--stale`
+  cannot see VMs outside the invoking configuration.
 
 ## Strategy
 
 Four independently shippable phases:
 
 1. **Core base-image cache** — `OpenHVF::ImageCache`, the `Disk` backing-format
-   fix, save/restore wiring in `VM::up`, chain verification, and coupling the
-   existing CI cache keys so the two workflow caches rotate together.
+   fix, save/restore wiring in `VM::up`, chain verification, and merging the two
+   CI cache steps into one entry so a base and its overlays cannot separate.
 2. **Operability** — `openhvf cache` subcommand, `image_cache` directive,
    `up --no-cache`, and documentation in `openhvf.1`.
 3. **Named snapshots** — the generic `openhvf snapshot` verb over the same

--- a/plans/003-openhvf-image-caching/plan-1.md
+++ b/plans/003-openhvf-image-caching/plan-1.md
@@ -10,11 +10,15 @@ boots an installed VM without downloading the miniroot or running the installer.
 ### 1.1 `Disk::create` backing format
 
 - `OpenHVF::Disk::create` already accepts `$backing_image` but hardwires
-  `-F raw` (`lib/OpenHVF/Disk.pm`). Add a backing-format parameter (the cache
+  `-F raw` (`lib/OpenHVF/Disk.pm:44`). Add a backing-format parameter (the cache
   passes `qcow2`) and keep the current default for compatibility.
 - Overlays are created without an explicit size so they inherit the backing
-  image's virtual size; verify `create` handles the size argument being optional
-  when a backing image is given.
+  image's virtual size. Make the size optional —
+  `sub create ( $self, $name, $size = undef, $backing_image = undef, $backing_format = 'raw' )`
+  — and split `Disk.pm:47` so the size is appended only when defined.
+- `Disk::create` returns early on an existing path (`Disk.pm:39`), so every
+  "replace the working disk with an overlay" step in this plan must unlink first
+  — otherwise it silently succeeds and changes nothing.
 
 ### 1.2 `OpenHVF::ImageCache`
 
@@ -23,65 +27,153 @@ New module (plus `.pod` sidecar and `t/openhvf/imagecache.t`):
 - `new($cache_dir)` — expands `~` like `OpenHVF::Image` does.
 - `key($vm_config)` — returns `<version>-<arch>-<hash8>`; `hash8` is a truncated
   `Digest::SHA` SHA-256 over version, `OpenHVF::Image::ARCH`, `disk_size`, the
-  bytes of the `install.exp` that `OpenHVF::Expect` resolves, and a
-  `CACHE_GENERATION` constant (bump when install-driver behavior changes outside
-  `install.exp`). Expose the script path from `OpenHVF::Expect` via a small
-  public method instead of duplicating its search logic.
+  bytes of the `install.exp` that `OpenHVF::Expect` resolves, and the contents
+  of `share/openhvf/cache-generation` (bump that file when install-driver
+  behavior changes outside `install.exp`). Serialize the inputs with an
+  unambiguous delimiter. The generation counter is a data file rather than a
+  constant in `ImageCache.pm` so a `hashFiles()` CI key can observe it:
+  `actions/cache` runs no save step on a primary-key hit, so a generation bump
+  the workflow key cannot see would rotate openhvf's key, miss, reinstall, and
+  then discard the result on every run until some unrelated hashed file changed.
+  Expose the script path from `OpenHVF::Expect` via a small public method
+  instead of duplicating its search logic.
 - `lookup($key)` — returns `{base => $path, meta => $hashref}` when both
   `base.qcow2` and a parseable `meta.json` exist, else undef (a half-written
   entry is a miss, not an error).
-- `store($key, $disk_path, $meta)` — `qemu-img convert -O qcow2` into a temp
-  file inside `installed/<key>/`, write `meta.json` (0600) with the root
-  password, creation time, and the key inputs echoed for diagnostics, then
-  atomically rename both and chmod the base 0400. Returns the base path, undef
-  on any failure.
+- `store($key, $disk_path, $meta)` — build the entire entry in a sibling temp
+  directory `installed/.tmp.<pid>.<rand>/`: `qemu-img convert -O qcow2` to
+  `base.qcow2` (then chmod 0400), and `meta.json` (0600) with the root password,
+  creation time, and the key inputs echoed for diagnostics. Publish by
+  `rename()`ing the DIRECTORY into place. One rename of one directory, not two
+  renames of two files: the root password is generated per install, so a base
+  from one install beside a `meta.json` from another is not a half-written entry
+  — it looks live, `lookup` hits it, and the seeded password then never opens
+  its own image, wedging `up` in `_wait_ssh_password` with no phase-1 way out.
+  `ENOTEMPTY` over a populated entry gives write-once for free; on collision
+  keep the existing entry and fall through to the degrade path rather than
+  re-pointing existing overlays at a foreign base. Remove the temp tree on every
+  failure path and from a SIGINT/`END` guard — an interrupt during the
+  minutes-long convert, not between renames, is what orphans multi-GB
+  temporaries. Returns the base path, undef on any failure.
 - `list` / `remove($key)` — enumeration and deletion for later phases.
+
+Re-storing an existing key needs no concurrency to reach: `up` creates the disk
+before the installer runs and marks the state installed only after it succeeds,
+so an aborted install leaves a disk present and state not-installed, and the
+next `up` re-installs onto it and arrives at `store` with the same key.
 
 ### 1.3 Save and restore in `VM::up`
 
-- **Restore:** in the no-disk path, consult
-  `ImageCache->lookup(ImageCache->key($config))` before creating a blank disk.
-  On a hit, create the working disk as an overlay backed by the base, seed state
-  from `meta.json` (`mark_installed`, `set_root_password`, plus a `cached_from`
-  key for diagnostics), and skip `OpenHVF::Image->ensure` entirely — only the
-  install path needs the miniroot. The existing `_needs_ssh_key_update` flow
-  then installs the checkout's SSH key using the seeded password.
-- **Save:** in the just-installed path, after the installer VM is stopped and
-  `clear_vm_pid` has run, call `store`; on success delete the standalone disk
-  and recreate it as an overlay backed by the new base before restarting. On
-  failure, log a warning and continue with the standalone disk — `up` must never
-  fail because caching failed.
+- **Key derivation:** derive the key exactly once per `up`, unconditionally and
+  before `run_install`, and pass that one value to both `lookup` and `store`.
+  `key()` reads `install.exp` at call time, so re-deriving it after a
+  tens-of-minutes install would publish the image the OLD installer produced
+  under the NEW digest; and the disk-exists-but-not-installed path never enters
+  the lookup block, so it has no key to carry otherwise.
+- **Restore:** in the no-disk path, consult `lookup` before creating a blank
+  disk. On a hit, create the working disk as an overlay backed by the base, seed
+  state from `meta.json` (`mark_installed`, `set_root_password`, plus a
+  `cached_from` key for diagnostics), and skip `OpenHVF::Image->ensure` entirely
+  — only the install path needs the miniroot. Gating that call also clears a
+  pre-existing wart: `ensure` runs unconditionally today (`VM.pm:119-132`) and
+  hard-fails an already-installed VM whose miniroot has been pruned. The
+  existing `_needs_ssh_key_update` flow then installs the checkout's SSH key
+  using the seeded password.
+- **Save:** in the just-installed path, gate the capture on a QEMU that is
+  provably gone. `VM.pm:199-201` discards the return values of both `_qmp_quit`
+  and `_wait_exit`, and `clear_vm_pid` only unlinks the pid file, after which
+  `_is_running` and `_force_stop` are blind — so "the installer VM is stopped"
+  is an assumption, and the design's "bit-identical to a cleanly shut-down disk"
+  contract rests on it. Capture the pid, check `_wait_exit`'s result, and only
+  then `clear_vm_pid` and `store`. A QEMU that had to be SIGKILLed
+  (`FuguLib::Process` escalates) disqualifies the capture: warn and skip
+  caching, never publish. On success delete the standalone disk and recreate it
+  as an overlay backed by the new base before restarting. On failure, log a
+  warning and continue with the standalone disk — `up` must never fail because
+  caching failed.
 - **Chain check:** when a disk already exists, verify with `qemu-img info` that
   its backing file (if any) resolves; if not, error with the remedy "backing
   image missing from cache; run `openhvf destroy` and `openhvf up`" instead of
-  letting QEMU fail opaquely at boot.
+  letting QEMU fail opaquely at boot. Run this check before the existing
+  `was_unclean_shutdown` branch (`VM.pm:90-102`), which otherwise reaches the
+  same condition first, maps it to `Disk::check`'s blanket 'corrupted' verdict,
+  and prints "run 'openhvf disk repair'" — a dead end, since
+  `qemu-img check -r all` cannot recreate a missing backing file. Skip or
+  downgrade that disk check when a broken chain is the proven cause.
 
-### 1.4 Keep the two CI caches rotating together
+### 1.4 Configured `cache_dir` reaches `VM::up`
 
-Phase 4 removes the `.openhvf` cache step, but until then a cached `.openhvf`
-may contain an overlay referencing `~/.cache/openhvf/installed/<key>/...`. Add
-`share/openhvf/expect/install.exp` to **both** `actions/cache` keys in
-`.github/workflows/integration.yml` so a base-key rotation also rotates the
-state cache, and note the coupling in a comment.
+`VM::_cache_dir` (`VM.pm:967-971`) hardcodes `$ENV{HOME}/.cache/openhvf`. The
+configurable accessor `Config::cache_dir` is used only by the `image` verb
+(`CLI.pm:315`), and `CLI.pm:155-160` hands `VM` nothing but the per-VM config
+hash. Since save/restore lives in `VM::up`, a non-default `cache_dir` would have
+`up` write `installed/<key>/` under `$HOME` while phase 2's `cache list` /
+`clear --stale` and phase 3's snapshot verbs work on a different tree.
+
+Inject the resolved `cache_dir` into the per-VM config in `Config::load_vm`
+exactly as `ssh_pubkey` is injected (`Config.pm:169`), or add it as a `VM->new`
+argument, and delete the hardcoded path. Phase 2 needs the same Config→VM
+channel for `image_cache`, so this is cheap now. Two riders: it also relocates
+the proxy/miniroot cache under a non-default `cache_dir`, and the workflow's
+hardcoded `path: ~/.cache/openhvf` documents the default only.
+
+### 1.5 One CI cache entry for the disk and its base
+
+Phase 4 retires `.openhvf` caching entirely; until then a cached `.openhvf`
+contains an overlay whose absolute backing reference points into
+`~/.cache/openhvf/installed/<key>/`. Coupling the keys of the two existing
+`actions/cache` steps is not sufficient — it makes them _rotate_ together, not
+be _present_ together. They are separate entries that hit, miss and get
+LRU-evicted independently. Restore `.openhvf` without `~/.cache/openhvf` and the
+new chain check fails the job, `scripts/vm_up.sh` runs under `set -e`, no step
+runs the `openhvf destroy` the message asks for, and the cache post-step does
+not save on a failed job — so every rerun fails identically until someone
+deletes the entry out of band.
+
+In `.github/workflows/integration.yml`:
+
+- Replace the two cache steps with ONE `actions/cache` step listing both paths
+  (`~/.cache/openhvf` and `.openhvf`) under one key, so presence is atomic and
+  an overlay is never restored without its base.
+- Key it on `runner.arch` plus
+  `hashFiles('.openhvfrc', 'share/openhvf/expect/install.exp', 'share/openhvf/cache-generation', 'deps/OpenBSD.txt', 'scripts/vm_provision.sh')`,
+  keeping the manual `v<N>` suffix as the documented cold-cache lever. Hashing
+  the generation file keeps a bump observable in CI during phases 1-3, where a
+  restored `.openhvf` means `ImageCache::key` is never called at all.
+- Note in a comment why the paths share one entry.
+
+Update `.claude/skills/integration-tests/SKILL.md` in this phase: its cold-cache
+procedure names two cache keys that no longer exist, and "bump `v<N>`" must name
+the surviving key.
 
 ## Deliverables
 
 - `lib/OpenHVF/ImageCache.pm` + `lib/OpenHVF/ImageCache.pod`
+- `share/openhvf/cache-generation`
 - Changes to `lib/OpenHVF/Disk.pm`, `lib/OpenHVF/VM.pm`, `lib/OpenHVF/Expect.pm`
-  (script-path accessor)
-- `t/openhvf/imagecache.t`; extended `t/openhvf/disk.t` and `t/openhvf/vm.t`
-- Key-coupling edit to `.github/workflows/integration.yml`
+  (script-path accessor), `lib/OpenHVF/Config.pm` (`cache_dir` injection)
+- `t/openhvf/imagecache.t`; extended `t/openhvf/disk.t`, `t/openhvf/vm.t` and
+  `t/openhvf/config.t`
+- Single-cache-step edit to `.github/workflows/integration.yml`
+- `.claude/skills/integration-tests/SKILL.md` cold-cache procedure
 
 ## Acceptance criteria
 
-- Unit tests cover: key stability and rotation (each input changes the key),
-  lookup miss on empty/partial entries, store/lookup round-trip including
-  metadata and permissions, and overlay creation with a qcow2 backing file.
-  Tests skip gracefully when `qemu-img` is unavailable, per `t/` conventions.
+- Unit tests cover: key stability and rotation (each input, including the
+  generation file, changes the key), lookup miss on empty/partial entries,
+  store/lookup round-trip including metadata and permissions, `store` refusing
+  to overwrite a populated key, temp-tree cleanup after a forced failure, and
+  overlay creation with a qcow2 backing file. Tests skip gracefully when
+  `qemu-img` is unavailable, per `t/` conventions.
 - On a host with QEMU: `openhvf up` (cold) installs and populates
   `installed/<key>/`; `openhvf destroy && openhvf up` (warm) reaches "VM ready"
   with no installer run and no miniroot download, and `openhvf ssh` works —
   key-installed via the seeded root password.
+- Deleting the cached base under a stopped VM's existing overlay produces the
+  chain-check error and its `openhvf destroy` remedy — not "Disk corruption
+  detected", and not an opaque QEMU failure.
+- With `cache_dir` set to a non-default path, `up` populates that path and
+  nothing under `~/.cache/openhvf`.
 - Disabling or corrupting the cache entry degrades to a full install with a
   warning, not a failure.
 - `make check` stays green.

--- a/plans/003-openhvf-image-caching/plan-2.md
+++ b/plans/003-openhvf-image-caching/plan-2.md
@@ -14,11 +14,21 @@ Add to `OpenHVF::CLI` alongside the existing `image` subcommand:
   marker on the entry matching the current configuration's derived key. Nothing
   cached prints "No cached images", mirroring `image list`.
 - `cache clear [--stale]` — removes cached entries. Bare `clear` removes all of
-  `installed/`; `--stale` keeps only the entry whose key matches the current
-  configuration. Refuse to remove the entry backing a currently existing working
-  disk while the VM is running (check via state), and warn when removal orphans
-  an existing stopped disk's backing chain — the phase 1 chain check makes the
-  consequence loud, this makes it predictable.
+  `installed/`; `--stale` keeps only the entry whose key matches the VM named by
+  `--vm`, matching every other verb's scoping. Say so explicitly: the key inputs
+  `version` and `disk_size` are per-VM (`Config.pm:163-164`) and a configuration
+  may declare many `vm` blocks plus `.openhvf/vms/*.conf`, so `--stale` run for
+  one VM prunes bases another VM would have hit. Widening the keep-set instead
+  would need a Config enumerator that does not exist today.
+- Before removing an entry, resolve which base an existing working disk uses via
+  `Disk::info` (`Disk.pm:85-95`, whose backing-filename phase 1 already reads).
+  Refuse while that VM is running (`State::is_vm_running`), and warn when
+  removal orphans an existing stopped disk's backing chain — the phase 1 chain
+  check makes the consequence loud, this makes it predictable. The refusal can
+  only cover VMs in the invoking checkout; a `cache_dir` shared between
+  checkouts cannot be surveyed, which is why the orphan case stays a warning.
+- Both forms also sweep leftover `installed/.tmp.*` trees from interrupted
+  `store` calls.
 
 ### 2.2 Cache on/off control
 
@@ -32,9 +42,18 @@ Add to `OpenHVF::CLI` alongside the existing `image` subcommand:
 ### 2.3 Documentation
 
 - `man/openhvf/openhvf.1`: document the `cache` subcommand, the `--no-cache`
-  option, the `image_cache` directive, the cache layout under `cache_dir`, and a
-  SECURITY note that `meta.json` stores the generated root password (mode 0600;
-  same exposure as the state directory today; test VMs are localhost-only).
+  option, the `image_cache` directive, the cache layout under `cache_dir`, the
+  per-VM scoping of `--stale`, and a SECURITY note that `meta.json` stores the
+  generated root password (mode 0600; the same secret the state directory
+  already holds, but now surviving `destroy` and rotating only with the base
+  key).
+- That note must not call these VMs localhost-only. The guest permits password
+  root login (`install.exp`, `firstboot.exp`), and `VM.pm:787` and `:791` pass
+  `hostfwd=tcp::<ssh_port>-:22` and `-serial tcp::<console_port>` with no host
+  address, so the forwarded SSH port and the telnet serial console bind every
+  interface. State the exposure as it is. Rebinding those to 127.0.0.1 is a
+  `VM.pm` networking change unrelated to caching — every in-tree consumer
+  already dials 127.0.0.1 — and belongs outside plan 003.
 - Update `lib/OpenHVF/ImageCache.pod` for any interface additions.
 - Update the `openhvf` skill (`.claude/skills/openhvf/SKILL.md`) only if its
   procedures change; it must point at the man page, not restate it.
@@ -49,8 +68,11 @@ Add to `OpenHVF::CLI` alongside the existing `image` subcommand:
 ## Acceptance criteria
 
 - `cache list` reflects reality before and after installs and `clear`
-  operations; `cache clear --stale` provably keeps the current key and removes
-  others (unit-tested with synthetic entries).
+  operations; `cache clear --stale` provably keeps the invoked VM's key and
+  removes others, and sweeps a synthetic `installed/.tmp.*` tree (unit-tested
+  with synthetic entries).
+- `cache clear` refuses while the VM whose disk is backed by that entry is
+  running, and warns rather than refusing when the disk is stopped.
 - `image_cache no` and `--no-cache` each force a full install and leave the
   cache untouched; default behavior is unchanged from phase 1.
 - Usage errors (`cache frobnicate`) return `EXIT_INVALID_ARGS` with a usage

--- a/plans/003-openhvf-image-caching/plan-3.md
+++ b/plans/003-openhvf-image-caching/plan-3.md
@@ -24,10 +24,18 @@ for free.
 
 ### 3.1 `OpenHVF::ImageCache` snapshot primitives
 
-- `snapshot_store($key, $name, $disk_path, $meta)` — copy the (stopped) working
-  overlay into `snapshots/`, atomically, 0400. The overlay's absolute backing
-  reference to `base.qcow2` stays valid because bases are immutable. Validate
-  `$name` like VM names (no `/`, no NUL, bounded length).
+- `snapshot_store($key, $name, $disk_path, $meta)` — flatten the (stopped)
+  working overlay into `snapshots/`, atomically, 0400, with
+  `qemu-img convert -O qcow2 -B <absolute .../base.qcow2> -F qcow2` so the
+  snapshot's parent is always `base.qcow2`. Do not plain-copy the overlay: a
+  copy carries the backing-file header verbatim, which is only correct while the
+  working disk hangs directly off the base. After a `snapshot restore` it hangs
+  off a snapshot, so a copy would either stack chains without bound or — when
+  the same name is re-saved, which phase 4's deps layer does on a normal second
+  run — publish a qcow2 that names itself as its own backing file. Flattening
+  also keeps the model above true, so no snapshot is ever another snapshot's
+  parent and `snapshot rm` cannot orphan one. Validate `$name` like VM names (no
+  `/`, no NUL, bounded length).
 - `snapshot_lookup($key, $name)`, `snapshot_list($key)`,
   `snapshot_remove($key, $name)`.
 - Snapshot metadata records the state fields the disk embodies at save time:
@@ -40,12 +48,22 @@ for free.
 
 - `openhvf snapshot save <name>` — requires an existing, installed, **stopped**
   VM (`EXIT_VM_RUNNING` otherwise; a live overlay copy is not consistent).
-  Requires the disk to be an overlay of a cached base (standalone disks from
-  `--no-cache` or pre-phase-1 states are a diagnosed error, not a crash).
-- `openhvf snapshot restore <name>` — VM stopped; replaces the working disk with
-  a fresh overlay backed by the snapshot and reseeds state from snapshot
-  metadata. Missing snapshot returns a distinct, scriptable failure so callers
-  can do `restore || provision-from-scratch`.
+  Requires the disk to resolve to a cached base, whether directly or through a
+  snapshot — re-saving after a restore is normal. Only a standalone disk (from
+  `--no-cache` or a pre-phase-1 state) is a diagnosed error, not a crash. Add
+  `EXIT_VM_RUNNING` and the missing-snapshot code to `OpenHVF::CLI`'s existing
+  exit-code set rather than inventing local numbers.
+- `openhvf snapshot restore <name>` — VM stopped; unlinks the working disk and
+  recreates it as a fresh overlay backed by the snapshot (`Disk::create` returns
+  early on an existing path, so a restore that skips the unlink reports success
+  while changing nothing), then reseeds state from snapshot metadata. Missing
+  snapshot returns a distinct, scriptable failure so callers can do
+  `restore || provision-from-scratch`. Verify the snapshot's own chain resolves
+  and report a broken snapshot as a miss, so that same idiom recovers instead of
+  failing hard.
+- Restore must also work from nothing — no working disk, no state — because
+  phase 4 calls it on a fresh checkout before `openhvf up`. Only `save` requires
+  an existing installed VM.
 - `openhvf snapshot list` / `openhvf snapshot rm <name>` — scoped to the current
   configuration's key; `cache list` gains real snapshot counts.
 
@@ -64,11 +82,18 @@ for free.
 ## Acceptance criteria
 
 - Unit tests cover: name validation, store/lookup/list/remove round-trips,
-  restore reseeding state, the running-VM and standalone-disk refusals, and the
-  scriptable missing-snapshot exit code.
+  restore reseeding state, restore into an empty state directory (no disk, no
+  state — the shape phase 4 uses), restore over an existing disk actually
+  replacing it, the running-VM and standalone-disk refusals, and the scriptable
+  missing-snapshot exit code.
+- A stored snapshot's backing file is `base.qcow2` even when it was saved from a
+  disk that had been restored from another snapshot; re-saving the same name
+  twice leaves a resolvable chain.
 - On a host with QEMU: `up` (warm base) → mutate guest → `down` →
   `snapshot save s1` → mutate guest again → `down` → `snapshot restore s1` →
   `up` shows the first mutation and not the second.
+- `destroy` (empty state directory) → `snapshot restore s1` → `up` → `ssh`
+  works, exercising the reseed-from-nothing path phase 4 depends on.
 - `openhvf ssh` works after a restore in a checkout with a different SSH key
   than the one saved (exercises reseeded password + key reinstall).
 - `make check` stays green.

--- a/plans/003-openhvf-image-caching/plan-4.md
+++ b/plans/003-openhvf-image-caching/plan-4.md
@@ -9,49 +9,95 @@ only cached artifact is `~/.cache/openhvf`.
 ### 4.1 Provisioning snapshot in the scripts
 
 - `scripts/vm_provision.sh` computes a provisioning key — a short SHA-256 over
-  `deps/OpenBSD.txt`, the `cpanfile` if present, and the provisioning sections
-  of the script itself — and splits its guest work:
+  `deps/OpenBSD.txt`, `scripts/deps.sh`, the `cpanfile` if present, and the
+  provisioning sections of the script itself — and splits its guest work:
   1. **Deps layer (cacheable):** `pkg_add -u`, cpanm bootstrap, `make deps`.
      Attempted first via `openhvf snapshot restore deps-<hash>`; on a miss, run
      the deps layer, then `openhvf down`, `openhvf snapshot save deps-<hash>`,
      `openhvf up`, `openhvf wait`. The stop/start cost is paid only when
      dependencies actually changed.
-  2. **OpenHAP layer (never cached):** build tarball, scp, `make install`,
-     user/service setup — unchanged, runs every time.
-- Snapshot restore requires a stopped VM, so the restore attempt belongs in
-  `scripts/vm_up.sh` before `openhvf up`, guarded to run only when no working
-  disk exists yet; it exports whether the deps layer was restored so
-  `vm_provision.sh` can skip it. Keep the exact split simple and legible — the
-  scripts own this policy, openhvf only provides the verbs.
+  2. **OpenHAP layer (never cached):** `make install`, user/service setup —
+     unchanged, runs every time.
+- `scripts/deps.sh` must be in the key: `make deps` is driven by it, and today's
+  workflow key omits it too, so editing it currently leaves the cached guest
+  stale — the same incomplete-invalidation class this plan exists to fix.
+- **Tarball first.** `make deps` only exists inside the extracted tarball
+  (`Makefile:55-56`, `DEPS = scripts/deps.sh`, and `deps.sh` reads
+  `deps/${OS}.txt` relative to cwd); all three reach the guest via the package.
+  So building, scp'ing and extracting the tarball must happen BEFORE the deps
+  layer, not with `make install` after it — otherwise layer 1's
+  `cd /tmp/openhap-*` matches nothing and aborts under `set -e` on every run.
+  Copying only `Makefile`, `scripts/deps.sh` and `deps/` for that layer is an
+  equally valid split; pick one and say which.
+- **Leave no versioned tree in the snapshot.** `TAG` derives from
+  `git rev-list --count HEAD`, and `vm_provision.sh` currently removes only
+  `openhap`, not `openhap-*`. A snapshot that bakes in `/tmp/openhap-<TAG>/`
+  makes the later `cd /tmp/openhap-*` multi-match on the next commit and abort
+  under `set -e`. `rm -rf /tmp/openhap-*` before `snapshot save`, or widen the
+  existing cleanup.
+- **No handoff variable.** `vm_up.sh` and `vm_provision.sh` are sibling make
+  recipes in separate shells (`Makefile:208-212`, no `.ONESHELL`, no
+  `.EXPORT_ALL_VARIABLES`), so an exported flag cannot reach the consumer — it
+  would always read "not restored", making every warm run redo `make deps` and
+  the stop/start, silently, with the suite still green. Let `vm_provision.sh`
+  decide from evidence in its own process: a guest-side marker written as the
+  last step of the deps layer, before `openhvf down`, e.g.
+  `vm_run 'test -f /var/db/openhvf-deps-<hash>'`. Guest-side rather than
+  host-side, because the marker travels inside the snapshot layer and also
+  answers the local case where nothing was restored but the working disk already
+  carries the deps. `snapshot list` is a cross-check only — a snapshot existing
+  in the cache says nothing about what the current disk is backed by.
+- The restore attempt still belongs in `scripts/vm_up.sh` before `openhvf up`,
+  guarded to run only when no working disk exists yet. Keep the split simple and
+  legible — the scripts own this policy, openhvf only provides the verbs.
+- Both `snapshot restore` and `snapshot save` run under `set -e` while a
+  best-effort base-cache miss legitimately leaves a standalone disk, which phase
+  3 makes a diagnosed `save` error. Guard them script-side (`|| warn`) so a
+  cache miss cannot abort provisioning; do not soften the verb.
 - Prune old provisioning snapshots: after a successful save, remove `deps-*`
-  snapshots other than the current hash.
+  snapshots other than the current hash. Safe because phase 3 flattens snapshots
+  onto `base.qcow2`, so no `deps-*` snapshot is another one's parent.
 
 ### 4.2 Workflow simplification
 
 In `.github/workflows/integration.yml`:
 
-- Replace the two cache steps ("Cache OpenBSD miniroot image", "Cache
-  provisioned VM disk") with a single step caching `~/.cache/openhvf`:
-  - `key`: runner arch +
-    `hashFiles('.openhvfrc', 'share/openhvf/expect/install.exp', 'deps/OpenBSD.txt', 'scripts/vm_provision.sh')`
+- Drop `.openhvf` from the merged cache step phase 1 created, leaving a single
+  step caching `~/.cache/openhvf` alone:
+  - `key`: runner arch + the manual `v<N>` lever +
+    `hashFiles('.openhvfrc', 'share/openhvf/expect/install.exp', 'share/openhvf/cache-generation', 'deps/OpenBSD.txt', 'scripts/deps.sh', 'scripts/vm_provision.sh')`
   - `restore-keys`: the arch-scoped prefix, so a key rotation still restores the
     miniroot, still-valid bases, and lets openhvf's own keying decide what is
-    reusable. `actions/cache` saves on miss, so a rotated key re-saves the
-    updated cache automatically.
-- Run `./bin/openhvf cache clear --stale` in the post-test cleanup step to bound
-  cache growth before the save.
+    reusable.
+  - State the save rule precisely, because it constrains the key: the post-step
+    saves only on a **primary-key miss**, so a rotated key re-saves
+    automatically, while any input the workflow key does not hash can never be
+    persisted at all — which is why the generation counter is a hashed file and
+    not a constant.
+- Run `./bin/openhvf cache clear --stale || true` in the post-test cleanup step
+  to bound cache growth before the save. The `|| true` is not optional: that
+  step is `if: always()`, `run:` blocks are `bash -e`, and the cache post-step
+  is `post-if: success()`, so any non-zero exit there would discard the cache
+  the run just populated. No cleanup command may determine job status. A
+  `--stale` prune gated on `success()` would instead skip exactly the red runs
+  where the cache grows, so keep it unconditional and guarded.
 - Drop the `.openhvf`-specific choreography that existed only for archiving: the
   socket `find -delete` and the cache-consistency comments. Keep the
   `openhvf down` step itself — a clean shutdown is still correct hygiene and
   keeps the qcow2 consistent for the snapshot machinery.
-- Keep the ephemeral-SSH-key step; note that it now interacts only with the
-  guest, not with any cached artifact, since `.openhvf` is no longer saved.
+- Keep the ephemeral-SSH-key step, and correct its comment rather than extending
+  it: the key is still written to the global `~/.openhvfrc` to keep the project
+  `.openhvfrc` hash stable, since that file is still hashed into the surviving
+  cache key. What changes is only that no `.openhvf` state directory is
+  archived. The root password is not thereby removed from the cache — it moves
+  into `meta.json` under `~/.cache/openhvf`, which is still saved.
 
 ### 4.3 Documentation
 
 - Update the workflow comments to describe the new single-cache model.
-- Update the `integration-tests` skill only if its operator procedure changes;
-  behavior reference stays in `openhvf.1` and the workflow file.
+- Update the `integration-tests` skill's cold-cache procedure again: phase 1
+  merged two keys into one, this phase changes what that key covers. Behavior
+  reference stays in `openhvf.1` and the workflow file.
 
 ## Deliverables
 
@@ -60,14 +106,21 @@ In `.github/workflows/integration.yml`:
 
 ## Acceptance criteria
 
-- Two consecutive Integration runs on the same tree: the first (cold) run
-  installs, provisions, and populates the cache; the second (warm) run performs
-  no OS install and no `make deps` package installation, with a clearly lower
-  job wall-clock, and the full suite stays green on both.
-- A run after touching `deps/OpenBSD.txt` re-runs only the deps layer (new
-  snapshot), not the OS install; a run after touching `install.exp` re-runs the
-  OS install (new base key).
+- Two consecutive Integration runs on the same branch (cache entries are
+  branch-scoped, so "same tree" is not enough): the first (cold) run installs,
+  provisions, and populates the cache; the second (warm) run performs no OS
+  install and no `make deps` package installation, with a clearly lower job
+  wall-clock, and the full suite stays green on both.
+- The warm run's log shows the deps layer SKIPPED, not re-run. This is the
+  criterion the handoff bug would have satisfied vacuously — every step is
+  idempotent and the suite stays green either way — so check the log, not the
+  exit status.
+- A run after touching `deps/OpenBSD.txt` or `scripts/deps.sh` re-runs only the
+  deps layer (new snapshot), not the OS install; a run after touching
+  `install.exp` or `share/openhvf/cache-generation` re-runs the OS install (new
+  base key).
 - `.openhvf` no longer appears in any `actions/cache` path; no run depends on a
   previous run's state directory.
-- `make integration` still works unchanged on a developer machine with no
-  GitHub-specific assumptions.
+- `make integration` works on a developer machine with a persistent `.openhvf`,
+  twice in a row and across a commit that changes `TAG`, with no GitHub-specific
+  assumptions.


### PR DESCRIPTION
Adversarial review of plan 003 from six angles — qcow2/QEMU mechanism, cache-key soundness, GitHub Actions semantics, security, failure modes and concurrency, and plan coherence — with every claim peer-confirmed by two independent reviewers against the code. 38 raw findings triaged to 16; 13 survived peer review. This applies their corrections to the plan documents. No code changes.

The design's premise holds and is unchanged: deriving the cache key inside openhvf instead of hand-listing `hashFiles` inputs is the right fix, and the phase order correctly defers retiring the provisioning cache until its replacement exists. The defects were in mechanism and sequencing.

## Blocking before phase 1

- **Two cache entries could separate.** Coupling the two `actions/cache` keys makes them rotate together, not be *present* together — they hit, miss and get LRU-evicted independently. A restored `.openhvf` overlay meeting an absent base is a hard chain-check failure that no workflow step clears, on every rerun. Phase 1 now merges them into one entry over both paths.
- **The base capture relied on a stop nobody verified.** `VM.pm:199-201` discards the return values of both `_qmp_quit` and `_wait_exit`, and `clear_vm_pid` only unlinks the pid file, after which `_is_running` and `_force_stop` are blind. The capture is now gated on a confirmed-dead QEMU; a SIGKILLed QEMU disqualifies it.
- **`store`'s two renames could mismatch base and metadata.** The root password is generated per install, so a base from one install beside a `meta.json` from another looks live to `lookup` but its password cannot open its own image. Now published as one directory rename, write-once via `ENOTEMPTY`, with temp-tree cleanup on every failure path.
- **`CACHE_GENERATION` could not live in a `.pm`.** `actions/cache` runs no save step on a primary-key hit, so a bump the workflow key cannot see would reinstall and then discard the result on every run. Moved to `share/openhvf/cache-generation` and hashed in CI.

## Also corrected

- `snapshot_store` flattens onto `base.qcow2`. A plain copy carries the backing-file header, so re-saving after a restore publishes a qcow2 naming itself as its own backing file, and the `deps-*` prune would delete a live parent.
- Phase 4's deps-layer handoff drops the exported variable, which cannot cross the make/script boundary — it would have made every warm run silently redo `make deps` while the suite stayed green.
- The tarball must reach the guest before `make deps`, since that target only exists inside it.

Smaller fixes: chain check ordered ahead of the unclean-shutdown branch, whose remedy is a dead end; `cache_dir` plumbed through to `VM::up`, which hardcodes `$HOME`; the key derived once per `up`, before the installer runs; delete-first stated for `snapshot restore`; `--stale` scoped per invoked VM; and "localhost-only" struck from the password justification, since the forwarded SSH port and serial console bind every interface.

## Verification

`make prettier` passes. `make check`'s other components (`tidy`, `lint`, `test`) fail identically on a stashed clean tree in the dev container — missing `Perl::Critic`, and test dependencies — so they were not verifiable locally; CI covers them. The changes are Markdown-only. `design.md` is at 199 of its 200-line budget, which required compressing two Problem bullets and the `--cache P` paragraph.

All qcow2/`qemu-img` and `actions/cache` behavior in the review was reasoned from the code and documented semantics — `qemu-img` was not available in the review environment, so no QEMU experiment was run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbJkKyoAnvjt1osvDpD5Re)_