### PR TITLE
docs(daemon): add plan 005 for pledge(2) and unveil(2) support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,10 +155,13 @@ Corollaries:
 Larger efforts are planned before they are implemented, under
 `plans/<NNN>-<slug>/` (numbered in order of creation):
 
-- `design.md` — the **design**: a high-level architectural plan of at most 200
-  lines, defining the target state — contracts, interfaces, call graphs or
-  mermaid diagrams. It says _what_ is being built and why, not how to sequence
-  the work.
+- `design.md` — the **design**: a high-level architectural plan defining the
+  target state — contracts, interfaces, call graphs or mermaid diagrams. It says
+  _what_ is being built and why, not how to sequence the work. The binding
+  constraint is altitude, not length: keep sequencing, task breakdowns, and
+  file-by-file detail in `plan-N.md`. Aim for 200 lines and treat 300 as the
+  ceiling; a design pushing past that is usually describing more than one
+  design.
 - `plan-N.md` — the **plans**: the implementation broken into N phases, one file
   per phase. Each phase is independently shippable and lists its tasks,
   deliverables, and acceptance criteria; phase N may depend only on phases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,13 +155,11 @@ Corollaries:
 Larger efforts are planned before they are implemented, under
 `plans/<NNN>-<slug>/` (numbered in order of creation):
 
-- `design.md` — the **design**: a high-level architectural plan defining the
-  target state — contracts, interfaces, call graphs or mermaid diagrams. It says
-  _what_ is being built and why, not how to sequence the work. The binding
-  constraint is altitude, not length: keep sequencing, task breakdowns, and
-  file-by-file detail in `plan-N.md`. Aim for 200 lines and treat 300 as the
-  ceiling; a design pushing past that is usually describing more than one
-  design.
+- `design.md` — the **design**: a brief, high-level architectural plan defining
+  the target state — contracts, interfaces, call graphs or mermaid diagrams. It
+  says _what_ is being built and why, not how to sequence the work. Aim for 200
+  lines; running over is a prompt to cut, or to split the effort in two, not a
+  hard failure. Sequencing and file-by-file detail belong in `plan-N.md`.
 - `plan-N.md` — the **plans**: the implementation broken into N phases, one file
   per phase. Each phase is independently shippable and lists its tasks,
   deliverables, and acceptance criteria; phase N may depend only on phases

--- a/plans/005-pledge-unveil/design.md
+++ b/plans/005-pledge-unveil/design.md
@@ -1,0 +1,200 @@
+# pledge(2) and unveil(2) for openhapd — Design
+
+## Problem
+
+`README.md` says OpenHAP is "Native with pledge(2)/unveil(2) support",
+`CLAUDE.md` names them as the production platform's defining property, and
+`web/index.body.html` links both man pages. None of it is true: there is no
+`pledge` or `unveil` call anywhere in `bin/` or `lib/`, no `FuguLib` module for
+either, and no test. `TODO.md:10-20` records the gap accurately.
+
+`bin/openhapd` daemonizes, drops to `_openhap`, then enters `HAP::run`. A
+compromised TLV or HTTP parser therefore has the full syscall surface and the
+whole filesystem, limited only by uid.
+
+One structural obstacle stands in the way. `OpenHAP::MDNS` advertises the
+service by spawning `mdnsctl publish` as a long-lived child (`MDNS.pm:117`,
+killed at shutdown by `MDNS.pm:152`), and any pledge covering that must include
+`proc exec` — most of what pledge exists to take away. The child exists only
+because `mdnsctl` holds the advertisement open for as long as its control socket
+is open, and openhapd can hold that socket itself.
+
+## Goals
+
+1. `openhapd` runs its event loop under a single `pledge(2)` promise set with no
+   `proc`, `exec`, or `prot_exec`, and under a locked `unveil(2)` view.
+2. The pledge/unveil API is a `FuguLib` platform abstraction: real on OpenBSD, a
+   no-op on Linux and Darwin, so `make check` behaves identically everywhere.
+3. mDNS advertisement speaks to `mdnsd(8)` over `/var/run/mdnsd.sock` directly:
+   no child process, no `mdnsctl.log`, no kill-on-shutdown.
+4. Failures fail closed: an unappliable restriction on OpenBSD is fatal.
+5. The restrictions are proven by tests that fail if they are silently absent.
+
+## Non-goals
+
+- **Two-stage or per-phase pledges.** One promise set, applied once. Tightening
+  after pairing, or a separate pre-privdrop stage, is a later refinement;
+  correctness now beats minimality now.
+- **Privilege separation** into helper processes (`TODO.md:489`), and **pledging
+  `hapctl`** — both follow-ups, the latter cheap once `FuguLib::Sandbox` exists.
+- **Weakening the documentation.** `README.md`, `CLAUDE.md` and `web/` keep
+  their claims; phase 3 makes them true rather than the docs shrinking to fit.
+- **Fixing `pv=1`.** `HAP.pm:1087` sends protocol version `1`, not `1.1`,
+  because mdnsd splits TXT strings on `.` with no escape. A native client hands
+  mdnsd the same dot-delimited payload, so the constraint is unchanged.
+- Bonjour/Avahi backends; mDNS stays OpenBSD-only, exactly as today.
+
+## Should the mDNS client be a fourth sub-project?
+
+No. The FuguLib/OpenHVF precedent splits on **lifecycle and audience**, not on
+subject matter. OpenHVF earned a namespace by being a separate _program_: its
+own entry point, config format, and man page section, development-only, never
+installed. FuguLib is the other shape — shipped libraries, reusable by any
+OpenBSD daemon, documented as `man/fugulib/<Module>.3p`. An mdnsd client is the
+FuguLib shape exactly: a shipped library with no CLI, no config, and no user of
+its own. So is a pledge wrapper. A fourth namespace would buy nothing and cost
+`install` rules, a man-page rename loop, a test directory, a `CLAUDE.md`, and
+web index wiring, for two modules. Precedent also says FuguLib _absorbs_ —
+`OpenHAP::Log` became `FuguLib::Log` and the OpenHAP copy went away — and this
+design does the same to `OpenHAP::MDNS`. Revisit only when the client grows what
+OpenHVF has: a browse/resolve API with consumers outside this repo, or a `bin/`
+tool of its own.
+
+## Architecture
+
+Three new `FuguLib` modules — `Sandbox` (pledge/unveil) and `MDNS` (the mdnsd
+group protocol) over `Imsg` (framing) — one deletion, one new call site.
+
+### `FuguLib::Sandbox`
+
+One module covering both mechanisms, because they are one decision applied at
+one point; a module named `Pledge` that also unveils would misname itself.
+
+- `is_supported()` — true only on OpenBSD.
+- `pledge(promises => $string)` — 1 on success, `die` on failure.
+- `unveil(path => $perms, ...)` — applies each pair, `die` on failure.
+- `unveil_lock()` — `unveil(undef, undef)`; no path can be added afterwards.
+
+On OpenBSD the base-system `OpenBSD::Pledge`/`OpenBSD::Unveil` load at `use`
+time and failing to load is fatal: there, their absence means a broken Perl, not
+an unsupported system. Off OpenBSD every method returns 1 having done nothing,
+logging once at debug so a misread test cannot mistake a no-op for enforcement.
+
+### `FuguLib::Imsg` and `FuguLib::MDNS`
+
+`mdnsctl publish` performs a four-message conversation and then simply stays
+alive; mdnsd withdraws the record when the control socket closes.
+
+```mermaid
+sequenceDiagram
+    openhapd->>mdnsd: connect(/var/run/mdnsd.sock)
+    openhapd->>mdnsd: IMSG_CTL_GROUP_ADD (group name)
+    openhapd->>mdnsd: IMSG_CTL_GROUP_ADD_SERVICE (struct mdns_service)
+    openhapd->>mdnsd: IMSG_CTL_GROUP_COMMIT (group name)
+    mdnsd-->>openhapd: IMSG_CTL_GROUP_PROBING / ANNOUNCING / PUBLISHED
+    Note over openhapd,mdnsd: socket held open for the daemon's lifetime
+```
+
+`FuguLib::Imsg` is the framing layer: a 16-byte native-endian header (`type`
+u32, `len` u16 counting the header, `flags` u16, `peerid` u32, `pid` u32) plus
+payload, and buffered reads yielding whole messages — pure serialisation,
+unit-testable with no daemon present.
+
+`FuguLib::MDNS` is the protocol layer: `connect`, `publish_service`,
+`update_txt` (`GROUP_RESET` → `GROUP_ADD_SERVICE` → `GROUP_COMMIT` on the same
+socket, no reconnect), `withdraw` (close), and translation of reply types —
+including `GROUP_ERR_COLLISION`, `GROUP_ERR_NOT_FOUND`, `GROUP_ERR_DOUBLE_ADD` —
+into logged outcomes. Its payload is a raw `struct mdns_service`
+(`mdnsd/mdns.h`), which couples this code to mdnsd's ABI. That is the design's
+principal risk and is treated as one: phase 1 verifies the layout against the
+installed openmdns before writing the client, and pins the size constants in one
+place. Field offsets live in `plan-1.md`.
+
+`OpenHAP::MDNS` and its `.pod` are deleted. `bin/openhapd` and
+`HAP::update_txt_records` (`HAP.pm:148`) talk to `FuguLib::MDNS`; the
+HAP-specific `_hap`/`tcp`/TXT knowledge stays where it already lives, in
+`HAP::get_mdns_txt_records`.
+
+### The promise set
+
+One string, applied after mDNS registration and before `$hap->run()`. Every
+promise is there for a reason that outlives startup:
+
+```
+stdio rpath wpath cpath fattr flock inet dns unix
+```
+
+| promise       | required by                                                      |
+| ------------- | ---------------------------------------------------------------- |
+| `stdio`       | always                                                           |
+| `rpath`       | `/dev/urandom` (`Crypto.pm:35`), `Storage` reads, lazy `require` |
+| `wpath cpath` | `Storage` writes, `make_path` (`Storage.pm:14`), log file        |
+| `fattr`       | `chmod 0600` (`Storage.pm:158`, `:240`)                          |
+| `flock`       | `Storage.pm:62,82,139,155`                                       |
+| `inet`        | listen socket built in `HAP::run` (`HAP.pm:158`), MQTT reconnect |
+| `dns`         | MQTT reconnect resolving `mqtt_host` when it is a name           |
+| `unix`        | the held `/var/run/mdnsd.sock` connection                        |
+
+Deliberately absent: `proc exec` (phase 1 removes the only `exec`), `prot_exec`
+(see below), `getpw` and `id` (`getpwnam` and privdrop both precede pledge),
+`sendfd recvfd`. Syslog needs no promise — `Sys::Syslog` in native mode reaches
+`sendsyslog(2)`, which pledge always permits. The constraint this imposes on
+future work is the point: implementing SIGHUP-as-reload (`TODO.md:141`) must not
+re-exec, or `exec` returns to the set and most of the benefit is gone.
+
+### Late loading, and why `prot_exec` stays out
+
+Perl loads code lazily, and two such loads happen _after_ the pledge point:
+`Math::BigInt` pulls in `Math::BigInt::GMP` on first use — during pairing — and
+`OpenHAP::MQTT` `require`s `Net::MQTT::Simple`, which a failed startup
+connection defers to the first reconnect. `dlopen` of an XS object needs
+`prot_exec`, so both are handled beforehand:
+
+- **Preload** every XS dependency and force one GMP-backed `Math::BigInt`
+  operation, so no shared object opens after pledge; `localtime` is called once
+  so `/usr/share/zoneinfo` need not be unveiled.
+- **Unveil `@INC` read-only**, so pure-Perl lazy loads still resolve. This is
+  the deliberate simplicity trade: weaker than proving every load is preloaded,
+  and far more robust than discovering a missed `require` in production.
+
+### The unveil view
+
+Read-only for the config file, `/dev/urandom`, the resolver files and the `@INC`
+directories; read-write-create for `$db_path`; write for the daemon log;
+read-write for `/var/run/mdnsd.sock`, because `connect(2)` needs write
+permission on the path. Then `unveil_lock()`, then `pledge`; the exact inventory
+is in `plan-3.md`. Both come after privdrop: unveil only removes reachability,
+so applying it as `_openhap` is correct and keeps the root-only `chown` loop
+(`bin/openhapd:118-137`) working unchanged.
+
+## Contracts
+
+- On OpenBSD, `openhapd` never reaches `HAP::run` without both restrictions
+  applied; failing to apply either is fatal before the loop starts. Off OpenBSD,
+  behaviour is byte-identical to today.
+- The socket to mdnsd is the advertisement's lifetime. Closing it withdraws the
+  service — that is how shutdown unregisters. No signal, no child, no kill.
+- A `FuguLib::MDNS` failure stays non-fatal, exactly as `OpenHAP::MDNS` failure
+  is today: HAP still serves, discovery is degraded, a warning is logged.
+- mDNS advertisement is lost if `mdnsd` restarts and is not re-established until
+  `openhapd` restarts. Parity with today — the `mdnsctl` child dies the same way
+  — so it is documented, not fixed.
+- The `struct mdns_service` layout is verified by a test that fails loudly on
+  mismatch, never by silent truncation.
+
+## Strategy
+
+Four phases. Phase 1 must precede 2: `proc exec` cannot leave the promise set
+while a child is spawned.
+
+1. **mDNS without exec** — `FuguLib::Imsg`, `FuguLib::MDNS`, ABI verification,
+   `OpenHAP::MDNS` deleted, `bin/openhapd` and `HAP.pm` rewired.
+2. **`FuguLib::Sandbox` and pledge** — the platform abstraction with man page
+   and tests, XS/timezone preloading, and the promise set applied.
+3. **unveil** — the path inventory including `@INC`, `unveil_lock`, ordering
+   against privdrop.
+4. **Proof and operability** — negative integration tests in the OpenBSD VM that
+   fail if either restriction is absent, an `openhapd.8` SECURITY section, and
+   the `TODO.md` items closed.
+
+Once a phase lands, the code, tests, and man pages are the source of truth.

--- a/plans/005-pledge-unveil/design.md
+++ b/plans/005-pledge-unveil/design.md
@@ -27,8 +27,10 @@ is open, and openhapd can hold that socket itself.
    no-op on Linux and Darwin, so `make check` behaves identically everywhere.
 3. mDNS advertisement speaks to `mdnsd(8)` over `/var/run/mdnsd.sock` directly:
    no child process, no `mdnsctl.log`, no kill-on-shutdown.
-4. Failures fail closed: an unappliable restriction on OpenBSD is fatal.
-5. The restrictions are proven by tests that fail if they are silently absent.
+4. The mdnsd protocol we implement is documented in `spec/` and covered by
+   conformance tests citing it, like every other protocol in the tree.
+5. Failures fail closed: an unappliable restriction on OpenBSD is fatal.
+6. The restrictions are proven by tests that fail if they are silently absent.
 
 ## Non-goals
 
@@ -38,10 +40,12 @@ is open, and openhapd can hold that socket itself.
 - **Privilege separation** into helper processes (`TODO.md:489`), and **pledging
   `hapctl`** — both follow-ups, the latter cheap once `FuguLib::Sandbox` exists.
 - **Weakening the documentation.** `README.md`, `CLAUDE.md` and `web/` keep
-  their claims; phase 3 makes them true rather than the docs shrinking to fit.
+  their claims; phase 4 makes them true rather than the docs shrinking to fit.
 - **Fixing `pv=1`.** `HAP.pm:1087` sends protocol version `1`, not `1.1`,
   because mdnsd splits TXT strings on `.` with no escape. A native client hands
   mdnsd the same dot-delimited payload, so the constraint is unchanged.
+- **A full mdnsd client.** Browse, resolve and lookup are specified in phase 1
+  because they share the framing and the enum, but only publish is implemented.
 - Bonjour/Avahi backends; mDNS stays OpenBSD-only, exactly as today.
 
 ## Should the mDNS client be a fourth sub-project?
@@ -63,22 +67,46 @@ tool of its own.
 ## Architecture
 
 Three new `FuguLib` modules — `Sandbox` (pledge/unveil) and `MDNS` (the mdnsd
-group protocol) over `Imsg` (framing) — one deletion, one new call site.
+group protocol) over `Imsg` (framing) — a new `spec/MDNS*.md` family, one
+deletion, one new call site.
 
-### `FuguLib::Sandbox`
+### The mDNS protocol reference
 
-One module covering both mechanisms, because they are one decision applied at
-one point; a module named `Pledge` that also unveils would misname itself.
+Implementing a wire protocol makes this a protocol reference's job, so phase 1
+extracts one into `spec/` before any client code exists:
 
-- `is_supported()` — true only on OpenBSD.
-- `pledge(promises => $string)` — 1 on success, `die` on failure.
-- `unveil(path => $perms, ...)` — applies each pair, `die` on failure.
-- `unveil_lock()` — `unveil(undef, undef)`; no path can be added afterwards.
+- `spec/MDNS.md` — index and overview. Unhyphenated, so `scripts/spec-coverage`
+  treats it as an index and does not count its sections.
+- `spec/MDNS-Imsg.md` — the imsg framing: header layout, length semantics,
+  `MAX_IMSGSIZE`, buffering rules, and the fd-passing facility we deliberately
+  do not use.
+- `spec/MDNS-Control.md` — the control socket: path and permissions, the
+  `imsg_type` enum, the group publish sequence, the `struct mdns_service` ABI,
+  and TXT string encoding.
 
-On OpenBSD the base-system `OpenBSD::Pledge`/`OpenBSD::Unveil` load at `use`
-time and failing to load is fatal: there, their absence means a broken Perl, not
-an unsupported system. Off OpenBSD every method returns 1 having done nothing,
-logging once at debug so a misread test cannot mistake a no-op for enforcement.
+A new `spec-mdns` skill owns them, reading openmdns from `external/` plus
+measurements taken on the installed port — the same shape as `spec-hap` and
+`spec-mqtt`. Hand-writing them would make them the first hand-maintained files
+in a directory whose `CLAUDE.md` forbids exactly that.
+
+This is also the right answer to the ABI coupling, which is this design's
+principal risk. The `IMSG_CTL_GROUP_ADD_SERVICE` payload is a raw
+`struct mdns_service`, so we are bound to mdnsd's in-memory layout, padding and
+all. A spec section recording the measured offsets, plus a byte-exact
+conformance test citing it, turns a hidden assumption into a checked one.
+
+`spec/HAP-mDNS.md` is not the same document and does not absorb this: it says
+_what_ HomeKit requires be advertised — TXT keys, service type, instance naming
+— while `MDNS-*.md` says _how_ to make that advertisement happen on OpenBSD.
+Different upstreams, different owning skills, and `spec-hap` would overwrite
+anything added to the former.
+
+`scripts/spec-coverage` recognises citations matching `HAP|MQTT` only
+(`spec-coverage:109`), so phase 1 extends the pattern there and in the
+convention documented in `t/CLAUDE.md`. Without that, `MDNS-*` citations are
+invisible to both the coverage count and stale-citation detection — the files
+would sit at 0% forever and a citation rotting after regeneration would go
+unreported.
 
 ### `FuguLib::Imsg` and `FuguLib::MDNS`
 
@@ -104,16 +132,27 @@ unit-testable with no daemon present.
 `update_txt` (`GROUP_RESET` → `GROUP_ADD_SERVICE` → `GROUP_COMMIT` on the same
 socket, no reconnect), `withdraw` (close), and translation of reply types —
 including `GROUP_ERR_COLLISION`, `GROUP_ERR_NOT_FOUND`, `GROUP_ERR_DOUBLE_ADD` —
-into logged outcomes. Its payload is a raw `struct mdns_service`
-(`mdnsd/mdns.h`), which couples this code to mdnsd's ABI. That is the design's
-principal risk and is treated as one: phase 1 verifies the layout against the
-installed openmdns before writing the client, and pins the size constants in one
-place. Field offsets live in `plan-1.md`.
+into logged outcomes.
 
 `OpenHAP::MDNS` and its `.pod` are deleted. `bin/openhapd` and
 `HAP::update_txt_records` (`HAP.pm:148`) talk to `FuguLib::MDNS`; the
 HAP-specific `_hap`/`tcp`/TXT knowledge stays where it already lives, in
 `HAP::get_mdns_txt_records`.
+
+### `FuguLib::Sandbox`
+
+One module covering both mechanisms, because they are one decision applied at
+one point; a module named `Pledge` that also unveils would misname itself.
+
+- `is_supported()` — true only on OpenBSD.
+- `pledge(promises => $string)` — 1 on success, `die` on failure.
+- `unveil(path => $perms, ...)` — applies each pair, `die` on failure.
+- `unveil_lock()` — `unveil(undef, undef)`; no path can be added afterwards.
+
+On OpenBSD the base-system `OpenBSD::Pledge`/`OpenBSD::Unveil` load at `use`
+time and failing to load is fatal: there, their absence means a broken Perl, not
+an unsupported system. Off OpenBSD every method returns 1 having done nothing,
+logging once at debug so a misread test cannot mistake a no-op for enforcement.
 
 ### The promise set
 
@@ -135,7 +174,7 @@ stdio rpath wpath cpath fattr flock inet dns unix
 | `dns`         | MQTT reconnect resolving `mqtt_host` when it is a name           |
 | `unix`        | the held `/var/run/mdnsd.sock` connection                        |
 
-Deliberately absent: `proc exec` (phase 1 removes the only `exec`), `prot_exec`
+Deliberately absent: `proc exec` (phase 2 removes the only `exec`), `prot_exec`
 (see below), `getpw` and `id` (`getpwnam` and privdrop both precede pledge),
 `sendfd recvfd`. Syslog needs no promise — `Sys::Syslog` in native mode reaches
 `sendsyslog(2)`, which pledge always permits. The constraint this imposes on
@@ -163,7 +202,7 @@ Read-only for the config file, `/dev/urandom`, the resolver files and the `@INC`
 directories; read-write-create for `$db_path`; write for the daemon log;
 read-write for `/var/run/mdnsd.sock`, because `connect(2)` needs write
 permission on the path. Then `unveil_lock()`, then `pledge`; the exact inventory
-is in `plan-3.md`. Both come after privdrop: unveil only removes reachability,
+is in `plan-4.md`. Both come after privdrop: unveil only removes reachability,
 so applying it as `_openhap` is correct and keeps the root-only `chown` loop
 (`bin/openhapd:118-137`) working unchanged.
 
@@ -179,22 +218,29 @@ so applying it as `_openhap` is correct and keeps the root-only `chown` loop
 - mDNS advertisement is lost if `mdnsd` restarts and is not re-established until
   `openhapd` restarts. Parity with today — the `mdnsctl` child dies the same way
   — so it is documented, not fixed.
-- The `struct mdns_service` layout is verified by a test that fails loudly on
-  mismatch, never by silent truncation.
+- The `struct mdns_service` layout is documented in `spec/MDNS-Control.md` and
+  verified by a conformance test citing it, which fails loudly on mismatch
+  rather than truncating silently.
+- `spec/MDNS*.md` are generated, not hand-maintained: regenerating with
+  `spec-mdns` is how they change, and citations that rot are caught by
+  `make spec-coverage`.
 
 ## Strategy
 
-Four phases. Phase 1 must precede 2: `proc exec` cannot leave the promise set
+Five phases. Phases 1–2 must precede 3: `proc exec` cannot leave the promise set
 while a child is spawned.
 
-1. **mDNS without exec** — `FuguLib::Imsg`, `FuguLib::MDNS`, ABI verification,
-   `OpenHAP::MDNS` deleted, `bin/openhapd` and `HAP.pm` rewired.
-2. **`FuguLib::Sandbox` and pledge** — the platform abstraction with man page
+1. **mDNS protocol reference** — `spec/MDNS*.md`, the `spec-mdns` skill,
+   openmdns in `external/`, and `spec-coverage` citation support.
+2. **mDNS client without exec** — `FuguLib::Imsg`, `FuguLib::MDNS`, conformance
+   tests citing phase 1, `OpenHAP::MDNS` deleted, `bin/openhapd` rewired.
+3. **`FuguLib::Sandbox` and pledge** — the platform abstraction with man page
    and tests, XS/timezone preloading, and the promise set applied.
-3. **unveil** — the path inventory including `@INC`, `unveil_lock`, ordering
+4. **unveil** — the path inventory including `@INC`, `unveil_lock`, ordering
    against privdrop.
-4. **Proof and operability** — negative integration tests in the OpenBSD VM that
+5. **Proof and operability** — negative integration tests in the OpenBSD VM that
    fail if either restriction is absent, an `openhapd.8` SECURITY section, and
    the `TODO.md` items closed.
 
-Once a phase lands, the code, tests, and man pages are the source of truth.
+Once a phase lands, the code, tests, spec, and man pages are the source of
+truth.

--- a/plans/005-pledge-unveil/design.md
+++ b/plans/005-pledge-unveil/design.md
@@ -14,10 +14,10 @@ whole filesystem, limited only by uid.
 
 One structural obstacle stands in the way. `OpenHAP::MDNS` advertises the
 service by spawning `mdnsctl publish` as a long-lived child (`MDNS.pm:117`,
-killed at shutdown by `MDNS.pm:152`), and any pledge covering that must include
-`proc exec` — most of what pledge exists to take away. The child exists only
-because `mdnsctl` holds the advertisement open for as long as its control socket
-is open, and openhapd can hold that socket itself.
+killed at `MDNS.pm:152`), and any pledge covering that needs `proc exec` — most
+of what pledge exists to take away. That child exists only because `mdnsctl`
+holds the advertisement open as long as its control socket is, and openhapd can
+hold it.
 
 ## Goals
 
@@ -25,44 +25,40 @@ is open, and openhapd can hold that socket itself.
    `proc`, `exec`, or `prot_exec`, and under a locked `unveil(2)` view.
 2. The pledge/unveil API is a `FuguLib` platform abstraction: real on OpenBSD, a
    no-op on Linux and Darwin, so `make check` behaves identically everywhere.
-3. mDNS advertisement speaks to `mdnsd(8)` over `/var/run/mdnsd.sock` directly:
-   no child process, no `mdnsctl.log`, no kill-on-shutdown.
-4. The mdnsd protocol we implement is documented in `spec/` and covered by
-   conformance tests citing it, like every other protocol in the tree.
+3. mDNS speaks to `mdnsd(8)` over `/var/run/mdnsd.sock` directly: no child
+   process, no `mdnsctl.log`, no kill-on-shutdown.
+4. That protocol is documented in `spec/` and covered by conformance tests
+   citing it, like every other protocol in the tree.
 5. Failures fail closed: an unappliable restriction on OpenBSD is fatal.
 6. The restrictions are proven by tests that fail if they are silently absent.
 
 ## Non-goals
 
-- **Two-stage or per-phase pledges.** One promise set, applied once. Tightening
-  after pairing, or a separate pre-privdrop stage, is a later refinement;
-  correctness now beats minimality now.
+- **Two-stage or per-phase pledges.** One promise set, applied once; tightening
+  after pairing is a later refinement. Correctness now beats minimality now.
 - **Privilege separation** into helper processes (`TODO.md:489`), and **pledging
   `hapctl`** — both follow-ups, the latter cheap once `FuguLib::Sandbox` exists.
 - **Weakening the documentation.** `README.md`, `CLAUDE.md` and `web/` keep
   their claims; phase 4 makes them true rather than the docs shrinking to fit.
 - **Fixing `pv=1`.** `HAP.pm:1087` sends protocol version `1`, not `1.1`,
   because mdnsd splits TXT strings on `.` with no escape. A native client hands
-  mdnsd the same dot-delimited payload, so the constraint is unchanged.
+  mdnsd the same payload, so the constraint is unchanged.
 - **A full mdnsd client.** Browse, resolve and lookup are specified in phase 1
   because they share the framing and the enum, but only publish is implemented.
 - Bonjour/Avahi backends; mDNS stays OpenBSD-only, exactly as today.
 
 ## Should the mDNS client be a fourth sub-project?
 
-No. The FuguLib/OpenHVF precedent splits on **lifecycle and audience**, not on
-subject matter. OpenHVF earned a namespace by being a separate _program_: its
-own entry point, config format, and man page section, development-only, never
-installed. FuguLib is the other shape — shipped libraries, reusable by any
-OpenBSD daemon, documented as `man/fugulib/<Module>.3p`. An mdnsd client is the
-FuguLib shape exactly: a shipped library with no CLI, no config, and no user of
-its own. So is a pledge wrapper. A fourth namespace would buy nothing and cost
-`install` rules, a man-page rename loop, a test directory, a `CLAUDE.md`, and
-web index wiring, for two modules. Precedent also says FuguLib _absorbs_ —
-`OpenHAP::Log` became `FuguLib::Log` and the OpenHAP copy went away — and this
-design does the same to `OpenHAP::MDNS`. Revisit only when the client grows what
-OpenHVF has: a browse/resolve API with consumers outside this repo, or a `bin/`
-tool of its own.
+No. The precedent splits on **lifecycle and audience**, not subject matter:
+OpenHVF earned a namespace by being a separate _program_, with its own entry
+point, config format and man page section, development-only and never installed.
+An mdnsd client is the other shape, FuguLib's — a shipped library with no CLI,
+no config, no user of its own — and so is a pledge wrapper. A fourth namespace
+buys nothing and costs `install` rules, a man-page rename loop, a test
+directory, a `CLAUDE.md` and web index wiring, for two modules. Precedent also
+says FuguLib _absorbs_: `OpenHAP::Log` became `FuguLib::Log`, and this design
+does the same to `OpenHAP::MDNS`. Revisit when the client grows what OpenHVF has
+— consumers outside this repo, or a `bin/` tool.
 
 ## Architecture
 
@@ -73,40 +69,22 @@ deletion, one new call site.
 ### The mDNS protocol reference
 
 Implementing a wire protocol makes this a protocol reference's job, so phase 1
-extracts one into `spec/` before any client code exists:
+extracts one into `spec/` before any client code exists: `MDNS.md` (index),
+`MDNS-Imsg.md` (framing) and `MDNS-Control.md` (control socket, `imsg_type`
+enum, group publish sequence, `struct mdns_service` ABI, TXT encoding). A new
+`spec-mdns` skill owns them, reading openmdns from `external/` plus measurements
+taken on the installed port — the same shape as `spec-hap` and `spec-mqtt`.
+Hand-writing them would make them the first hand-maintained files in a directory
+whose `CLAUDE.md` forbids exactly that.
 
-- `spec/MDNS.md` — index and overview. Unhyphenated, so `scripts/spec-coverage`
-  treats it as an index and does not count its sections.
-- `spec/MDNS-Imsg.md` — the imsg framing: header layout, length semantics,
-  `MAX_IMSGSIZE`, buffering rules, and the fd-passing facility we deliberately
-  do not use.
-- `spec/MDNS-Control.md` — the control socket: path and permissions, the
-  `imsg_type` enum, the group publish sequence, the `struct mdns_service` ABI,
-  and TXT string encoding.
-
-A new `spec-mdns` skill owns them, reading openmdns from `external/` plus
-measurements taken on the installed port — the same shape as `spec-hap` and
-`spec-mqtt`. Hand-writing them would make them the first hand-maintained files
-in a directory whose `CLAUDE.md` forbids exactly that.
-
-This is also the right answer to the ABI coupling, which is this design's
-principal risk. The `IMSG_CTL_GROUP_ADD_SERVICE` payload is a raw
-`struct mdns_service`, so we are bound to mdnsd's in-memory layout, padding and
-all. A spec section recording the measured offsets, plus a byte-exact
-conformance test citing it, turns a hidden assumption into a checked one.
-
-`spec/HAP-mDNS.md` is not the same document and does not absorb this: it says
-_what_ HomeKit requires be advertised — TXT keys, service type, instance naming
-— while `MDNS-*.md` says _how_ to make that advertisement happen on OpenBSD.
-Different upstreams, different owning skills, and `spec-hap` would overwrite
-anything added to the former.
-
-`scripts/spec-coverage` recognises citations matching `HAP|MQTT` only
-(`spec-coverage:109`), so phase 1 extends the pattern there and in the
-convention documented in `t/CLAUDE.md`. Without that, `MDNS-*` citations are
-invisible to both the coverage count and stale-citation detection — the files
-would sit at 0% forever and a citation rotting after regeneration would go
-unreported.
+It is also the right answer to the ABI coupling, this design's principal risk:
+the `IMSG_CTL_GROUP_ADD_SERVICE` payload is a raw `struct mdns_service`, binding
+us to mdnsd's in-memory layout, padding and all. A spec section recording the
+measured offsets plus a byte-exact conformance test citing it turns a hidden
+assumption into a checked one. `spec/HAP-mDNS.md` does not absorb this and must
+not: it says _what_ HomeKit requires be advertised, while `MDNS-*.md` says _how_
+to advertise it on OpenBSD — different upstreams, different owning skills, and
+`spec-hap` would overwrite anything added to the former.
 
 ### `FuguLib::Imsg` and `FuguLib::MDNS`
 
@@ -123,16 +101,12 @@ sequenceDiagram
     Note over openhapd,mdnsd: socket held open for the daemon's lifetime
 ```
 
-`FuguLib::Imsg` is the framing layer: a 16-byte native-endian header (`type`
-u32, `len` u16 counting the header, `flags` u16, `peerid` u32, `pid` u32) plus
-payload, and buffered reads yielding whole messages — pure serialisation,
-unit-testable with no daemon present.
-
-`FuguLib::MDNS` is the protocol layer: `connect`, `publish_service`,
-`update_txt` (`GROUP_RESET` → `GROUP_ADD_SERVICE` → `GROUP_COMMIT` on the same
-socket, no reconnect), `withdraw` (close), and translation of reply types —
-including `GROUP_ERR_COLLISION`, `GROUP_ERR_NOT_FOUND`, `GROUP_ERR_DOUBLE_ADD` —
-into logged outcomes.
+`FuguLib::Imsg` is the framing layer — a 16-byte native-endian header plus
+payload, and buffered reads yielding whole messages; pure serialisation,
+unit-testable with no daemon present. `FuguLib::MDNS` is the protocol layer:
+`connect`, `publish_service`, `update_txt` (`GROUP_RESET` → `GROUP_ADD_SERVICE`
+→ `GROUP_COMMIT` on the same socket, no reconnect), `withdraw` (close), and
+translation of the reply and error types into logged outcomes.
 
 `OpenHAP::MDNS` and its `.pod` are deleted. `bin/openhapd` and
 `HAP::update_txt_records` (`HAP.pm:148`) talk to `FuguLib::MDNS`; the
@@ -150,9 +124,10 @@ one point; a module named `Pledge` that also unveils would misname itself.
 - `unveil_lock()` — `unveil(undef, undef)`; no path can be added afterwards.
 
 On OpenBSD the base-system `OpenBSD::Pledge`/`OpenBSD::Unveil` load at `use`
-time and failing to load is fatal: there, their absence means a broken Perl, not
-an unsupported system. Off OpenBSD every method returns 1 having done nothing,
-logging once at debug so a misread test cannot mistake a no-op for enforcement.
+time and failing to load is fatal — there, their absence means a broken Perl,
+not an unsupported system. Off OpenBSD every method returns 1 having done
+nothing, logging once at debug so a misread test cannot mistake a no-op for
+enforcement.
 
 ### The promise set
 
@@ -175,11 +150,11 @@ stdio rpath wpath cpath fattr flock inet dns unix
 | `unix`        | the held `/var/run/mdnsd.sock` connection                        |
 
 Deliberately absent: `proc exec` (phase 2 removes the only `exec`), `prot_exec`
-(see below), `getpw` and `id` (`getpwnam` and privdrop both precede pledge),
-`sendfd recvfd`. Syslog needs no promise — `Sys::Syslog` in native mode reaches
-`sendsyslog(2)`, which pledge always permits. The constraint this imposes on
-future work is the point: implementing SIGHUP-as-reload (`TODO.md:141`) must not
-re-exec, or `exec` returns to the set and most of the benefit is gone.
+(below), `getpw` and `id` (`getpwnam` and privdrop precede pledge),
+`sendfd recvfd`. Syslog needs none — `Sys::Syslog` in native mode reaches
+`sendsyslog(2)`, always permitted. The constraint on future work is the point:
+SIGHUP-as-reload (`TODO.md:141`) must not re-exec, or `exec` returns and the
+benefit goes.
 
 ### Late loading, and why `prot_exec` stays out
 
@@ -187,30 +162,27 @@ Perl loads code lazily, and two such loads happen _after_ the pledge point:
 `Math::BigInt` pulls in `Math::BigInt::GMP` on first use — during pairing — and
 `OpenHAP::MQTT` `require`s `Net::MQTT::Simple`, which a failed startup
 connection defers to the first reconnect. `dlopen` of an XS object needs
-`prot_exec`, so both are handled beforehand:
-
-- **Preload** every XS dependency and force one GMP-backed `Math::BigInt`
-  operation, so no shared object opens after pledge; `localtime` is called once
-  so `/usr/share/zoneinfo` need not be unveiled.
-- **Unveil `@INC` read-only**, so pure-Perl lazy loads still resolve. This is
-  the deliberate simplicity trade: weaker than proving every load is preloaded,
-  and far more robust than discovering a missed `require` in production.
+`prot_exec`, so both are handled beforehand: **preload** every XS dependency and
+force one GMP-backed `Math::BigInt` operation, and **unveil `@INC` read-only**
+so pure-Perl lazy loads still resolve. That second half is the deliberate
+simplicity trade — weaker than proving every load is preloaded, far more robust
+than discovering a missed `require` in production.
 
 ### The unveil view
 
 Read-only for the config file, `/dev/urandom`, the resolver files and the `@INC`
 directories; read-write-create for `$db_path`; write for the daemon log;
 read-write for `/var/run/mdnsd.sock`, because `connect(2)` needs write
-permission on the path. Then `unveil_lock()`, then `pledge`; the exact inventory
-is in `plan-4.md`. Both come after privdrop: unveil only removes reachability,
-so applying it as `_openhap` is correct and keeps the root-only `chown` loop
-(`bin/openhapd:118-137`) working unchanged.
+permission on the path. Then `unveil_lock()`, then `pledge`; the inventory is in
+`plan-4.md`. Both come after privdrop: unveil only removes reachability, so
+applying it as `_openhap` keeps the root-only `chown` loop
+(`bin/openhapd:118-137`) working.
 
 ## Contracts
 
 - On OpenBSD, `openhapd` never reaches `HAP::run` without both restrictions
-  applied; failing to apply either is fatal before the loop starts. Off OpenBSD,
-  behaviour is byte-identical to today.
+  applied; failing to apply either is fatal first. Off OpenBSD, behaviour is
+  byte-identical to today.
 - The socket to mdnsd is the advertisement's lifetime. Closing it withdraws the
   service — that is how shutdown unregisters. No signal, no child, no kill.
 - A `FuguLib::MDNS` failure stays non-fatal, exactly as `OpenHAP::MDNS` failure
@@ -218,29 +190,18 @@ so applying it as `_openhap` is correct and keeps the root-only `chown` loop
 - mDNS advertisement is lost if `mdnsd` restarts and is not re-established until
   `openhapd` restarts. Parity with today — the `mdnsctl` child dies the same way
   — so it is documented, not fixed.
-- The `struct mdns_service` layout is documented in `spec/MDNS-Control.md` and
-  verified by a conformance test citing it, which fails loudly on mismatch
-  rather than truncating silently.
-- `spec/MDNS*.md` are generated, not hand-maintained: regenerating with
-  `spec-mdns` is how they change, and citations that rot are caught by
-  `make spec-coverage`.
+- The `struct mdns_service` layout lives in `spec/MDNS-Control.md` and is
+  verified by a conformance test citing it, failing loudly rather than
+  truncating silently.
+- `spec/MDNS*.md` are generated, not hand-maintained: `spec-mdns` is how they
+  change, and citations that rot are caught by `make spec-coverage`.
 
 ## Strategy
 
-Five phases. Phases 1–2 must precede 3: `proc exec` cannot leave the promise set
-while a child is spawned.
-
-1. **mDNS protocol reference** — `spec/MDNS*.md`, the `spec-mdns` skill,
-   openmdns in `external/`, and `spec-coverage` citation support.
-2. **mDNS client without exec** — `FuguLib::Imsg`, `FuguLib::MDNS`, conformance
-   tests citing phase 1, `OpenHAP::MDNS` deleted, `bin/openhapd` rewired.
-3. **`FuguLib::Sandbox` and pledge** — the platform abstraction with man page
-   and tests, XS/timezone preloading, and the promise set applied.
-4. **unveil** — the path inventory including `@INC`, `unveil_lock`, ordering
-   against privdrop.
-5. **Proof and operability** — negative integration tests in the OpenBSD VM that
-   fail if either restriction is absent, an `openhapd.8` SECURITY section, and
-   the `TODO.md` items closed.
+Five phases, each with its own `plan-N.md`: (1) the mDNS protocol reference, (2)
+the mDNS client without exec, (3) `FuguLib::Sandbox` and pledge, (4) unveil, (5)
+proof and operability. Phases 1–2 must precede 3 — `proc exec` cannot leave the
+promise set while a child is spawned.
 
 Once a phase lands, the code, tests, spec, and man pages are the source of
 truth.

--- a/plans/005-pledge-unveil/plan-1.md
+++ b/plans/005-pledge-unveil/plan-1.md
@@ -1,0 +1,175 @@
+# Phase 1 — mDNS without exec
+
+Replace the `mdnsctl publish` child with a native client speaking imsg over
+`/var/run/mdnsd.sock`. This phase changes no security posture on its own; it
+removes the only `exec` in the daemon, which is what lets phase 2 pledge without
+`proc exec`. Independently shippable: it deletes a child process, a log file,
+and a kill-on-shutdown path.
+
+## Tasks
+
+### 1.1 Verify the mdnsd ABI before writing the client
+
+`FuguLib::MDNS` sends a raw `struct mdns_service`, so the wire format is
+openmdns' in-memory layout. Derive it, then **prove** it against the installed
+port rather than trusting the derivation. Two independent checks, both run
+inside the OpenBSD VM (`make integration`, or the `openhvf` skill for an
+interactive shell):
+
+1. Compile a three-line C program against `/usr/local/include/mdns.h` that
+   prints `sizeof(struct mdns_service)` and `offsetof` for every field, and
+   compare with the table below.
+2. Capture what `mdnsctl publish` actually sends.
+   `ktrace -i mdnsctl publish ...` plus `kdump` shows the `write(2)` payloads on
+   the control socket; the first four messages are the conversation to
+   replicate.
+
+Check 2 also settles three things the header cannot: whether `app` carries `hap`
+or `_hap` (`mdnsctl/parser.c` may normalise what `MDNS.pm:93` passes as `hap`),
+what `mdnsctl` puts in `target`/`addr`, and what `priority`/`weight` default to.
+
+Derived layout (LP64), to be confirmed, not assumed:
+
+| offset | field      | C type           | bytes |
+| ------ | ---------- | ---------------- | ----- |
+| 0      | `entry`    | `LIST_ENTRY`     | 16    |
+| 16     | `app`      | `char[64]`       | 64    |
+| 80     | `proto`    | `char[4]`        | 4     |
+| 84     | `name`     | `char[256]`      | 256   |
+| 340    | `target`   | `char[256]`      | 256   |
+| 596    | `priority` | `u_int16_t`      | 2     |
+| 598    | `weight`   | `u_int16_t`      | 2     |
+| 600    | `port`     | `u_int16_t`      | 2     |
+| 602    | `txt`      | `char[256]`      | 256   |
+| 858    | (padding)  |                  | 2     |
+| 860    | `addr`     | `struct in_addr` | 4     |
+
+864 bytes total, from `MAXLABELLEN` 64, `MAXPROTOLEN` 4, `MAXHOSTNAMELEN` 256
+and `MAXCHARSTR` = `MAXHOSTNAMELEN`. The `LIST_ENTRY` is mdnsd's own list
+linkage, two pointers wide, and is sent as zeros.
+
+Record the confirmed numbers in the commit message and as constants in the code.
+If the measured layout differs, the constants change and the rest of the phase
+is unaffected — that is the point of doing this first.
+
+### 1.2 `FuguLib::Imsg`
+
+Framing only, no mdnsd knowledge:
+
+- `new(fh => $fh)` over an already-connected handle, so tests can use a
+  `socketpair` and the module never opens anything itself.
+- `send(type => $n, data => $bytes)` — 16-byte native-endian header (`type` u32,
+  `len` u16 **including** the header, `flags` u16 zero, `peerid` u32 zero, `pid`
+  u32 `$$`) followed by payload. Refuse payloads that would exceed
+  `MAX_IMSGSIZE` (16384) rather than truncating.
+- `recv(timeout => $seconds)` — buffered, returns `{ type, data }` for one whole
+  message, `undef` on timeout or clean EOF; short reads accumulate across calls.
+  `IO::Select` for the timeout, never `alarm`.
+- No fd passing (`SCM_RIGHTS`): the mdnsd group protocol does not use it, and
+  omitting it keeps `sendfd`/`recvfd` out of the promise set.
+
+Ships with `man/fugulib/Imsg.3p`, a `MAN3P` entry in the `Makefile`, and
+`t/fugulib/imsg.t`. The test is platform-independent — round-trip over a
+`socketpair`, byte-exact header assertions, an oversized payload rejection, a
+truncated-header read, and a two-messages-in-one-read case.
+
+### 1.3 `FuguLib::MDNS`
+
+The mdnsd group protocol, OpenHAP-agnostic:
+
+- Constants for the `imsg_type` enum values used here. The enum is positional,
+  so pin all of `IMSG_NONE`(0) through `IMSG_CTL_GROUP_PUBLISHED`(17) in order
+  and name the openmdns version they came from in a comment.
+- `new(socket_path => ..., group => ...)` defaulting to `/var/run/mdnsd.sock`.
+- `connect()` — `IO::Socket::UNIX` `SOCK_STREAM`; returns `undef` with a warning
+  when the socket is missing or unreadable, matching how `MDNS.pm:70` treats a
+  missing `mdnsctl` today.
+- `publish_service(name =>, app =>, proto =>, port =>, txt =>)` — `GROUP_ADD`,
+  `GROUP_ADD_SERVICE`, `GROUP_COMMIT`, then read replies with a bounded timeout
+  (2s) until `GROUP_PUBLISHED`, an error type, or timeout. `GROUP_PROBING` and
+  `GROUP_ANNOUNCING` are logged at debug and are not terminal.
+- `update_txt(txt => ...)` — `GROUP_RESET`, `GROUP_ADD_SERVICE`, `GROUP_COMMIT`
+  on the **same** socket. No reconnect, no withdraw-and-republish.
+- `withdraw()` — close the socket; that is the entire operation.
+- `is_published()`.
+- TXT records join with `.`, preserving the convention and hazard documented at
+  `MDNS.pm:80-82`; the module states the constraint in its man page so the
+  `pv=1` workaround at `HAP.pm:1087` has something to point at.
+- Group-name and instance-name inputs longer than the field are an error, not a
+  silent truncation.
+
+Ships with `man/fugulib/MDNS.3p`, a `MAN3P` entry, and `t/fugulib/mdns.t`. The
+test stands up a temporary `AF_UNIX` listener as a fake mdnsd, asserts the exact
+bytes of all four messages against the confirmed layout, and drives the reply
+paths: `PUBLISHED`, `ERR_COLLISION`, `ERR_DOUBLE_ADD`, EOF mid-conversation, and
+a reply timeout. It runs on Linux and Darwin unchanged, which is where CI will
+exercise it.
+
+### 1.4 Rewire `openhapd` and delete `OpenHAP::MDNS`
+
+- `bin/openhapd`: replace the `OpenHAP::MDNS->new(...)` construction
+  (`:108-112`) with `FuguLib::MDNS`, and `register_service` (`:157`) with
+  `connect` + `publish_service`, passing `hap`/`tcp` and
+  `$hap->get_mdns_txt_records` from the call site.
+- `OpenHAP::HAP`: `set_mdns` keeps its signature; `update_txt_records`
+  (`HAP.pm:148`) calls `update_txt`.
+- The shutdown cleanup (`bin/openhapd:166-176`) calls `withdraw` instead of
+  `unregister_service`.
+- Delete `lib/OpenHAP/MDNS.pm`, `lib/OpenHAP/MDNS.pod`, and `t/openhap/mdns.t`
+  (or move whatever coverage in it is not mdnsctl-specific).
+- Remove the `$db_path/mdnsctl.log` machinery and the now-unused `log_dir`
+  plumbing. Check whether `FuguLib::Process` retains any other caller; if
+  `spawn_command`/`terminate` become dead code, say so in the commit message and
+  leave removal to a separate change — `FuguLib` is a library and its API is not
+  ours to prune on the way past.
+
+### 1.5 Ordering, privileges, and documentation
+
+- `/var/run/mdnsd.sock` is root:wheel, so the existing requirement that
+  `_openhap` be in `wheel` (`bin/openhapd:116`) still holds, and the connection
+  can still be made after privdrop. Keep the current ordering — privdrop, then
+  advertise — and update the stale comment at `:115-117` that explains it in
+  terms of killing a child process.
+- `man/openhap/openhapd.8`: the daemon no longer spawns a child, no longer
+  writes `mdnsctl.log`, and needs `mdnsd(8)` running rather than `mdnsctl(8)`
+  installed. Add `mdnsd(8)` to SEE ALSO.
+- `deps/OpenBSD.txt` keeps `openmdns` — the daemon is still required; only the
+  CLI is no longer invoked.
+- `.claude/skills/openhapd/SKILL.md`: update any procedure that greps for the
+  `mdnsctl` child or reads `mdnsctl.log`.
+
+### 1.6 Integration coverage
+
+Extend `t/openhap/integration/` (which never skips — see
+`t/openhap/integration/CLAUDE.md`) to assert, inside the VM:
+
+- `mdnsctl browse _hap._tcp` sees the advertised service after `openhapd`
+  starts.
+- No `mdnsctl` process is a child of `openhapd`, and no `mdnsctl.log` is
+  created.
+- The TXT record changes after a pairing state change (`sf` flips).
+- The advertisement disappears within a few seconds of `openhapd` exiting, which
+  is the socket-close contract.
+
+## Deliverables
+
+- `lib/FuguLib/Imsg.pm`, `lib/FuguLib/MDNS.pm`
+- `man/fugulib/Imsg.3p`, `man/fugulib/MDNS.3p`, `Makefile` `MAN3P` entries
+- `t/fugulib/imsg.t`, `t/fugulib/mdns.t`, new integration assertions
+- Changes to `bin/openhapd`, `lib/OpenHAP/HAP.pm`, `man/openhap/openhapd.8`
+- Deleted: `lib/OpenHAP/MDNS.pm`, `lib/OpenHAP/MDNS.pod`, `t/openhap/mdns.t`
+
+## Acceptance criteria
+
+- The measured `struct mdns_service` layout matches the constants in
+  `FuguLib::MDNS`, verified by task 1.1 and asserted by a test that fails loudly
+  on mismatch.
+- `mdnsctl browse` in the VM sees the service, its TXT updates on pairing state
+  change, and it disappears when the daemon exits.
+- `openhapd` spawns no child process at all: `pgrep -P $(pgrep openhapd)` is
+  empty.
+- A missing or unreachable `/var/run/mdnsd.sock` logs a warning and leaves the
+  HAP server serving, exactly as a missing `mdnsctl` does today.
+- `make check` green on Linux (unit tests use `socketpair`/`AF_UNIX` and need no
+  mdnsd); `make integration` green on OpenBSD.
+- `mandoc -Tlint -W warning` clean for both new man pages.

--- a/plans/005-pledge-unveil/plan-1.md
+++ b/plans/005-pledge-unveil/plan-1.md
@@ -1,34 +1,57 @@
-# Phase 1 — mDNS without exec
+# Phase 1 — The mDNS protocol reference
 
-Replace the `mdnsctl publish` child with a native client speaking imsg over
-`/var/run/mdnsd.sock`. This phase changes no security posture on its own; it
-removes the only `exec` in the daemon, which is what lets phase 2 pledge without
-`proc exec`. Independently shippable: it deletes a child process, a log file,
-and a kill-on-shutdown path.
+Extract the mdnsd control protocol into `spec/` before writing a line of client
+code, and teach the coverage tooling to see it. Independently shippable: it adds
+a protocol reference and the citation support for it, with no behaviour change.
+
+This phase exists because phase 2 implements a wire protocol against another
+daemon's in-memory struct layout. Deriving that from a header while writing the
+client would bury the assumptions in Perl comments. Extracting it first puts
+them in the one place this repo already trusts for protocol facts.
 
 ## Tasks
 
-### 1.1 Verify the mdnsd ABI before writing the client
+### 1.1 Add openmdns to `external/`
 
-`FuguLib::MDNS` sends a raw `struct mdns_service`, so the wire format is
-openmdns' in-memory layout. Derive it, then **prove** it against the installed
-port rather than trusting the derivation. Two independent checks, both run
-inside the OpenBSD VM (`make integration`, or the `openhvf` skill for an
-interactive shell):
+`.claude/skills/fetch-external/SKILL.md` clones five reference sources; add a
+sixth:
 
-1. Compile a three-line C program against `/usr/local/include/mdns.h` that
-   prints `sizeof(struct mdns_service)` and `offsetof` for every field, and
-   compare with the table below.
-2. Capture what `mdnsctl publish` actually sends.
-   `ktrace -i mdnsctl publish ...` plus `kdump` shows the `write(2)` payloads on
-   the control socket; the first four messages are the conversation to
-   replicate.
+```sh
+git clone --depth 1 https://github.com/haesbaert/mdnsd external/openmdns
+```
 
-Check 2 also settles three things the header cannot: whether `app` carries `hap`
-or `_hap` (`mdnsctl/parser.c` may normalise what `MDNS.pm:93` passes as `hap`),
+- Add `external/openmdns/mdnsd/mdns.h` and `external/openmdns/libmdns/mdnsl.c`
+  to the skill's "verify the key paths exist" list.
+- Add a Source Map row: openmdns — mdnsd control protocol,
+  `struct mdns_service`, the `imsg_type` enum — best for the mdnsd IPC protocol.
+- Note in the skill that `haesbaert/mdnsd` is upstream but the OpenBSD
+  `net/openmdns` port may carry patches, and **the installed port is
+  authoritative for us**. `cynix/openmdns` is a maintained fork; if the port
+  tracks it, clone that instead and say so in the provenance.
+
+### 1.2 Measure the ABI on the installed port
+
+Upstream source gives the field list; it does not give offsets, padding, or what
+`mdnsctl` actually puts on the wire. Both measurements happen inside the OpenBSD
+VM (`make integration`, or the `openhvf` skill for an interactive shell) and
+their output is what the spec records:
+
+1. Compile a short C program against the installed `/usr/local/include/mdns.h`
+   printing `sizeof(struct mdns_service)` and `offsetof` for every field.
+2. `ktrace -i mdnsctl publish ...` then `kdump`, to capture the `write(2)`
+   payloads on the control socket. The first four messages are the conversation
+   phase 2 replicates.
+
+Capture 2 settles three things no header can: whether `app` carries `hap` or
+`_hap` (`mdnsctl/parser.c` may normalise what `MDNS.pm:93` passes as `hap`),
 what `mdnsctl` puts in `target`/`addr`, and what `priority`/`weight` default to.
 
-Derived layout (LP64), to be confirmed, not assumed:
+Also record the OpenBSD version of `/usr/include/imsg.h` — imsg framing is base
+system, not openmdns, and is not in `external/`. The installed header is the
+authority for it.
+
+Derived layout to check the measurement against (LP64; `MAXLABELLEN` 64,
+`MAXPROTOLEN` 4, `MAXHOSTNAMELEN` 256, `MAXCHARSTR` = `MAXHOSTNAMELEN`):
 
 | offset | field      | C type           | bytes |
 | ------ | ---------- | ---------------- | ----- |
@@ -44,132 +67,111 @@ Derived layout (LP64), to be confirmed, not assumed:
 | 858    | (padding)  |                  | 2     |
 | 860    | `addr`     | `struct in_addr` | 4     |
 
-864 bytes total, from `MAXLABELLEN` 64, `MAXPROTOLEN` 4, `MAXHOSTNAMELEN` 256
-and `MAXCHARSTR` = `MAXHOSTNAMELEN`. The `LIST_ENTRY` is mdnsd's own list
-linkage, two pointers wide, and is sent as zeros.
+864 bytes total. The `LIST_ENTRY` is mdnsd's own list linkage, two pointers
+wide, and goes on the wire as zeros. If the measurement disagrees, the
+measurement wins and the table in the spec is the measured one — this table is a
+cross-check, not a source.
 
-Record the confirmed numbers in the commit message and as constants in the code.
-If the measured layout differs, the constants change and the rest of the phase
-is unaffected — that is the point of doing this first.
+### 1.3 The `spec-mdns` skill
 
-### 1.2 `FuguLib::Imsg`
+New `.claude/skills/spec-mdns/SKILL.md`, modelled on `spec-mqtt`: objective,
+preconditions (`fetch-external` first), primary sources, what to document, scope
+boundaries, output structure, formatting guidelines.
 
-Framing only, no mdnsd knowledge:
+Points specific to this skill:
 
-- `new(fh => $fh)` over an already-connected handle, so tests can use a
-  `socketpair` and the module never opens anything itself.
-- `send(type => $n, data => $bytes)` — 16-byte native-endian header (`type` u32,
-  `len` u16 **including** the header, `flags` u16 zero, `peerid` u32 zero, `pid`
-  u32 `$$`) followed by payload. Refuse payloads that would exceed
-  `MAX_IMSGSIZE` (16384) rather than truncating.
-- `recv(timeout => $seconds)` — buffered, returns `{ type, data }` for one whole
-  message, `undef` on timeout or clean EOF; short reads accumulate across calls.
-  `IO::Select` for the timeout, never `alarm`.
-- No fd passing (`SCM_RIGHTS`): the mdnsd group protocol does not use it, and
-  omitting it keeps `sendfd`/`recvfd` out of the promise set.
+- Primary sources are `external/openmdns/mdnsd/mdns.h` (enum, structs, socket
+  path), `external/openmdns/libmdns/mdnsl.c` (client sequences), and
+  `external/openmdns/mdnsctl/` (what a real client sends).
+- The ABI measurements from 1.2 are an input the skill cannot derive by reading
+  code. The skill must say so, and say that regeneration without a fresh
+  measurement carries the previous one forward with its provenance intact.
+- Scope: the control-socket protocol only. Not the mDNS wire protocol on the
+  network (RFC 6762/6763) — mdnsd owns that, and `spec/HAP-mDNS.md` already
+  covers what HomeKit needs advertised.
+- Provenance block near the top of `MDNS.md`, matching `MQTT.md`'s: extraction
+  date, `git -C external/openmdns rev-parse --short HEAD`, the installed port
+  version (`pkg_info -Q openmdns`), the OpenBSD release measured on, and the
+  `/usr/include/imsg.h` version.
 
-Ships with `man/fugulib/Imsg.3p`, a `MAN3P` entry in the `Makefile`, and
-`t/fugulib/imsg.t`. The test is platform-independent — round-trip over a
-`socketpair`, byte-exact header assertions, an oversized payload rejection, a
-truncated-header read, and a two-messages-in-one-read case.
+### 1.4 Write the spec files
 
-### 1.3 `FuguLib::MDNS`
+Three files, per the design. **Numbered `##`/`###` headings throughout** — the
+inventory regex in `scripts/spec-coverage:80` matches only `##` and `###` with a
+leading number, so a `####` heading cannot be cited and a heading whose number
+is missing is invisible. Anything a conformance test needs to cite must be `##`
+or `###`.
 
-The mdnsd group protocol, OpenHAP-agnostic:
+- `spec/MDNS.md` — index and overview. Glossary (imsg, control socket, group,
+  service, probing, announcing, collision), the publish flow end to end, links
+  to the topic files, provenance. Unhyphenated, so `spec-coverage` treats it as
+  an index and does not count its sections.
+- `spec/MDNS-Imsg.md` — framing. Header field layout and byte order, `len`
+  counting the header, `MAX_IMSGSIZE`, partial reads and message boundaries,
+  `peerid`/`pid` semantics, and the fd-passing facility with an explicit note
+  that we do not use it and why (it would need `sendfd`/`recvfd` in the pledge).
+- `spec/MDNS-Control.md` — the control protocol. Socket path and permissions
+  (root:wheel, hence the `wheel` requirement at `bin/openhapd:116`), the full
+  `imsg_type` enum with its ordinal values, the group publish sequence, reply
+  and error semantics, the `struct mdns_service` ABI as measured, TXT string
+  encoding including the `.` delimiter and its no-escaping consequence, and
+  field length limits. Specify browse/resolve/lookup message shapes too — they
+  share the enum and framing, cost a paragraph each, and stop the file from
+  looking like it describes the whole protocol when it describes a third of it.
 
-- Constants for the `imsg_type` enum values used here. The enum is positional,
-  so pin all of `IMSG_NONE`(0) through `IMSG_CTL_GROUP_PUBLISHED`(17) in order
-  and name the openmdns version they came from in a comment.
-- `new(socket_path => ..., group => ...)` defaulting to `/var/run/mdnsd.sock`.
-- `connect()` — `IO::Socket::UNIX` `SOCK_STREAM`; returns `undef` with a warning
-  when the socket is missing or unreadable, matching how `MDNS.pm:70` treats a
-  missing `mdnsctl` today.
-- `publish_service(name =>, app =>, proto =>, port =>, txt =>)` — `GROUP_ADD`,
-  `GROUP_ADD_SERVICE`, `GROUP_COMMIT`, then read replies with a bounded timeout
-  (2s) until `GROUP_PUBLISHED`, an error type, or timeout. `GROUP_PROBING` and
-  `GROUP_ANNOUNCING` are logged at debug and are not terminal.
-- `update_txt(txt => ...)` — `GROUP_RESET`, `GROUP_ADD_SERVICE`, `GROUP_COMMIT`
-  on the **same** socket. No reconnect, no withdraw-and-republish.
-- `withdraw()` — close the socket; that is the entire operation.
-- `is_published()`.
-- TXT records join with `.`, preserving the convention and hazard documented at
-  `MDNS.pm:80-82`; the module states the constraint in its man page so the
-  `pv=1` workaround at `HAP.pm:1087` has something to point at.
-- Group-name and instance-name inputs longer than the field are an error, not a
-  silent truncation.
+Include a byte-exact worked example of a full publish conversation, taken from
+the 1.2 capture. That example is what phase 2's conformance test replays.
 
-Ships with `man/fugulib/MDNS.3p`, a `MAN3P` entry, and `t/fugulib/mdns.t`. The
-test stands up a temporary `AF_UNIX` listener as a fake mdnsd, asserts the exact
-bytes of all four messages against the confirmed layout, and drives the reply
-paths: `PUBLISHED`, `ERR_COLLISION`, `ERR_DOUBLE_ADD`, EOF mid-conversation, and
-a reply timeout. It runs on Linux and Darwin unchanged, which is where CI will
-exercise it.
+### 1.5 Teach the tooling about the new family
 
-### 1.4 Rewire `openhapd` and delete `OpenHAP::MDNS`
+- `scripts/spec-coverage:109` — extend the citation pattern from
+  `(?:HAP|MQTT)[A-Za-z0-9-]*` to include `MDNS`. Without this, `[MDNS-Imsg §2]`
+  never matches: the citation is not counted, and — worse — is not stale-checked
+  either, so it silently rots when the spec is regenerated.
+- `t/CLAUDE.md:58` documents that grep pattern; update it in lockstep, and
+  mention the new topic ↔ test mapping in the conformance section.
+- `spec/CLAUDE.md` — add the `MDNS.md` / `MDNS-*.md` bullet naming `spec-mdns`
+  as the owning skill.
+- `.claude/skills/fetch-external/SKILL.md` — the description line lists the
+  sources it fetches and the skills that need it; add openmdns and `spec-mdns`.
+- Check whether `.claude/skills/compliance-hap/SKILL.md` should learn about the
+  new spec family. It audits against `spec/HAP*.md`; an mdnsd-transport audit is
+  a separate concern and probably should not be folded in, but decide
+  deliberately rather than by omission.
 
-- `bin/openhapd`: replace the `OpenHAP::MDNS->new(...)` construction
-  (`:108-112`) with `FuguLib::MDNS`, and `register_service` (`:157`) with
-  `connect` + `publish_service`, passing `hap`/`tcp` and
-  `$hap->get_mdns_txt_records` from the call site.
-- `OpenHAP::HAP`: `set_mdns` keeps its signature; `update_txt_records`
-  (`HAP.pm:148`) calls `update_txt`.
-- The shutdown cleanup (`bin/openhapd:166-176`) calls `withdraw` instead of
-  `unregister_service`.
-- Delete `lib/OpenHAP/MDNS.pm`, `lib/OpenHAP/MDNS.pod`, and `t/openhap/mdns.t`
-  (or move whatever coverage in it is not mdnsctl-specific).
-- Remove the `$db_path/mdnsctl.log` machinery and the now-unused `log_dir`
-  plumbing. Check whether `FuguLib::Process` retains any other caller; if
-  `spawn_command`/`terminate` become dead code, say so in the commit message and
-  leave removal to a separate change — `FuguLib` is a library and its API is not
-  ours to prune on the way past.
+No `Makefile` change: `spec-coverage` globs `spec/*.md` and picks the new files
+up on its own.
 
-### 1.5 Ordering, privileges, and documentation
+### 1.6 Verify the tooling actually sees them
 
-- `/var/run/mdnsd.sock` is root:wheel, so the existing requirement that
-  `_openhap` be in `wheel` (`bin/openhapd:116`) still holds, and the connection
-  can still be made after privdrop. Keep the current ordering — privdrop, then
-  advertise — and update the stale comment at `:115-117` that explains it in
-  terms of killing a child process.
-- `man/openhap/openhapd.8`: the daemon no longer spawns a child, no longer
-  writes `mdnsctl.log`, and needs `mdnsd(8)` running rather than `mdnsctl(8)`
-  installed. Add `mdnsd(8)` to SEE ALSO.
-- `deps/OpenBSD.txt` keeps `openmdns` — the daemon is still required; only the
-  CLI is no longer invoked.
-- `.claude/skills/openhapd/SKILL.md`: update any procedure that greps for the
-  `mdnsctl` child or reads `mdnsctl.log`.
+`make spec-coverage` must list the two new topic files. Coverage will read 0/N
+until phase 2 — that is correct and non-fatal (the script exits nonzero only on
+stale citations), and it is what makes this phase shippable alone.
 
-### 1.6 Integration coverage
-
-Extend `t/openhap/integration/` (which never skips — see
-`t/openhap/integration/CLAUDE.md`) to assert, inside the VM:
-
-- `mdnsctl browse _hap._tcp` sees the advertised service after `openhapd`
-  starts.
-- No `mdnsctl` process is a child of `openhapd`, and no `mdnsctl.log` is
-  created.
-- The TXT record changes after a pairing state change (`sf` flips).
-- The advertisement disappears within a few seconds of `openhapd` exiting, which
-  is the socket-close contract.
+Prove the wiring rather than assuming it: add a temporary citation to a real
+section, confirm it counts, then a citation to a nonexistent section, confirm
+`make spec-coverage` exits nonzero with `STALE`. Remove both before committing.
 
 ## Deliverables
 
-- `lib/FuguLib/Imsg.pm`, `lib/FuguLib/MDNS.pm`
-- `man/fugulib/Imsg.3p`, `man/fugulib/MDNS.3p`, `Makefile` `MAN3P` entries
-- `t/fugulib/imsg.t`, `t/fugulib/mdns.t`, new integration assertions
-- Changes to `bin/openhapd`, `lib/OpenHAP/HAP.pm`, `man/openhap/openhapd.8`
-- Deleted: `lib/OpenHAP/MDNS.pm`, `lib/OpenHAP/MDNS.pod`, `t/openhap/mdns.t`
+- `spec/MDNS.md`, `spec/MDNS-Imsg.md`, `spec/MDNS-Control.md`
+- `.claude/skills/spec-mdns/SKILL.md`
+- Changes to `.claude/skills/fetch-external/SKILL.md`, `scripts/spec-coverage`,
+  `t/CLAUDE.md`, `spec/CLAUDE.md`
 
 ## Acceptance criteria
 
-- The measured `struct mdns_service` layout matches the constants in
-  `FuguLib::MDNS`, verified by task 1.1 and asserted by a test that fails loudly
-  on mismatch.
-- `mdnsctl browse` in the VM sees the service, its TXT updates on pairing state
-  change, and it disappears when the daemon exits.
-- `openhapd` spawns no child process at all: `pgrep -P $(pgrep openhapd)` is
-  empty.
-- A missing or unreachable `/var/run/mdnsd.sock` logs a warning and leaves the
-  HAP server serving, exactly as a missing `mdnsctl` does today.
-- `make check` green on Linux (unit tests use `socketpair`/`AF_UNIX` and need no
-  mdnsd); `make integration` green on OpenBSD.
-- `mandoc -Tlint -W warning` clean for both new man pages.
+- The `struct mdns_service` layout in `spec/MDNS-Control.md` is the measured
+  one, and the spec says which OpenBSD release and port version it was measured
+  on.
+- `spec/MDNS-Control.md` contains a byte-exact publish conversation captured
+  from a real `mdnsctl`, sufficient for phase 2 to replay without re-deriving
+  anything.
+- Every section a conformance test will cite is a numbered `##` or `###`
+  heading.
+- `make spec-coverage` lists both topic files, reports 0 covered sections, and
+  exits zero; a deliberately bogus citation makes it exit nonzero with `STALE`.
+- `make prettier` clean. `make check` unaffected — no Perl and no tests change,
+  and `scripts/spec-coverage` is not in `lint`'s file list, so run it directly.
+- Regenerating with `spec-mdns` on a populated `external/` reproduces the files
+  modulo the provenance block and the carried-forward measurements.

--- a/plans/005-pledge-unveil/plan-2.md
+++ b/plans/005-pledge-unveil/plan-2.md
@@ -1,130 +1,177 @@
-# Phase 2 — `FuguLib::Sandbox` and pledge(2)
+# Phase 2 — mDNS client without exec
 
-Build the platform abstraction and apply the pledge. Depends on phase 1: while
-`openhapd` spawns `mdnsctl`, the promise set would need `proc exec` and the
-exercise would be close to pointless.
+Replace the `mdnsctl publish` child with a native client speaking imsg over
+`/var/run/mdnsd.sock`, implemented against the phase 1 spec. This phase changes
+no security posture on its own; it removes the only `exec` in the daemon, which
+is what lets phase 3 pledge without `proc exec`. Independently shippable: it
+deletes a child process, a log file, and a kill-on-shutdown path.
+
+Depends on phase 1 for `spec/MDNS-Imsg.md` and `spec/MDNS-Control.md` — the
+measured `struct mdns_service` layout, the `imsg_type` ordinals, and the
+byte-exact publish conversation all come from there, and the conformance tests
+cite it.
 
 ## Tasks
 
-### 2.1 `FuguLib::Sandbox`
+### 2.1 `FuguLib::Imsg`
 
-One module, both mechanisms, three platforms. The whole point is that callers
-never write `if ($^O eq 'openbsd')`.
+Framing only, no mdnsd knowledge:
 
-```perl
-FuguLib::Sandbox->is_supported;                 # 1 on OpenBSD, '' elsewhere
-FuguLib::Sandbox->pledge(promises => $string);  # 1, or die
-FuguLib::Sandbox->unveil(paths => \@pairs);     # 1, or die
-FuguLib::Sandbox->unveil_lock;                  # 1, or die
-```
+- `new(fh => $fh)` over an already-connected handle, so tests can use a
+  `socketpair` and the module never opens anything itself.
+- `send(type => $n, data => $bytes)` — 16-byte native-endian header (`type` u32,
+  `len` u16 **including** the header, `flags` u16 zero, `peerid` u32 zero, `pid`
+  u32 `$$`) followed by payload. Refuse payloads that would exceed
+  `MAX_IMSGSIZE` (16384) rather than truncating.
+- `recv(timeout => $seconds)` — buffered, returns `{ type, data }` for one whole
+  message, `undef` on timeout or clean EOF; short reads accumulate across calls.
+  `IO::Select` for the timeout, never `alarm`.
+- No fd passing (`SCM_RIGHTS`): the mdnsd group protocol does not use it, and
+  omitting it keeps `sendfd`/`recvfd` out of the promise set.
 
-- On OpenBSD, `OpenBSD::Pledge` and `OpenBSD::Unveil` are loaded at compile
-  time. They are base-system modules; failing to load them there means a broken
-  Perl, so that is fatal at `use` time rather than a runtime fallback to "no
-  protection".
-- Off OpenBSD every method is a no-op returning 1, and logs **once** at debug
-  (`'sandbox: %s is a no-op on %s'`). Once, not per call, so a daemon that
-  re-pledges does not flood the log; and at debug rather than silence so a test
-  reading logs can tell enforcement from emulation.
-- `pledge` and `unveil` failures `die` with the promise string or path and `$!`.
-  Fail closed: there is no `force => 0` and no warn-and-continue mode. A daemon
-  that cannot restrict itself must not start.
-- `unveil(paths => [[$path, $perms], ...])` applies pairs in order and reports
-  which pair failed. `$path` that does not exist is a failure, not a skip — a
-  typo'd path silently accepted is the failure mode that makes unveil useless.
-- `unveil_lock` calls `OpenBSD::Unveil::unveil()` with no arguments.
-- Keep it stateless: class methods, no object. It wraps two syscalls that are
-  themselves process-global.
+Ships with `man/fugulib/Imsg.3p`, a `MAN3P` entry in the `Makefile`, and
+`t/fugulib/imsg.t`. The module test is platform-independent — round-trip over a
+`socketpair`, an oversized payload rejection, a truncated-header read, and a
+two-messages-in-one-read case. Byte-exact header assertions belong in the
+conformance test (2.3), not here; module tests verify API behaviour and error
+paths, the conformance tier verifies the wire format.
 
-Ships with `man/fugulib/Sandbox.3p`, a `MAN3P` entry, and `t/fugulib/sandbox.t`.
+The man page documents the API. It does not restate the framing — that is
+`spec/MDNS-Imsg.md`'s job — and points there instead.
 
-The test must be meaningful on both kinds of platform, which needs care:
+### 2.2 `FuguLib::MDNS`
 
-- Everywhere: `is_supported` agrees with `$^O`; a no-op platform returns 1 from
-  every method and does not die.
-- On OpenBSD only: fork a child, `pledge('stdio')` in it, have it attempt
-  `socket(AF_INET)`, and assert it dies of `SIGABRT` — pledge violations abort,
-  they do not return `EPERM`. Assert in the **child**, never the parent, or the
-  test process pledges itself and takes the rest of the suite down.
-- On OpenBSD only: a child that unveils `$tmpdir` read-only, locks, and then
-  fails to open a file outside it.
-- A bogus promise string dies rather than being accepted.
+The mdnsd group protocol, OpenHAP-agnostic:
 
-Guard the OpenBSD-only cases with `plan skip_all` at the file level only if the
-whole file is OpenBSD-specific; here it is not, so guard per-subtest and make
-the skip message name the reason.
+- Constants for the `imsg_type` enum values used here. The enum is positional,
+  so pin all of `IMSG_NONE`(0) through `IMSG_CTL_GROUP_PUBLISHED`(17) in order,
+  taken from `spec/MDNS-Control.md` rather than re-read from the header, with a
+  comment citing the section.
+- `new(socket_path => ..., group => ...)` defaulting to `/var/run/mdnsd.sock`.
+- `connect()` — `IO::Socket::UNIX` `SOCK_STREAM`; returns `undef` with a warning
+  when the socket is missing or unreadable, matching how `MDNS.pm:70` treats a
+  missing `mdnsctl` today.
+- `publish_service(name =>, app =>, proto =>, port =>, txt =>)` — `GROUP_ADD`,
+  `GROUP_ADD_SERVICE`, `GROUP_COMMIT`, then read replies with a bounded timeout
+  (2s) until `GROUP_PUBLISHED`, an error type, or timeout. `GROUP_PROBING` and
+  `GROUP_ANNOUNCING` are logged at debug and are not terminal.
+- `update_txt(txt => ...)` — `GROUP_RESET`, `GROUP_ADD_SERVICE`, `GROUP_COMMIT`
+  on the **same** socket. No reconnect, no withdraw-and-republish.
+- `withdraw()` — close the socket; that is the entire operation.
+- `is_published()`.
+- TXT records join with `.`, per the encoding section of `spec/MDNS-Control.md`;
+  the man page points at that section so the `pv=1` workaround at `HAP.pm:1087`
+  has something to cite.
+- Group-name and instance-name inputs longer than the field are an error, not a
+  silent truncation.
+- The `struct mdns_service` field offsets and size come from the spec, as named
+  constants in one place, so an openmdns change is a one-line edit next to a
+  citation.
 
-### 2.2 Preload everything that would `dlopen` later
+Ships with `man/fugulib/MDNS.3p`, a `MAN3P` entry, and `t/fugulib/mdns.t`. The
+module test stands up a temporary `AF_UNIX` listener as a fake mdnsd and drives
+the reply paths — `PUBLISHED`, `ERR_COLLISION`, `ERR_DOUBLE_ADD`, EOF
+mid-conversation, a reply timeout, and an over-length name — on Linux and Darwin
+unchanged, which is where CI exercises it.
 
-`prot_exec` stays out of the promise set, so no shared object may be opened
-after the pledge. Two known offenders load lazily (see the design), and both are
-handled in `bin/openhapd` before pledging:
+### 2.3 Conformance tests
 
-- Explicitly `use`/`require` the XS runtime dependencies: `Crypt::Ed25519`,
-  `Crypt::Curve25519`, `Crypt::AuthEnc::ChaCha20Poly1305`,
-  `Crypt::KeyDerivation`, `Digest::SHA`, `JSON::XS`, `Net::MQTT::Simple`,
-  `Sys::Syslog`.
-- Force `Math::BigInt` to load its GMP backend by performing one modular
-  exponentiation. `Math::BigInt::GMP` is pulled in on first use, and first use
-  is otherwise during SRP at pairing time — long after the pledge.
-- Call `localtime` once so the zone file is cached.
+Per `t/CLAUDE.md`, one `.t` per normative topic file, named after the lowercased
+stem: `t/conformance/mdns-imsg.t` and `t/conformance/mdns-control.t`. This is
+the tier that closes the loop opened in phase 1 — the spec records what the
+protocol is, these assert our encoder produces it.
 
-Put this in one clearly commented block — a `_preload` sub in `bin/openhapd` —
-with a comment saying _why_, because the next person to read it will otherwise
-delete it as redundant `use` statements. Note in the comment that adding an XS
-dependency means adding it here.
+Both follow the conformance rules: every subtest name starts with a citation,
+wire examples are replayed byte-exactly, vectors live inline with no network and
+no `external/`, `Test::More` + `subtest`, `skip_all` on missing CPAN
+dependencies.
 
-### 2.3 Apply the pledge in `bin/openhapd`
+- `mdns-imsg.t` — header encoding field by field against `[MDNS-Imsg §…]`: byte
+  order, `len` counting the header, `MAX_IMSGSIZE` refusal, message-boundary
+  handling on a split read.
+- `mdns-control.t` — the `imsg_type` ordinals; `struct mdns_service` encoded
+  byte-exactly, including the zeroed `LIST_ENTRY`, the internal padding, and NUL
+  padding of each fixed field; TXT `.` joining; the full publish conversation
+  from the spec's worked example, replayed byte-for-byte; and the reply/error
+  type meanings.
 
-After the mDNS advertisement is established and before the signal handlers and
-`$hap->run()`:
+The struct assertion is the one that matters most: it is the only thing standing
+between an openmdns layout change and a daemon that silently advertises garbage.
+Assert the whole 864-byte buffer against a literal, not field by field — a
+field-by-field check passes even when the total size or padding is wrong.
 
-```
-stdio rpath wpath cpath fattr flock inet dns unix
-```
+`make spec-coverage` should now report real coverage for both topic files where
+it reported 0 in phase 1.
 
-Derivation is in the design; the code carries a comment per promise so a future
-reader can shrink the set safely. Also:
+### 2.4 Rewire `openhapd` and delete `OpenHAP::MDNS`
 
-- Both `-f`/foreground and daemon mode pledge identically. Foreground differs
-  only in where the log goes, which is already an open fd by then.
-- `-n`/`--check` exits at `bin/openhapd:34-37`, before any of this. Leave it
-  alone; a config check is not a long-running process.
-- Log at info that the pledge was applied, naming the promise set. On a no-op
-  platform, log nothing at info — the debug line from 2.1 is enough — so the
-  absence of that info line is itself a signal.
+- `bin/openhapd`: replace the `OpenHAP::MDNS->new(...)` construction
+  (`:108-112`) with `FuguLib::MDNS`, and `register_service` (`:157`) with
+  `connect` + `publish_service`, passing `hap`/`tcp` and
+  `$hap->get_mdns_txt_records` from the call site.
+- `OpenHAP::HAP`: `set_mdns` keeps its signature; `update_txt_records`
+  (`HAP.pm:148`) calls `update_txt`.
+- The shutdown cleanup (`bin/openhapd:166-176`) calls `withdraw` instead of
+  `unregister_service`.
+- Delete `lib/OpenHAP/MDNS.pm`, `lib/OpenHAP/MDNS.pod`, and `t/openhap/mdns.t`
+  (or move whatever coverage in it is not mdnsctl-specific).
+- Remove the `$db_path/mdnsctl.log` machinery and the now-unused `log_dir`
+  plumbing. Check whether `FuguLib::Process` retains any other caller; if
+  `spawn_command`/`terminate` become dead code, say so in the commit message and
+  leave removal to a separate change — `FuguLib` is a library and its API is not
+  ours to prune on the way past.
 
-### 2.4 Documentation
+### 2.5 Ordering, privileges, and documentation
 
-- `man/fugulib/Sandbox.3p` is the API reference for the module (FuguLib is
-  documented in man3p, not in sidecars).
-- `man/openhap/openhapd.8`: state the promise set and that OpenBSD is the only
-  platform where it is enforced. The full SECURITY section lands in phase 4,
-  once unveil is in place; here, one accurate paragraph.
-- Do not touch `README.md`, `CLAUDE.md`, or `web/` — their claims become fully
-  true at the end of phase 3, and hedging them for one phase then unhedging them
-  is churn.
+- `/var/run/mdnsd.sock` is root:wheel, so the existing requirement that
+  `_openhap` be in `wheel` (`bin/openhapd:116`) still holds, and the connection
+  can still be made after privdrop. Keep the current ordering — privdrop, then
+  advertise — and update the stale comment at `:115-117` that explains it in
+  terms of killing a child process.
+- `man/openhap/openhapd.8`: the daemon no longer spawns a child, no longer
+  writes `mdnsctl.log`, and needs `mdnsd(8)` running rather than `mdnsctl(8)`
+  installed. Add `mdnsd(8)` to SEE ALSO.
+- `deps/OpenBSD.txt` keeps `openmdns` — the daemon is still required; only the
+  CLI is no longer invoked.
+- `.claude/skills/openhapd/SKILL.md`: update any procedure that greps for the
+  `mdnsctl` child or reads `mdnsctl.log`.
+
+### 2.6 Integration coverage
+
+Extend `t/openhap/integration/` (which never skips — see
+`t/openhap/integration/CLAUDE.md`) to assert, inside the VM:
+
+- `mdnsctl browse _hap._tcp` sees the advertised service after `openhapd`
+  starts.
+- No `mdnsctl` process is a child of `openhapd`, and no `mdnsctl.log` is
+  created.
+- The TXT record changes after a pairing state change (`sf` flips).
+- The advertisement disappears within a few seconds of `openhapd` exiting, which
+  is the socket-close contract.
 
 ## Deliverables
 
-- `lib/FuguLib/Sandbox.pm`, `man/fugulib/Sandbox.3p`, `Makefile` `MAN3P` entry
-- `t/fugulib/sandbox.t`
-- Changes to `bin/openhapd` (preload block, pledge call)
-- `man/openhap/openhapd.8` paragraph
+- `lib/FuguLib/Imsg.pm`, `lib/FuguLib/MDNS.pm`
+- `man/fugulib/Imsg.3p`, `man/fugulib/MDNS.3p`, `Makefile` `MAN3P` entries
+- `t/fugulib/imsg.t`, `t/fugulib/mdns.t`
+- `t/conformance/mdns-imsg.t`, `t/conformance/mdns-control.t`
+- New integration assertions in `t/openhap/integration/`
+- Changes to `bin/openhapd`, `lib/OpenHAP/HAP.pm`, `man/openhap/openhapd.8`
+- Deleted: `lib/OpenHAP/MDNS.pm`, `lib/OpenHAP/MDNS.pod`, `t/openhap/mdns.t`
 
 ## Acceptance criteria
 
-- On OpenBSD, `openhapd` starts, pairs, serves characteristics, publishes mDNS,
-  and survives an MQTT broker restart — all under the pledge. The MQTT case
-  matters most: reconnection is the one code path that resolves names and loads
-  `Net::MQTT::Simple` after the pledge point, and it is the likeliest thing to
-  abort in production rather than in a test.
-- A full SRP pairing completes under the pledge, proving the `Math::BigInt::GMP`
-  preload works. Without it this aborts, and only at pairing time.
-- `t/fugulib/sandbox.t` proves a pledge violation aborts a child process on
-  OpenBSD, and proves the no-op contract elsewhere.
-- `make check` green on Linux and Darwin with behaviour byte-identical to
-  before.
-- `kdump`/`ktrace` of a running `openhapd` shows no `pledge` violation and no
-  `mmap` with `PROT_EXEC` after startup.
-- `mandoc -Tlint -W warning` clean.
+- `t/conformance/mdns-control.t` asserts the whole encoded `struct mdns_service`
+  against a literal and replays the spec's publish conversation byte-for-byte;
+  changing any offset constant makes it fail.
+- `make spec-coverage` reports non-zero coverage for `MDNS-Imsg` and
+  `MDNS-Control`, and exits zero — no stale citations.
+- `mdnsctl browse` in the VM sees the service, its TXT updates on pairing state
+  change, and it disappears when the daemon exits.
+- `openhapd` spawns no child process at all: `pgrep -P $(pgrep openhapd)` is
+  empty.
+- A missing or unreachable `/var/run/mdnsd.sock` logs a warning and leaves the
+  HAP server serving, exactly as a missing `mdnsctl` does today.
+- `make check` green on Linux (tests use `socketpair`/`AF_UNIX` and need no
+  mdnsd); `make integration` green on OpenBSD.
+- `mandoc -Tlint -W warning` clean for both new man pages.

--- a/plans/005-pledge-unveil/plan-2.md
+++ b/plans/005-pledge-unveil/plan-2.md
@@ -1,0 +1,130 @@
+# Phase 2 — `FuguLib::Sandbox` and pledge(2)
+
+Build the platform abstraction and apply the pledge. Depends on phase 1: while
+`openhapd` spawns `mdnsctl`, the promise set would need `proc exec` and the
+exercise would be close to pointless.
+
+## Tasks
+
+### 2.1 `FuguLib::Sandbox`
+
+One module, both mechanisms, three platforms. The whole point is that callers
+never write `if ($^O eq 'openbsd')`.
+
+```perl
+FuguLib::Sandbox->is_supported;                 # 1 on OpenBSD, '' elsewhere
+FuguLib::Sandbox->pledge(promises => $string);  # 1, or die
+FuguLib::Sandbox->unveil(paths => \@pairs);     # 1, or die
+FuguLib::Sandbox->unveil_lock;                  # 1, or die
+```
+
+- On OpenBSD, `OpenBSD::Pledge` and `OpenBSD::Unveil` are loaded at compile
+  time. They are base-system modules; failing to load them there means a broken
+  Perl, so that is fatal at `use` time rather than a runtime fallback to "no
+  protection".
+- Off OpenBSD every method is a no-op returning 1, and logs **once** at debug
+  (`'sandbox: %s is a no-op on %s'`). Once, not per call, so a daemon that
+  re-pledges does not flood the log; and at debug rather than silence so a test
+  reading logs can tell enforcement from emulation.
+- `pledge` and `unveil` failures `die` with the promise string or path and `$!`.
+  Fail closed: there is no `force => 0` and no warn-and-continue mode. A daemon
+  that cannot restrict itself must not start.
+- `unveil(paths => [[$path, $perms], ...])` applies pairs in order and reports
+  which pair failed. `$path` that does not exist is a failure, not a skip — a
+  typo'd path silently accepted is the failure mode that makes unveil useless.
+- `unveil_lock` calls `OpenBSD::Unveil::unveil()` with no arguments.
+- Keep it stateless: class methods, no object. It wraps two syscalls that are
+  themselves process-global.
+
+Ships with `man/fugulib/Sandbox.3p`, a `MAN3P` entry, and `t/fugulib/sandbox.t`.
+
+The test must be meaningful on both kinds of platform, which needs care:
+
+- Everywhere: `is_supported` agrees with `$^O`; a no-op platform returns 1 from
+  every method and does not die.
+- On OpenBSD only: fork a child, `pledge('stdio')` in it, have it attempt
+  `socket(AF_INET)`, and assert it dies of `SIGABRT` — pledge violations abort,
+  they do not return `EPERM`. Assert in the **child**, never the parent, or the
+  test process pledges itself and takes the rest of the suite down.
+- On OpenBSD only: a child that unveils `$tmpdir` read-only, locks, and then
+  fails to open a file outside it.
+- A bogus promise string dies rather than being accepted.
+
+Guard the OpenBSD-only cases with `plan skip_all` at the file level only if the
+whole file is OpenBSD-specific; here it is not, so guard per-subtest and make
+the skip message name the reason.
+
+### 2.2 Preload everything that would `dlopen` later
+
+`prot_exec` stays out of the promise set, so no shared object may be opened
+after the pledge. Two known offenders load lazily (see the design), and both are
+handled in `bin/openhapd` before pledging:
+
+- Explicitly `use`/`require` the XS runtime dependencies: `Crypt::Ed25519`,
+  `Crypt::Curve25519`, `Crypt::AuthEnc::ChaCha20Poly1305`,
+  `Crypt::KeyDerivation`, `Digest::SHA`, `JSON::XS`, `Net::MQTT::Simple`,
+  `Sys::Syslog`.
+- Force `Math::BigInt` to load its GMP backend by performing one modular
+  exponentiation. `Math::BigInt::GMP` is pulled in on first use, and first use
+  is otherwise during SRP at pairing time — long after the pledge.
+- Call `localtime` once so the zone file is cached.
+
+Put this in one clearly commented block — a `_preload` sub in `bin/openhapd` —
+with a comment saying _why_, because the next person to read it will otherwise
+delete it as redundant `use` statements. Note in the comment that adding an XS
+dependency means adding it here.
+
+### 2.3 Apply the pledge in `bin/openhapd`
+
+After the mDNS advertisement is established and before the signal handlers and
+`$hap->run()`:
+
+```
+stdio rpath wpath cpath fattr flock inet dns unix
+```
+
+Derivation is in the design; the code carries a comment per promise so a future
+reader can shrink the set safely. Also:
+
+- Both `-f`/foreground and daemon mode pledge identically. Foreground differs
+  only in where the log goes, which is already an open fd by then.
+- `-n`/`--check` exits at `bin/openhapd:34-37`, before any of this. Leave it
+  alone; a config check is not a long-running process.
+- Log at info that the pledge was applied, naming the promise set. On a no-op
+  platform, log nothing at info — the debug line from 2.1 is enough — so the
+  absence of that info line is itself a signal.
+
+### 2.4 Documentation
+
+- `man/fugulib/Sandbox.3p` is the API reference for the module (FuguLib is
+  documented in man3p, not in sidecars).
+- `man/openhap/openhapd.8`: state the promise set and that OpenBSD is the only
+  platform where it is enforced. The full SECURITY section lands in phase 4,
+  once unveil is in place; here, one accurate paragraph.
+- Do not touch `README.md`, `CLAUDE.md`, or `web/` — their claims become fully
+  true at the end of phase 3, and hedging them for one phase then unhedging them
+  is churn.
+
+## Deliverables
+
+- `lib/FuguLib/Sandbox.pm`, `man/fugulib/Sandbox.3p`, `Makefile` `MAN3P` entry
+- `t/fugulib/sandbox.t`
+- Changes to `bin/openhapd` (preload block, pledge call)
+- `man/openhap/openhapd.8` paragraph
+
+## Acceptance criteria
+
+- On OpenBSD, `openhapd` starts, pairs, serves characteristics, publishes mDNS,
+  and survives an MQTT broker restart — all under the pledge. The MQTT case
+  matters most: reconnection is the one code path that resolves names and loads
+  `Net::MQTT::Simple` after the pledge point, and it is the likeliest thing to
+  abort in production rather than in a test.
+- A full SRP pairing completes under the pledge, proving the `Math::BigInt::GMP`
+  preload works. Without it this aborts, and only at pairing time.
+- `t/fugulib/sandbox.t` proves a pledge violation aborts a child process on
+  OpenBSD, and proves the no-op contract elsewhere.
+- `make check` green on Linux and Darwin with behaviour byte-identical to
+  before.
+- `kdump`/`ktrace` of a running `openhapd` shows no `pledge` violation and no
+  `mmap` with `PROT_EXEC` after startup.
+- `mandoc -Tlint -W warning` clean.

--- a/plans/005-pledge-unveil/plan-3.md
+++ b/plans/005-pledge-unveil/plan-3.md
@@ -91,7 +91,7 @@ reader can shrink the set safely. Also:
 - `-n`/`--check` exits at `bin/openhapd:34-37`, before any of this. Leave it
   alone; a config check is not a long-running process.
 - Log at info that the pledge was applied, naming the promise set. On a no-op
-  platform, log nothing at info — the debug line from 2.1 is enough — so the
+  platform, log nothing at info — the debug line from 3.1 is enough — so the
   absence of that info line is itself a signal.
 
 ### 3.4 Documentation

--- a/plans/005-pledge-unveil/plan-3.md
+++ b/plans/005-pledge-unveil/plan-3.md
@@ -1,108 +1,130 @@
-# Phase 3 — unveil(2)
+# Phase 3 — `FuguLib::Sandbox` and pledge(2)
 
-Restrict the filesystem view. Depends on phase 2 for `FuguLib::Sandbox`, which
-already carries the `unveil` and `unveil_lock` API; this phase only builds the
-path inventory and calls them. At the end of this phase the claims in
-`README.md` and `web/index.body.html` are true.
+Build the platform abstraction and apply the pledge. Depends on phase 2: while
+`openhapd` spawns `mdnsctl`, the promise set would need `proc exec` and the
+exercise would be close to pointless.
 
 ## Tasks
 
-### 3.1 The path inventory
+### 3.1 `FuguLib::Sandbox`
 
-Assembled in `bin/openhapd` from configuration, not hardcoded — `$config_file`,
-`$db_path` and the log path are all variable.
+One module, both mechanisms, three platforms. The whole point is that callers
+never write `if ($^O eq 'openbsd')`.
 
-| path                    | perms | needed for                            |
-| ----------------------- | ----- | ------------------------------------- |
-| `$config_file`          | `r`   | re-read after a future SIGHUP reload  |
-| `$db_path`              | `rwc` | pairings, device state (`Storage.pm`) |
-| `/var/log/openhapd.log` | `w`   | daemon-mode log (`Daemon::daemonize`) |
-| `/var/run/mdnsd.sock`   | `rw`  | `connect(2)` needs `w` on the path    |
-| `/dev/urandom`          | `r`   | `Crypto.pm:35`                        |
-| `/etc/resolv.conf`      | `r`   | resolver, on MQTT reconnect           |
-| `/etc/hosts`            | `r`   | resolver, on MQTT reconnect           |
-| each `@INC` directory   | `r`   | lazy `require` of pure-Perl modules   |
+```perl
+FuguLib::Sandbox->is_supported;                 # 1 on OpenBSD, '' elsewhere
+FuguLib::Sandbox->pledge(promises => $string);  # 1, or die
+FuguLib::Sandbox->unveil(paths => \@pairs);     # 1, or die
+FuguLib::Sandbox->unveil_lock;                  # 1, or die
+```
 
-Notes that matter:
+- On OpenBSD, `OpenBSD::Pledge` and `OpenBSD::Unveil` are loaded at compile
+  time. They are base-system modules; failing to load them there means a broken
+  Perl, so that is fatal at `use` time rather than a runtime fallback to "no
+  protection".
+- Off OpenBSD every method is a no-op returning 1, and logs **once** at debug
+  (`'sandbox: %s is a no-op on %s'`). Once, not per call, so a daemon that
+  re-pledges does not flood the log; and at debug rather than silence so a test
+  reading logs can tell enforcement from emulation.
+- `pledge` and `unveil` failures `die` with the promise string or path and `$!`.
+  Fail closed: there is no `force => 0` and no warn-and-continue mode. A daemon
+  that cannot restrict itself must not start.
+- `unveil(paths => [[$path, $perms], ...])` applies pairs in order and reports
+  which pair failed. `$path` that does not exist is a failure, not a skip — a
+  typo'd path silently accepted is the failure mode that makes unveil useless.
+- `unveil_lock` calls `OpenBSD::Unveil::unveil()` with no arguments.
+- Keep it stateless: class methods, no object. It wraps two syscalls that are
+  themselves process-global.
 
-- **`@INC` read-only is a deliberate choice**, and the design says why: Perl's
-  lazy loading makes "prove nothing loads late" a claim no test can hold over
-  time, while unveiling the library tree read-only is one line and cannot
-  regress. The comment in the code must say this, or someone will "tighten" it
-  and break pairing three months later.
-- Skip `@INC` entries that are not directories (`.`, code refs from any future
-  loader hooks) rather than failing on them.
-- `/var/log/openhapd.log` is already an open fd by unveil time, so this entry
-  exists for log rotation and reopen, not for the current write path. Keep it —
-  the cost is one line and the alternative is a surprise later.
-- `/etc/resolv.conf` and `/etc/hosts` are only needed when `mqtt_host` is a
-  name. Unveil them unconditionally: conditionally-restricted is harder to
-  reason about than uniformly-restricted, and neither file is sensitive to this
-  daemon.
-- No `x` anywhere. Phase 1 removed the only `exec`, and an unveil that grants
-  `x` while pledge withholds `exec` is a confusing contradiction in the source.
+Ships with `man/fugulib/Sandbox.3p`, a `MAN3P` entry, and `t/fugulib/sandbox.t`.
 
-### 3.2 Call site and ordering
+The test must be meaningful on both kinds of platform, which needs care:
 
-In `bin/openhapd`, between the mDNS advertisement and the pledge from phase 2:
+- Everywhere: `is_supported` agrees with `$^O`; a no-op platform returns 1 from
+  every method and does not die.
+- On OpenBSD only: fork a child, `pledge('stdio')` in it, have it attempt
+  `socket(AF_INET)`, and assert it dies of `SIGABRT` — pledge violations abort,
+  they do not return `EPERM`. Assert in the **child**, never the parent, or the
+  test process pledges itself and takes the rest of the suite down.
+- On OpenBSD only: a child that unveils `$tmpdir` read-only, locks, and then
+  fails to open a file outside it.
+- A bogus promise string dies rather than being accepted.
 
-1. Preload (phase 2, task 2.2) — before unveil, because it reads from `@INC` and
-   `dlopen`s.
-2. `FuguLib::Sandbox->unveil(paths => \@paths)`.
-3. `FuguLib::Sandbox->unveil_lock`.
-4. `FuguLib::Sandbox->pledge(promises => ...)`.
+Guard the OpenBSD-only cases with `plan skip_all` at the file level only if the
+whole file is OpenBSD-specific; here it is not, so guard per-subtest and make
+the skip message name the reason.
 
-All four after privdrop. Unveil only removes reachability — it grants nothing —
-so applying it as `_openhap` is correct, and it keeps the root-only `chown` loop
-at `bin/openhapd:118-137` untouched. `Storage` has already run `make_path` on
-`$db_path` (`Storage.pm:14`) via `HAP->new`, so the directory exists by the time
-we unveil it; a `$db_path` that still does not exist is a hard failure, and
-correctly so.
+### 3.2 Preload everything that would `dlopen` later
 
-Add a short comment block naming the four steps and their order, because the
-ordering is load-bearing and not locally obvious.
+`prot_exec` stays out of the promise set, so no shared object may be opened
+after the pledge. Two known offenders load lazily (see the design), and both are
+handled in `bin/openhapd` before pledging:
 
-### 3.3 Tests
+- Explicitly `use`/`require` the XS runtime dependencies: `Crypt::Ed25519`,
+  `Crypt::Curve25519`, `Crypt::AuthEnc::ChaCha20Poly1305`,
+  `Crypt::KeyDerivation`, `Digest::SHA`, `JSON::XS`, `Net::MQTT::Simple`,
+  `Sys::Syslog`.
+- Force `Math::BigInt` to load its GMP backend by performing one modular
+  exponentiation. `Math::BigInt::GMP` is pulled in on first use, and first use
+  is otherwise during SRP at pairing time — long after the pledge.
+- Call `localtime` once so the zone file is cached.
 
-`t/openhap/openhapd.t`-style coverage cannot exercise unveil without running the
-daemon, so split the work:
+Put this in one clearly commented block — a `_preload` sub in `bin/openhapd` —
+with a comment saying _why_, because the next person to read it will otherwise
+delete it as redundant `use` statements. Note in the comment that adding an XS
+dependency means adding it here.
 
-- `t/fugulib/sandbox.t` (extended from phase 2): on OpenBSD, a forked child
-  unveils a temp directory `r`, locks, then fails to read a file outside it and
-  succeeds inside it. Also assert that unveiling a nonexistent path dies.
-- A unit test for the inventory builder: factor path assembly into a small
-  testable sub (or `FuguLib::Sandbox` helper) that takes the config values and
-  returns the pair list, so the `@INC` filtering and the config-derived paths
-  can be asserted on any platform without unveiling anything.
-- Integration (phase 4 expands this): the daemon runs, pairs, and serves with
-  unveil active.
+### 3.3 Apply the pledge in `bin/openhapd`
+
+After the mDNS advertisement is established and before the signal handlers and
+`$hap->run()`:
+
+```
+stdio rpath wpath cpath fattr flock inet dns unix
+```
+
+Derivation is in the design; the code carries a comment per promise so a future
+reader can shrink the set safely. Also:
+
+- Both `-f`/foreground and daemon mode pledge identically. Foreground differs
+  only in where the log goes, which is already an open fd by then.
+- `-n`/`--check` exits at `bin/openhapd:34-37`, before any of this. Leave it
+  alone; a config check is not a long-running process.
+- Log at info that the pledge was applied, naming the promise set. On a no-op
+  platform, log nothing at info — the debug line from 2.1 is enough — so the
+  absence of that info line is itself a signal.
 
 ### 3.4 Documentation
 
-- `man/openhap/openhapd.8`: list the unveiled paths in the FILES section, and
-  note that `openhapd` cannot read anything else — an operator debugging "why
-  can't it read my file" needs this to be findable.
-- `man/fugulib/Sandbox.3p`: document `unveil`'s die-on-missing-path behaviour
-  and the lock semantics.
-- `README.md`, `CLAUDE.md`, `web/`: unchanged. As of this phase they are
-  accurate.
+- `man/fugulib/Sandbox.3p` is the API reference for the module (FuguLib is
+  documented in man3p, not in sidecars).
+- `man/openhap/openhapd.8`: state the promise set and that OpenBSD is the only
+  platform where it is enforced. The full SECURITY section lands in phase 5,
+  once unveil is in place; here, one accurate paragraph.
+- Do not touch `README.md`, `CLAUDE.md`, or `web/` — their claims become fully
+  true at the end of phase 4, and hedging them for one phase then unhedging them
+  is churn.
 
 ## Deliverables
 
-- Changes to `bin/openhapd` (inventory, unveil, lock, ordering comment)
-- Possibly a small helper in `lib/FuguLib/Sandbox.pm` for `@INC` filtering
-- Extended `t/fugulib/sandbox.t`, new inventory unit test
-- `man/openhap/openhapd.8` FILES section, `man/fugulib/Sandbox.3p` updates
+- `lib/FuguLib/Sandbox.pm`, `man/fugulib/Sandbox.3p`, `Makefile` `MAN3P` entry
+- `t/fugulib/sandbox.t`
+- Changes to `bin/openhapd` (preload block, pledge call)
+- `man/openhap/openhapd.8` paragraph
 
 ## Acceptance criteria
 
-- On OpenBSD, `openhapd` completes a full pairing, serves characteristic reads
-  and writes, publishes and updates mDNS, and reconnects to a restarted MQTT
-  broker, all with unveil locked. The MQTT restart is the sharpest test: it is
-  the path that touches the resolver files and lazily `require`s
-  `Net::MQTT::Simple`.
-- A file outside the unveiled set is unreadable by the running daemon, verified
-  from inside the VM rather than asserted in prose.
-- Unveiling a nonexistent path is fatal at startup with the path in the message.
-- `make check` green on Linux and Darwin, behaviour unchanged.
+- On OpenBSD, `openhapd` starts, pairs, serves characteristics, publishes mDNS,
+  and survives an MQTT broker restart — all under the pledge. The MQTT case
+  matters most: reconnection is the one code path that resolves names and loads
+  `Net::MQTT::Simple` after the pledge point, and it is the likeliest thing to
+  abort in production rather than in a test.
+- A full SRP pairing completes under the pledge, proving the `Math::BigInt::GMP`
+  preload works. Without it this aborts, and only at pairing time.
+- `t/fugulib/sandbox.t` proves a pledge violation aborts a child process on
+  OpenBSD, and proves the no-op contract elsewhere.
+- `make check` green on Linux and Darwin with behaviour byte-identical to
+  before.
+- `kdump`/`ktrace` of a running `openhapd` shows no `pledge` violation and no
+  `mmap` with `PROT_EXEC` after startup.
 - `mandoc -Tlint -W warning` clean.

--- a/plans/005-pledge-unveil/plan-3.md
+++ b/plans/005-pledge-unveil/plan-3.md
@@ -1,0 +1,108 @@
+# Phase 3 — unveil(2)
+
+Restrict the filesystem view. Depends on phase 2 for `FuguLib::Sandbox`, which
+already carries the `unveil` and `unveil_lock` API; this phase only builds the
+path inventory and calls them. At the end of this phase the claims in
+`README.md` and `web/index.body.html` are true.
+
+## Tasks
+
+### 3.1 The path inventory
+
+Assembled in `bin/openhapd` from configuration, not hardcoded — `$config_file`,
+`$db_path` and the log path are all variable.
+
+| path                    | perms | needed for                            |
+| ----------------------- | ----- | ------------------------------------- |
+| `$config_file`          | `r`   | re-read after a future SIGHUP reload  |
+| `$db_path`              | `rwc` | pairings, device state (`Storage.pm`) |
+| `/var/log/openhapd.log` | `w`   | daemon-mode log (`Daemon::daemonize`) |
+| `/var/run/mdnsd.sock`   | `rw`  | `connect(2)` needs `w` on the path    |
+| `/dev/urandom`          | `r`   | `Crypto.pm:35`                        |
+| `/etc/resolv.conf`      | `r`   | resolver, on MQTT reconnect           |
+| `/etc/hosts`            | `r`   | resolver, on MQTT reconnect           |
+| each `@INC` directory   | `r`   | lazy `require` of pure-Perl modules   |
+
+Notes that matter:
+
+- **`@INC` read-only is a deliberate choice**, and the design says why: Perl's
+  lazy loading makes "prove nothing loads late" a claim no test can hold over
+  time, while unveiling the library tree read-only is one line and cannot
+  regress. The comment in the code must say this, or someone will "tighten" it
+  and break pairing three months later.
+- Skip `@INC` entries that are not directories (`.`, code refs from any future
+  loader hooks) rather than failing on them.
+- `/var/log/openhapd.log` is already an open fd by unveil time, so this entry
+  exists for log rotation and reopen, not for the current write path. Keep it —
+  the cost is one line and the alternative is a surprise later.
+- `/etc/resolv.conf` and `/etc/hosts` are only needed when `mqtt_host` is a
+  name. Unveil them unconditionally: conditionally-restricted is harder to
+  reason about than uniformly-restricted, and neither file is sensitive to this
+  daemon.
+- No `x` anywhere. Phase 1 removed the only `exec`, and an unveil that grants
+  `x` while pledge withholds `exec` is a confusing contradiction in the source.
+
+### 3.2 Call site and ordering
+
+In `bin/openhapd`, between the mDNS advertisement and the pledge from phase 2:
+
+1. Preload (phase 2, task 2.2) — before unveil, because it reads from `@INC` and
+   `dlopen`s.
+2. `FuguLib::Sandbox->unveil(paths => \@paths)`.
+3. `FuguLib::Sandbox->unveil_lock`.
+4. `FuguLib::Sandbox->pledge(promises => ...)`.
+
+All four after privdrop. Unveil only removes reachability — it grants nothing —
+so applying it as `_openhap` is correct, and it keeps the root-only `chown` loop
+at `bin/openhapd:118-137` untouched. `Storage` has already run `make_path` on
+`$db_path` (`Storage.pm:14`) via `HAP->new`, so the directory exists by the time
+we unveil it; a `$db_path` that still does not exist is a hard failure, and
+correctly so.
+
+Add a short comment block naming the four steps and their order, because the
+ordering is load-bearing and not locally obvious.
+
+### 3.3 Tests
+
+`t/openhap/openhapd.t`-style coverage cannot exercise unveil without running the
+daemon, so split the work:
+
+- `t/fugulib/sandbox.t` (extended from phase 2): on OpenBSD, a forked child
+  unveils a temp directory `r`, locks, then fails to read a file outside it and
+  succeeds inside it. Also assert that unveiling a nonexistent path dies.
+- A unit test for the inventory builder: factor path assembly into a small
+  testable sub (or `FuguLib::Sandbox` helper) that takes the config values and
+  returns the pair list, so the `@INC` filtering and the config-derived paths
+  can be asserted on any platform without unveiling anything.
+- Integration (phase 4 expands this): the daemon runs, pairs, and serves with
+  unveil active.
+
+### 3.4 Documentation
+
+- `man/openhap/openhapd.8`: list the unveiled paths in the FILES section, and
+  note that `openhapd` cannot read anything else — an operator debugging "why
+  can't it read my file" needs this to be findable.
+- `man/fugulib/Sandbox.3p`: document `unveil`'s die-on-missing-path behaviour
+  and the lock semantics.
+- `README.md`, `CLAUDE.md`, `web/`: unchanged. As of this phase they are
+  accurate.
+
+## Deliverables
+
+- Changes to `bin/openhapd` (inventory, unveil, lock, ordering comment)
+- Possibly a small helper in `lib/FuguLib/Sandbox.pm` for `@INC` filtering
+- Extended `t/fugulib/sandbox.t`, new inventory unit test
+- `man/openhap/openhapd.8` FILES section, `man/fugulib/Sandbox.3p` updates
+
+## Acceptance criteria
+
+- On OpenBSD, `openhapd` completes a full pairing, serves characteristic reads
+  and writes, publishes and updates mDNS, and reconnects to a restarted MQTT
+  broker, all with unveil locked. The MQTT restart is the sharpest test: it is
+  the path that touches the resolver files and lazily `require`s
+  `Net::MQTT::Simple`.
+- A file outside the unveiled set is unreadable by the running daemon, verified
+  from inside the VM rather than asserted in prose.
+- Unveiling a nonexistent path is fatal at startup with the path in the message.
+- `make check` green on Linux and Darwin, behaviour unchanged.
+- `mandoc -Tlint -W warning` clean.

--- a/plans/005-pledge-unveil/plan-4.md
+++ b/plans/005-pledge-unveil/plan-4.md
@@ -1,0 +1,111 @@
+# Phase 4 — Proof and operability
+
+Phases 1–3 make the daemon restricted. This phase makes the restriction
+_provable_ and _operable_: tests that fail if either mechanism silently stops
+working, and documentation an operator can act on when it bites. Depends on
+phases 2 and 3.
+
+The motivating risk is specific. `FuguLib::Sandbox` is a no-op on Linux and
+Darwin by design, which is exactly the shape of a bug that hides: if a refactor
+makes `is_supported` return false on OpenBSD, or a `pledge` call is dropped from
+`bin/openhapd`, every existing test still passes. Nothing in phases 1–3 catches
+that. Something has to.
+
+## Tasks
+
+### 4.1 Negative integration tests
+
+In `t/openhap/integration/` (which never skips — see
+`t/openhap/integration/CLAUDE.md`), inside the OpenBSD VM:
+
+- **Pledge is really on.** Start `openhapd`, then confirm from outside that the
+  process is pledged. `ps -o pledge` is not available; the reliable signal is
+  that a pledge violation aborts. Two workable approaches, in order of
+  preference:
+  1. A test-only helper invocation that pledges with the production promise set
+     and then deliberately violates it, asserting `SIGABRT`. This proves the
+     promise string in the daemon is a real pledge, not an empty string.
+  2. `ktrace -p $(pgrep openhapd)` during a normal pairing and `kdump` asserting
+     no `pledge` violations — a regression net for promise-set drift, since a
+     missing promise shows up here before it shows up in production.
+- **Unveil is really on.** Assert the daemon cannot read a file outside its
+  unveiled set. Create `/tmp/openhap-unveil-probe` and drive the daemon down a
+  path that would read an operator-supplied path; if no such path exists, use
+  the helper from the pledge test to unveil the production inventory and then
+  probe.
+- **No child processes.** `pgrep -P $(pgrep openhapd)` is empty. This is phase
+  1's contract, and it is what keeps `proc exec` out of the promise set; without
+  a test it can regress the moment anyone adds a `system()` call.
+- **Startup fails closed.** With a deliberately bogus promise string or a
+  nonexistent unveil path, `openhapd` exits nonzero and logs why, rather than
+  starting unrestricted. Drive this through a test-only flag or environment
+  override — not by editing the production string — and make sure the override
+  cannot loosen anything, only break startup.
+
+Each of these must fail when the corresponding call is commented out of
+`bin/openhapd`. Verify that by actually commenting it out once during
+development; a test that cannot fail is not evidence.
+
+### 4.2 `openhapd.8` SECURITY section
+
+One place an operator can read to understand the daemon's posture. Contents:
+
+- The promise set, with a one-line gloss on why each promise is present, and the
+  explicit statement that `proc`, `exec`, and `prot_exec` are absent.
+- The unveiled paths and their permissions (cross-referencing FILES from phase
+  3).
+- The privilege model: starts as root, `chown`s `$db_path`, drops to `_openhap`,
+  requires `wheel` membership for `/var/run/mdnsd.sock`, then unveils and
+  pledges. Say plainly that pledge and unveil are applied _after_ the privilege
+  drop and what that does and does not buy.
+- OpenBSD-only enforcement. Linux and Darwin are development platforms and the
+  restrictions are no-ops there. An operator who reads only the README should
+  not be able to conclude that a Linux deployment is hardened.
+- What a violation looks like in practice: the process aborts, `dmesg` and
+  `/var/log/messages` carry a `pledge` line naming the syscall. This is the
+  single most useful paragraph in the section — it turns "the daemon died" into
+  a diagnosis.
+
+### 4.3 Close out `TODO.md`
+
+- Mark the pledge and unveil items (`TODO.md:10-20`) done, in the style the file
+  already uses for completed entries — a short "Implemented:" summary with the
+  files, as at `TODO.md:48-53`. Do not just tick the box; the file's value is
+  that finished entries say what landed.
+- The `Privilege separation` item (`TODO.md:489`) stays open, but update it: a
+  pledged monolith changes what separation would buy, and the entry should say
+  so rather than reading as though nothing has happened.
+- Add a `hapctl` pledge item. It is now cheap — `FuguLib::Sandbox` exists, and
+  `hapctl` reads config and state and prints, so `stdio rpath` plus a handful of
+  unveiled paths covers it — and leaving it undone while `openhapd` is pledged
+  is the kind of asymmetry that goes unnoticed.
+- Add an item for re-establishing the mDNS advertisement after an `mdnsd`
+  restart. Phase 1 documents this as parity with the old `mdnsctl` behaviour,
+  which makes it a known limitation rather than a bug, but "known" should mean
+  "recorded".
+
+### 4.4 Verify the aspirational docs are now accurate
+
+No rewriting — checking. `README.md:16`, `CLAUDE.md:7`, `CLAUDE.md:103`, and
+`web/index.body.html:19-20` all claim pledge/unveil support. Read each one
+against what shipped and confirm it is now true rather than merely plausible. If
+any claim overreaches — for instance implying Linux is hardened too — fix that
+specific sentence, and only that one.
+
+## Deliverables
+
+- New/extended tests in `t/openhap/integration/`
+- `man/openhap/openhapd.8` SECURITY section
+- `TODO.md` updates
+- Any narrow corrections to `README.md`, `CLAUDE.md`, `web/index.body.html`
+
+## Acceptance criteria
+
+- Every test in 4.1 provably fails when the corresponding `bin/openhapd` call is
+  removed — demonstrated, not assumed.
+- `make integration` green on OpenBSD; `make check` green on Linux and Darwin.
+- `openhapd.8` renders clean under `mandoc -Tlint -W warning` and answers,
+  without reference to the source: what is pledged, what is unveiled, what
+  happens on violation, and where enforcement applies.
+- `TODO.md` has no remaining claim that pledge or unveil is unimplemented.
+- `make spec-coverage` unaffected (no spec citations change in this plan).

--- a/plans/005-pledge-unveil/plan-4.md
+++ b/plans/005-pledge-unveil/plan-4.md
@@ -1,111 +1,108 @@
-# Phase 4 — Proof and operability
+# Phase 4 — unveil(2)
 
-Phases 1–3 make the daemon restricted. This phase makes the restriction
-_provable_ and _operable_: tests that fail if either mechanism silently stops
-working, and documentation an operator can act on when it bites. Depends on
-phases 2 and 3.
-
-The motivating risk is specific. `FuguLib::Sandbox` is a no-op on Linux and
-Darwin by design, which is exactly the shape of a bug that hides: if a refactor
-makes `is_supported` return false on OpenBSD, or a `pledge` call is dropped from
-`bin/openhapd`, every existing test still passes. Nothing in phases 1–3 catches
-that. Something has to.
+Restrict the filesystem view. Depends on phase 3 for `FuguLib::Sandbox`, which
+already carries the `unveil` and `unveil_lock` API; this phase only builds the
+path inventory and calls them. At the end of this phase the claims in
+`README.md` and `web/index.body.html` are true.
 
 ## Tasks
 
-### 4.1 Negative integration tests
+### 4.1 The path inventory
 
-In `t/openhap/integration/` (which never skips — see
-`t/openhap/integration/CLAUDE.md`), inside the OpenBSD VM:
+Assembled in `bin/openhapd` from configuration, not hardcoded — `$config_file`,
+`$db_path` and the log path are all variable.
 
-- **Pledge is really on.** Start `openhapd`, then confirm from outside that the
-  process is pledged. `ps -o pledge` is not available; the reliable signal is
-  that a pledge violation aborts. Two workable approaches, in order of
-  preference:
-  1. A test-only helper invocation that pledges with the production promise set
-     and then deliberately violates it, asserting `SIGABRT`. This proves the
-     promise string in the daemon is a real pledge, not an empty string.
-  2. `ktrace -p $(pgrep openhapd)` during a normal pairing and `kdump` asserting
-     no `pledge` violations — a regression net for promise-set drift, since a
-     missing promise shows up here before it shows up in production.
-- **Unveil is really on.** Assert the daemon cannot read a file outside its
-  unveiled set. Create `/tmp/openhap-unveil-probe` and drive the daemon down a
-  path that would read an operator-supplied path; if no such path exists, use
-  the helper from the pledge test to unveil the production inventory and then
-  probe.
-- **No child processes.** `pgrep -P $(pgrep openhapd)` is empty. This is phase
-  1's contract, and it is what keeps `proc exec` out of the promise set; without
-  a test it can regress the moment anyone adds a `system()` call.
-- **Startup fails closed.** With a deliberately bogus promise string or a
-  nonexistent unveil path, `openhapd` exits nonzero and logs why, rather than
-  starting unrestricted. Drive this through a test-only flag or environment
-  override — not by editing the production string — and make sure the override
-  cannot loosen anything, only break startup.
+| path                    | perms | needed for                            |
+| ----------------------- | ----- | ------------------------------------- |
+| `$config_file`          | `r`   | re-read after a future SIGHUP reload  |
+| `$db_path`              | `rwc` | pairings, device state (`Storage.pm`) |
+| `/var/log/openhapd.log` | `w`   | daemon-mode log (`Daemon::daemonize`) |
+| `/var/run/mdnsd.sock`   | `rw`  | `connect(2)` needs `w` on the path    |
+| `/dev/urandom`          | `r`   | `Crypto.pm:35`                        |
+| `/etc/resolv.conf`      | `r`   | resolver, on MQTT reconnect           |
+| `/etc/hosts`            | `r`   | resolver, on MQTT reconnect           |
+| each `@INC` directory   | `r`   | lazy `require` of pure-Perl modules   |
 
-Each of these must fail when the corresponding call is commented out of
-`bin/openhapd`. Verify that by actually commenting it out once during
-development; a test that cannot fail is not evidence.
+Notes that matter:
 
-### 4.2 `openhapd.8` SECURITY section
+- **`@INC` read-only is a deliberate choice**, and the design says why: Perl's
+  lazy loading makes "prove nothing loads late" a claim no test can hold over
+  time, while unveiling the library tree read-only is one line and cannot
+  regress. The comment in the code must say this, or someone will "tighten" it
+  and break pairing three months later.
+- Skip `@INC` entries that are not directories (`.`, code refs from any future
+  loader hooks) rather than failing on them.
+- `/var/log/openhapd.log` is already an open fd by unveil time, so this entry
+  exists for log rotation and reopen, not for the current write path. Keep it —
+  the cost is one line and the alternative is a surprise later.
+- `/etc/resolv.conf` and `/etc/hosts` are only needed when `mqtt_host` is a
+  name. Unveil them unconditionally: conditionally-restricted is harder to
+  reason about than uniformly-restricted, and neither file is sensitive to this
+  daemon.
+- No `x` anywhere. Phase 2 removed the only `exec`, and an unveil that grants
+  `x` while pledge withholds `exec` is a confusing contradiction in the source.
 
-One place an operator can read to understand the daemon's posture. Contents:
+### 4.2 Call site and ordering
 
-- The promise set, with a one-line gloss on why each promise is present, and the
-  explicit statement that `proc`, `exec`, and `prot_exec` are absent.
-- The unveiled paths and their permissions (cross-referencing FILES from phase
-  3).
-- The privilege model: starts as root, `chown`s `$db_path`, drops to `_openhap`,
-  requires `wheel` membership for `/var/run/mdnsd.sock`, then unveils and
-  pledges. Say plainly that pledge and unveil are applied _after_ the privilege
-  drop and what that does and does not buy.
-- OpenBSD-only enforcement. Linux and Darwin are development platforms and the
-  restrictions are no-ops there. An operator who reads only the README should
-  not be able to conclude that a Linux deployment is hardened.
-- What a violation looks like in practice: the process aborts, `dmesg` and
-  `/var/log/messages` carry a `pledge` line naming the syscall. This is the
-  single most useful paragraph in the section — it turns "the daemon died" into
-  a diagnosis.
+In `bin/openhapd`, between the mDNS advertisement and the pledge from phase 3:
 
-### 4.3 Close out `TODO.md`
+1. Preload (phase 3, task 3.2) — before unveil, because it reads from `@INC` and
+   `dlopen`s.
+2. `FuguLib::Sandbox->unveil(paths => \@paths)`.
+3. `FuguLib::Sandbox->unveil_lock`.
+4. `FuguLib::Sandbox->pledge(promises => ...)`.
 
-- Mark the pledge and unveil items (`TODO.md:10-20`) done, in the style the file
-  already uses for completed entries — a short "Implemented:" summary with the
-  files, as at `TODO.md:48-53`. Do not just tick the box; the file's value is
-  that finished entries say what landed.
-- The `Privilege separation` item (`TODO.md:489`) stays open, but update it: a
-  pledged monolith changes what separation would buy, and the entry should say
-  so rather than reading as though nothing has happened.
-- Add a `hapctl` pledge item. It is now cheap — `FuguLib::Sandbox` exists, and
-  `hapctl` reads config and state and prints, so `stdio rpath` plus a handful of
-  unveiled paths covers it — and leaving it undone while `openhapd` is pledged
-  is the kind of asymmetry that goes unnoticed.
-- Add an item for re-establishing the mDNS advertisement after an `mdnsd`
-  restart. Phase 1 documents this as parity with the old `mdnsctl` behaviour,
-  which makes it a known limitation rather than a bug, but "known" should mean
-  "recorded".
+All four after privdrop. Unveil only removes reachability — it grants nothing —
+so applying it as `_openhap` is correct, and it keeps the root-only `chown` loop
+at `bin/openhapd:118-137` untouched. `Storage` has already run `make_path` on
+`$db_path` (`Storage.pm:14`) via `HAP->new`, so the directory exists by the time
+we unveil it; a `$db_path` that still does not exist is a hard failure, and
+correctly so.
 
-### 4.4 Verify the aspirational docs are now accurate
+Add a short comment block naming the four steps and their order, because the
+ordering is load-bearing and not locally obvious.
 
-No rewriting — checking. `README.md:16`, `CLAUDE.md:7`, `CLAUDE.md:103`, and
-`web/index.body.html:19-20` all claim pledge/unveil support. Read each one
-against what shipped and confirm it is now true rather than merely plausible. If
-any claim overreaches — for instance implying Linux is hardened too — fix that
-specific sentence, and only that one.
+### 4.3 Tests
+
+`t/openhap/openhapd.t`-style coverage cannot exercise unveil without running the
+daemon, so split the work:
+
+- `t/fugulib/sandbox.t` (extended from phase 3): on OpenBSD, a forked child
+  unveils a temp directory `r`, locks, then fails to read a file outside it and
+  succeeds inside it. Also assert that unveiling a nonexistent path dies.
+- A unit test for the inventory builder: factor path assembly into a small
+  testable sub (or `FuguLib::Sandbox` helper) that takes the config values and
+  returns the pair list, so the `@INC` filtering and the config-derived paths
+  can be asserted on any platform without unveiling anything.
+- Integration (phase 5 expands this): the daemon runs, pairs, and serves with
+  unveil active.
+
+### 4.4 Documentation
+
+- `man/openhap/openhapd.8`: list the unveiled paths in the FILES section, and
+  note that `openhapd` cannot read anything else — an operator debugging "why
+  can't it read my file" needs this to be findable.
+- `man/fugulib/Sandbox.3p`: document `unveil`'s die-on-missing-path behaviour
+  and the lock semantics.
+- `README.md`, `CLAUDE.md`, `web/`: unchanged. As of this phase they are
+  accurate.
 
 ## Deliverables
 
-- New/extended tests in `t/openhap/integration/`
-- `man/openhap/openhapd.8` SECURITY section
-- `TODO.md` updates
-- Any narrow corrections to `README.md`, `CLAUDE.md`, `web/index.body.html`
+- Changes to `bin/openhapd` (inventory, unveil, lock, ordering comment)
+- Possibly a small helper in `lib/FuguLib/Sandbox.pm` for `@INC` filtering
+- Extended `t/fugulib/sandbox.t`, new inventory unit test
+- `man/openhap/openhapd.8` FILES section, `man/fugulib/Sandbox.3p` updates
 
 ## Acceptance criteria
 
-- Every test in 4.1 provably fails when the corresponding `bin/openhapd` call is
-  removed — demonstrated, not assumed.
-- `make integration` green on OpenBSD; `make check` green on Linux and Darwin.
-- `openhapd.8` renders clean under `mandoc -Tlint -W warning` and answers,
-  without reference to the source: what is pledged, what is unveiled, what
-  happens on violation, and where enforcement applies.
-- `TODO.md` has no remaining claim that pledge or unveil is unimplemented.
-- `make spec-coverage` unaffected (no spec citations change in this plan).
+- On OpenBSD, `openhapd` completes a full pairing, serves characteristic reads
+  and writes, publishes and updates mDNS, and reconnects to a restarted MQTT
+  broker, all with unveil locked. The MQTT restart is the sharpest test: it is
+  the path that touches the resolver files and lazily `require`s
+  `Net::MQTT::Simple`.
+- A file outside the unveiled set is unreadable by the running daemon, verified
+  from inside the VM rather than asserted in prose.
+- Unveiling a nonexistent path is fatal at startup with the path in the message.
+- `make check` green on Linux and Darwin, behaviour unchanged.
+- `mandoc -Tlint -W warning` clean.

--- a/plans/005-pledge-unveil/plan-5.md
+++ b/plans/005-pledge-unveil/plan-5.md
@@ -1,0 +1,119 @@
+# Phase 5 — Proof and operability
+
+Phases 1–4 make the daemon restricted. This phase makes the restriction
+_provable_ and _operable_: tests that fail if either mechanism silently stops
+working, and documentation an operator can act on when it bites. Depends on
+phases 3 and 4.
+
+The motivating risk is specific. `FuguLib::Sandbox` is a no-op on Linux and
+Darwin by design, which is exactly the shape of a bug that hides: if a refactor
+makes `is_supported` return false on OpenBSD, or a `pledge` call is dropped from
+`bin/openhapd`, every existing test still passes. Nothing in phases 1–4 catches
+that. Something has to.
+
+## Tasks
+
+### 5.1 Negative integration tests
+
+In `t/openhap/integration/` (which never skips — see
+`t/openhap/integration/CLAUDE.md`), inside the OpenBSD VM:
+
+- **Pledge is really on.** Start `openhapd`, then confirm from outside that the
+  process is pledged. `ps -o pledge` is not available; the reliable signal is
+  that a pledge violation aborts. Two workable approaches, in order of
+  preference:
+  1. A test-only helper invocation that pledges with the production promise set
+     and then deliberately violates it, asserting `SIGABRT`. This proves the
+     promise string in the daemon is a real pledge, not an empty string.
+  2. `ktrace -p $(pgrep openhapd)` during a normal pairing and `kdump` asserting
+     no `pledge` violations — a regression net for promise-set drift, since a
+     missing promise shows up here before it shows up in production.
+- **Unveil is really on.** Assert the daemon cannot read a file outside its
+  unveiled set. Create `/tmp/openhap-unveil-probe` and drive the daemon down a
+  path that would read an operator-supplied path; if no such path exists, use
+  the helper from the pledge test to unveil the production inventory and then
+  probe.
+- **No child processes.** `pgrep -P $(pgrep openhapd)` is empty. This is phase
+  2's contract, and it is what keeps `proc exec` out of the promise set; without
+  a test it can regress the moment anyone adds a `system()` call.
+- **Startup fails closed.** With a deliberately bogus promise string or a
+  nonexistent unveil path, `openhapd` exits nonzero and logs why, rather than
+  starting unrestricted. Drive this through a test-only flag or environment
+  override — not by editing the production string — and make sure the override
+  cannot loosen anything, only break startup.
+
+Each of these must fail when the corresponding call is commented out of
+`bin/openhapd`. Verify that by actually commenting it out once during
+development; a test that cannot fail is not evidence.
+
+### 5.2 `openhapd.8` SECURITY section
+
+One place an operator can read to understand the daemon's posture. Contents:
+
+- The promise set, with a one-line gloss on why each promise is present, and the
+  explicit statement that `proc`, `exec`, and `prot_exec` are absent.
+- The unveiled paths and their permissions (cross-referencing FILES from phase
+  4).
+- The privilege model: starts as root, `chown`s `$db_path`, drops to `_openhap`,
+  requires `wheel` membership for `/var/run/mdnsd.sock`, then unveils and
+  pledges. Say plainly that pledge and unveil are applied _after_ the privilege
+  drop and what that does and does not buy.
+- OpenBSD-only enforcement. Linux and Darwin are development platforms and the
+  restrictions are no-ops there. An operator who reads only the README should
+  not be able to conclude that a Linux deployment is hardened.
+- What a violation looks like in practice: the process aborts, `dmesg` and
+  `/var/log/messages` carry a `pledge` line naming the syscall. This is the
+  single most useful paragraph in the section — it turns "the daemon died" into
+  a diagnosis.
+
+### 5.3 Close out `TODO.md`
+
+- Mark the pledge and unveil items (`TODO.md:10-20`) done, in the style the file
+  already uses for completed entries — a short "Implemented:" summary with the
+  files, as at `TODO.md:48-53`. Do not just tick the box; the file's value is
+  that finished entries say what landed.
+- The `Privilege separation` item (`TODO.md:489`) stays open, but update it: a
+  pledged monolith changes what separation would buy, and the entry should say
+  so rather than reading as though nothing has happened.
+- Add a `hapctl` pledge item. It is now cheap — `FuguLib::Sandbox` exists, and
+  `hapctl` reads config and state and prints, so `stdio rpath` plus a handful of
+  unveiled paths covers it — and leaving it undone while `openhapd` is pledged
+  is the kind of asymmetry that goes unnoticed.
+- Add an item for re-establishing the mDNS advertisement after an `mdnsd`
+  restart. Phase 2 documents this as parity with the old `mdnsctl` behaviour,
+  which makes it a known limitation rather than a bug, but "known" should mean
+  "recorded".
+- Add an item for the unimplemented half of `spec/MDNS-Control.md`: browse,
+  resolve and lookup are specified but only publish is coded. A spec section
+  with no implementation and no conformance citation is exactly what
+  `make spec-coverage` is for, so record it rather than letting the coverage gap
+  read as an oversight.
+
+### 5.4 Verify the aspirational docs are now accurate
+
+No rewriting — checking. `README.md:16`, `CLAUDE.md:7`, `CLAUDE.md:103`, and
+`web/index.body.html:19-20` all claim pledge/unveil support. Read each one
+against what shipped and confirm it is now true rather than merely plausible. If
+any claim overreaches — for instance implying Linux is hardened too — fix that
+specific sentence, and only that one.
+
+## Deliverables
+
+- New/extended tests in `t/openhap/integration/`
+- `man/openhap/openhapd.8` SECURITY section
+- `TODO.md` updates
+- Any narrow corrections to `README.md`, `CLAUDE.md`, `web/index.body.html`
+
+## Acceptance criteria
+
+- Every test in 5.1 provably fails when the corresponding `bin/openhapd` call is
+  removed — demonstrated, not assumed.
+- `make integration` green on OpenBSD; `make check` green on Linux and Darwin.
+- `openhapd.8` renders clean under `mandoc -Tlint -W warning` and answers,
+  without reference to the source: what is pledged, what is unveiled, what
+  happens on violation, and where enforcement applies.
+- `TODO.md` has no remaining claim that pledge or unveil is unimplemented.
+- `make spec-coverage` exits zero with `MDNS-Imsg` and `MDNS-Control` coverage
+  no lower than phase 2 left it. This phase adds no spec citations, so the check
+  is a regression net: it catches a `spec/MDNS*.md` regeneration that moved
+  sections out from under phase 2's conformance tests.


### PR DESCRIPTION
Design and five phase plans for closing the gap between the pledge/unveil support the documentation claims and the none that exists. `README.md:16`, `CLAUDE.md:7`, `CLAUDE.md:103` and `web/index.body.html:19-20` all advertise it; there is no `pledge` or `unveil` call anywhere in `bin/` or `lib/`, no `FuguLib` module for either, and no test. The docs stay as they are — phase 4 makes them true.

Planning only. No behaviour change in this PR.

## The blocking obstacle

`OpenHAP::MDNS` advertises the service by spawning `mdnsctl publish` as a long-lived child (`MDNS.pm:117`, killed at `MDNS.pm:152`), so any pledge covering the daemon would need `proc exec` — most of what pledge exists to take away. That child exists only because `mdnsctl` holds the advertisement open for as long as its control socket is open, and openhapd can hold that socket itself.

## Phases

1. **mDNS protocol reference** — `spec/MDNS.md`, `spec/MDNS-Imsg.md`, `spec/MDNS-Control.md` via a new `spec-mdns` skill reading openmdns from `external/`, plus offsets measured on the installed port. Extends `scripts/spec-coverage`, whose citation pattern matches `HAP|MQTT` only, so `MDNS-*` citations would otherwise be invisible to both the coverage count and stale-citation detection.
2. **mDNS client without exec** — `FuguLib::Imsg` (framing) and `FuguLib::MDNS` (mdnsd group protocol), conformance tests citing phase 1, `OpenHAP::MDNS` deleted, `bin/openhapd` rewired.
3. **`FuguLib::Sandbox` and pledge** — the platform abstraction (real on OpenBSD, no-op on Linux/Darwin), XS/timezone preloading, and one promise set: `stdio rpath wpath cpath fattr flock inet dns unix`.
4. **unveil** — the path inventory including `@INC`, `unveil_lock`, ordering against privdrop.
5. **Proof and operability** — negative integration tests that fail if either restriction is silently absent, an `openhapd.8` SECURITY section, `TODO.md` closed out.

Phases 1–2 must precede 3: `proc exec` cannot leave the promise set while a child is spawned.

## Design decisions worth review

**No fourth sub-project for the mDNS client.** The FuguLib/OpenHVF precedent splits on lifecycle and audience, not subject matter. OpenHVF earned a namespace by being a separate program; an mdnsd client is a shipped library with no CLI, config, or user of its own, which is FuguLib's shape. Precedent also says FuguLib absorbs — `OpenHAP::Log` became `FuguLib::Log` — so `OpenHAP::MDNS` goes away.

**`prot_exec` stays out of the promise set**, which requires preloading. `Math::BigInt` pulls in `Math::BigInt::GMP` on first use — during pairing — and `OpenHAP::MQTT` lazily `require`s `Net::MQTT::Simple`, deferred to the first reconnect if the broker was down at startup. Both would abort in production rather than in a test. `@INC` is unveiled read-only as a deliberate simplicity trade: proving no module ever loads late is not a claim a test can hold over time.

**One pledge, applied once.** Two-stage and per-phase pledges are an explicit non-goal.

## Also in this PR

`CLAUDE.md`'s design-length rule. Designs 003 and 004 landed at 199 and 200 lines against a 200-line cap, which is the signature of a binding constraint rather than a guideline. The rule now keeps brevity as the stated intent with 200 as a soft target, and says that running over is a prompt to cut or split rather than a hard failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AedLR4nNoCytYvEEidYk8v)_