### PR TITLE
ci: filter every workflow on explicit path includes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,11 @@ name: Build
 
 on:
   workflow_run:
-    # Gate releases on the test suite. The Test workflow only runs when
-    # production code changed, so docs-only merges produce no release;
-    # the commit-count-derived tag simply skips ahead on the next one.
+    # Gate releases on the test suite, which is also what filters this
+    # workflow: workflow_run takes no paths of its own. Test declares an
+    # explicit include list of the sources a release is built from, so a
+    # merge that touches nothing on that list produces no release; the
+    # commit-count-derived tag simply skips ahead on the next one.
     workflows: ["Test"]
     types:
       - completed

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,45 @@
 name: Check
 
+# Explicit includes, never excludes: a path that no job reads must not be
+# able to start this workflow just because nobody remembered to exclude it.
+# The list is the union of what the three jobs below actually consume.
 on:
   push:
     branches: [main]
+    paths:
+      # Perl that tidy, lint and the syntax sweep read
+      - "bin/*"
+      - "lib/**.pm"
+      - ".perlcriticrc"
+      - ".perltidyrc"
+      # Prettier formats every Markdown, JSON and YAML file in the tree,
+      # so this workflow has to see all of them.  The YAML glob is also
+      # what makes the workflow re-run on edits to itself and to the
+      # composite action under .github/.
+      - "**.md"
+      - "**.json"
+      - "**.yml"
+      - ".prettierrc"
+      # The toolchain the jobs install and drive
+      - "Makefile"
+      - "cpanfile"
+      - "deps/*.txt"
+      - "scripts/deps.sh"
   pull_request:
     branches: [main]
+    paths:
+      - "bin/*"
+      - "lib/**.pm"
+      - ".perlcriticrc"
+      - ".perltidyrc"
+      - "**.md"
+      - "**.json"
+      - "**.yml"
+      - ".prettierrc"
+      - "Makefile"
+      - "cpanfile"
+      - "deps/*.txt"
+      - "scripts/deps.sh"
 
 jobs:
   tidy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,32 +1,80 @@
 name: Integration
 
+# This job boots an OpenBSD guest under TCG emulation and can run for
+# hours, so its trigger set is the narrowest in the repository: only an
+# edit that can change what runs inside the VM, or how the VM is built,
+# belongs here.  Explicit includes, never excludes - a new top-level
+# directory must not silently start costing three hours a push.
+#
+# Everything hashed into the image cache key below also appears here.
+# That is deliberate: an input that can rotate the cache key but cannot
+# start a run would be rebuilt on the next unrelated push instead of the
+# one that changed it.
+#
+# Anything left out - unit tests, docs, man pages, the website, spec/,
+# plans/ - is still reachable through workflow_dispatch and the weekly
+# schedule.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "**.pod"
-      - "spec/**"
-      - "plans/**"
-      - "man/**"
-      - ".claude/**"
-      - ".devcontainer/**"
-      - ".prettierrc"
-      - ".gitignore"
-      - "LICENSE"
+    paths:
+      # The daemon, library and files installed into the guest
+      - "bin/hapctl"
+      - "bin/openhapd"
+      - "lib/FuguLib/*.pm"
+      - "lib/OpenHAP/**.pm"
+      - "etc/rc.d/openhapd"
+      - "share/openhap/examples/*.sample"
+      # The suite itself and the mocks it carries over
+      - "t/openhap/integration/*.t"
+      - "t/lib/**.pm"
+      # The harness that installs the guest, provisions it and drives
+      # the run
+      - "bin/openhvf"
+      - "lib/OpenHVF/**.pm"
+      - ".openhvfrc"
+      - "share/openhvf/cache-generation"
+      - "share/openhvf/expect/*.exp"
+      - "scripts/deps.sh"
+      - "scripts/deps_key.sh"
+      - "scripts/ftp.sh"
+      - "scripts/integration.sh"
+      - "scripts/vm_provision.sh"
+      - "scripts/vm_up.sh"
+      # Guest dependencies, and the package and install rules that put
+      # the checkout on the guest
+      - "cpanfile"
+      - "deps/OpenBSD.txt"
+      - "Makefile"
+      - ".github/actions/setup-perl/action.yml"
+      - ".github/workflows/integration.yml"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "**.pod"
-      - "spec/**"
-      - "plans/**"
-      - "man/**"
-      - ".claude/**"
-      - ".devcontainer/**"
-      - ".prettierrc"
-      - ".gitignore"
-      - "LICENSE"
+    paths:
+      - "bin/hapctl"
+      - "bin/openhapd"
+      - "lib/FuguLib/*.pm"
+      - "lib/OpenHAP/**.pm"
+      - "etc/rc.d/openhapd"
+      - "share/openhap/examples/*.sample"
+      - "t/openhap/integration/*.t"
+      - "t/lib/**.pm"
+      - "bin/openhvf"
+      - "lib/OpenHVF/**.pm"
+      - ".openhvfrc"
+      - "share/openhvf/cache-generation"
+      - "share/openhvf/expect/*.exp"
+      - "scripts/deps.sh"
+      - "scripts/deps_key.sh"
+      - "scripts/ftp.sh"
+      - "scripts/integration.sh"
+      - "scripts/vm_provision.sh"
+      - "scripts/vm_up.sh"
+      - "cpanfile"
+      - "deps/OpenBSD.txt"
+      - "Makefile"
+      - ".github/actions/setup-perl/action.yml"
+      - ".github/workflows/integration.yml"
   # Manual runs against any branch, e.g. to test workflow changes
   # before merging
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,32 +1,46 @@
 name: Test
 
+# Explicit includes, never excludes: only what `make test` and
+# `make spec-coverage` actually load may start a run.  Note that the
+# Build workflow releases off a successful run of this one, so a path
+# missing here is also a change that never ships.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "**.pod"
-      - "spec/**"
-      - "plans/**"
-      - "man/**"
-      - ".claude/**"
-      - ".devcontainer/**"
-      - ".prettierrc"
-      - ".gitignore"
-      - "LICENSE"
+    paths:
+      # Everything the suite loads
+      - "bin/*"
+      - "lib/**.pm"
+      # Every *.t in the tree, not just the four directories `make test`
+      # proves: spec-coverage scans all of t/ for spec citations, so a
+      # stale citation anywhere has to be able to fail this workflow.
+      - "t/**.t"
+      - "t/lib/**.pm"
+      # The other half of the spec-coverage cross-check
+      - "spec/*.md"
+      - "scripts/spec-coverage"
+      # The toolchain and dependency set the job installs
+      - "Makefile"
+      - "cpanfile"
+      - "deps/*.txt"
+      - "scripts/deps.sh"
+      - ".github/actions/setup-perl/action.yml"
+      - ".github/workflows/test.yml"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "**.pod"
-      - "spec/**"
-      - "plans/**"
-      - "man/**"
-      - ".claude/**"
-      - ".devcontainer/**"
-      - ".prettierrc"
-      - ".gitignore"
-      - "LICENSE"
+    paths:
+      - "bin/*"
+      - "lib/**.pm"
+      - "t/**.t"
+      - "t/lib/**.pm"
+      - "spec/*.md"
+      - "scripts/spec-coverage"
+      - "Makefile"
+      - "cpanfile"
+      - "deps/*.txt"
+      - "scripts/deps.sh"
+      - ".github/actions/setup-perl/action.yml"
+      - ".github/workflows/test.yml"
 
 jobs:
   test:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,10 +1,47 @@
 name: Website
 
+# Explicit includes, never excludes: the site is rendered from a known
+# set of sources, so anything outside that set cannot change the build.
+# The published site is derived entirely from these paths, which is what
+# makes it safe for a push to main to skip the deploy job below.
 on:
   push:
     branches: [main]
+    paths:
+      # Hand-written pages, shared chrome, assets and the two renderers
+      - "web/*.html"
+      - "web/*.css"
+      - "web/*.sh"
+      - "web/CNAME"
+      - "web/robots.txt"
+      # Everything the build renders into a page
+      - "man/**.1"
+      - "man/**.3p"
+      - "man/**.5"
+      - "man/**.8"
+      - "lib/**.pod"
+      - "INSTALL.md"
+      # The build rules and the test that checks the result
+      - "Makefile"
+      - "t/web/*.t"
+      - ".github/workflows/web.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "web/*.html"
+      - "web/*.css"
+      - "web/*.sh"
+      - "web/CNAME"
+      - "web/robots.txt"
+      - "man/**.1"
+      - "man/**.3p"
+      - "man/**.5"
+      - "man/**.8"
+      - "lib/**.pod"
+      - "INSTALL.md"
+      - "Makefile"
+      - "t/web/*.t"
+      - ".github/workflows/web.yml"
 
 # Deploying needs more than this; it is granted on the deploy job alone
 permissions:


### PR DESCRIPTION
Replace the `paths-ignore` lists on Test and Integration, and the absent filters on Check and Website, with explicit `paths:` include lists derived from what each workflow actually reads.

An exclude list fails open: a new top-level directory triggers every workflow until someone remembers to exclude it, and the OpenBSD VM run costs hours. An include list fails closed, and it can also express what an exclude list cannot — `lib/**.pm` without `lib/**.pod`, `deps/OpenBSD.txt` without `deps/Linux.txt`, the openhvf expect scripts without the conf samples beside them.

### Per workflow

**Integration** is the narrowest — five groups: the daemon and library installed into the guest; the integration suite and its mocks; the openhvf harness that builds and drives the VM; the guest dependency set; and the package and install rules. Unit tests, `man/`, `web/`, `spec/`, `plans/`, `.claude/` and pods no longer start it, while `workflow_dispatch` and the weekly schedule remain as escape hatches. The harness itself stays in the list deliberately: this is the only workflow that boots a VM, so a change that breaks provisioning has nowhere else to surface. Every input hashed into the image cache key also appears in the filter, so an edit that rotates the key is also an edit that rebuilds it.

**Test** takes all of `t/**.t` rather than only the five directories `make test` proves, because `spec-coverage` scans the whole of `t/` for spec citations and a stale one has to be able to fail here.

**Website** takes the `web/` sources, the mdoc pages, the `.pod` sidecars, `INSTALL.md`, `Makefile` and `t/web/*.t` — the site is derived entirely from those, which is what makes it safe for a push to `main` to skip the deploy job.

**Check** is necessarily the widest, since prettier formats every Markdown, JSON and YAML file in the tree and GitHub cannot filter per job. It is still narrower than today, where it runs on everything: `t/**`, `man/**`, `web/*.html` and pods now skip it.

**Build** takes no filter of its own — `workflow_run` has none — and is now documented as inheriting Test's.

### Verification

Simulated GitHub's glob semantics against all tracked files. The push and pull_request lists are identical for every path, and the only files that trigger nothing are `LICENSE`, `.gitignore` and `share/openhvf/*.conf.sample` — samples with no runtime consumer. That sweep also caught `scripts/ftp.sh`, which `OpenHVF::Image` shells out to for the miniroot download, so it is in the Integration list.

Patterns use the documented `**.ext` form rather than `**/*.ext`, since only the former appears verbatim in GitHub's filter-pattern documentation.

`make prettier` passes. `make lint` and `make test` cannot run in the session container for missing CPAN modules; the identical failures reproduce on the unmodified tree, and this change is YAML only.

### Note

If `main` has required status checks configured, a skipped workflow reports nothing, so a docs-only PR can sit pending. Branch protection is untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn8wsbSiymCVN2fQk8UpeB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn8wsbSiymCVN2fQk8UpeB)_