### PR TITLE
ci(deps): install and cache dependencies in setup-perl

### DIFF
--- a/.github/actions/setup-perl/action.yml
+++ b/.github/actions/setup-perl/action.yml
@@ -1,17 +1,66 @@
 name: "Setup Perl with dependencies"
-description: "Install system dependencies and set up Perl for OpenHAP"
+description:
+  "Install OpenHAP's dependencies for one environment, with the CPAN tree cached"
+
+# Linux only: the bootstrap below drives apt-get, and the cache key hashes
+# deps/Linux.txt.  Every runner this repository uses is Ubuntu, x86_64 or
+# arm64; the guest's dependencies are installed inside the VM by
+# scripts/vm-provision, never here.
+
+inputs:
+  dependencies:
+    description:
+      "Dependency environment to install: runtime, test or develop.  Names the
+      environment column of deps/Linux.txt, so it is also the make target:
+      runtime is `make deps`, the other two `make deps-<name>`."
+    required: false
+    default: "test"
+
+outputs:
+  cache-hit:
+    description:
+      "true when the CPAN tree was restored from an exact key match, i.e. when
+      nothing had to be built"
+    value: ${{ steps.restore.outputs.cache-hit }}
 
 runs:
   using: "composite"
   steps:
-    - name: Install system dependencies and Perl toolchain
+    - name: Resolve the dependency environment
+      id: env
+      shell: bash
+      env:
+        DEPENDENCIES: ${{ inputs.dependencies }}
+      run: |
+        # Fail closed, and fail first: an unrecognised environment
+        # selects nothing, and `make deps-typo` would then either be a
+        # no-op or an error many minutes into the job.
+        case "$DEPENDENCIES" in
+        runtime)
+          echo "target=deps" >> "$GITHUB_OUTPUT"
+          ;;
+        test|develop)
+          echo "target=deps-$DEPENDENCIES" >> "$GITHUB_OUTPUT"
+          ;;
+        *)
+          echo "setup-perl: unknown dependencies '$DEPENDENCIES'" \
+            "(expected runtime, test or develop)" >&2
+          exit 1
+          ;;
+        esac
+
+    - name: Install the Perl toolchain
       shell: bash
       run: |
+        # Only the bootstrap: everything else comes from
+        # deps/Linux.txt via `make deps*` below, which is the single
+        # authoritative list.  cpanminus is installed from a package
+        # rather than left to scripts/deps, which would otherwise fetch
+        # and build App::cpanminus from cpanmin.us on every run.
         sudo apt-get update
         sudo apt-get install -y \
           cpanminus \
-          liblocal-lib-perl \
-          libssh2-1-dev
+          liblocal-lib-perl
 
     - name: Configure local::lib environment
       shell: bash
@@ -22,3 +71,77 @@ runs:
         echo "PERL_MB_OPT=--install_base ${{ github.workspace }}/local" >> $GITHUB_ENV
         echo "PERL_MM_OPT=INSTALL_BASE=${{ github.workspace }}/local" >> $GITHUB_ENV
         echo "${{ github.workspace }}/local/bin" >> $GITHUB_PATH
+
+    - name: Compute the cache key
+      id: cache
+      shell: bash
+      run: |
+        # Computed once and read by both the restore and the save step
+        # below: the cache API rejects a write to an existing key, so two
+        # copies of this expression that drifted apart would miss on
+        # every run and then fail to store the result.
+        #
+        # The key covers exactly what decides the contents of the tree:
+        # the environment, the interpreter, the manifest that names the
+        # modules and the script that installs them.  Nothing else - the
+        # Makefile changes for unrelated reasons every other week and
+        # hashing it would rebuild the tree from source each time.
+        # cpanfile is not read on Linux (scripts/deps reads
+        # deps/Linux.txt) and the documented workflow keeps the two in
+        # sync, so a module added to one rotates this key through the
+        # other.
+        #
+        # The tree holds compiled XS - CryptX, Net::SSH2,
+        # Math::BigInt::GMP - so it is only valid for the perl that built
+        # it.  archname carries the OS, the CPU and the threading model,
+        # so a runner image that bumps perl, or an arm64 runner, gets its
+        # own cache rather than a tree of unloadable .so files.
+        #
+        # To force a cold rebuild, bump the v<N> below or delete the
+        # cache from Actions -> Caches.
+        perl=$(perl -MConfig -e \
+          'print "perl$Config{version}-$Config{archname}"')
+
+        # Same environment only, so that a develop tree is never
+        # restored for a test run and then saved back under the test key,
+        # growing it with modules that run never needs.
+        prefix="openhap-cpan-v1-${{ inputs.dependencies }}-$perl-"
+
+        echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
+        echo "key=$prefix${{ hashFiles('deps/Linux.txt', 'scripts/deps') }}" \
+          >> "$GITHUB_OUTPUT"
+
+    - name: Restore the CPAN tree
+      id: restore
+      # local/ is the whole of what cpanm installs: scripts/deps passes
+      # --local-lib=$PERL_LOCAL_LIB_ROOT, so nothing lands in the system
+      # perl.  The OS packages are deliberately not cached - apt's
+      # archive directory is root-owned, which the cache post-step could
+      # not restore into, and the win would be the download only, never
+      # dpkg's unpack.
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ github.workspace }}/local
+        key: ${{ steps.cache.outputs.key }}
+        # A near miss still restores a tree built by the same perl from
+        # an older manifest; the install below reconciles it and the save
+        # step stores the result under the new key.
+        restore-keys: ${{ steps.cache.outputs.prefix }}
+
+    - name: Install dependencies
+      shell: bash
+      # Unconditional, cache hit or not: the OS packages are not cached,
+      # and cpanm over an already-complete tree is a version check per
+      # module rather than a build.  scripts/deps is idempotent, so this
+      # is also what verifies that a restored tree is actually usable.
+      run: make ${{ steps.env.outputs.target }}
+
+    - name: Save the CPAN tree
+      # Only on a miss - an exact hit has nothing new to store, and the
+      # cache API rejects a write to an existing key.  No `always()`:
+      # a failed install must not be cached as the tree for this key.
+      if: steps.restore.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ github.workspace }}/local
+        key: ${{ steps.cache.outputs.key }}

--- a/.github/actions/setup-perl/action.yml
+++ b/.github/actions/setup-perl/action.yml
@@ -107,9 +107,14 @@ runs:
         # growing it with modules that run never needs.
         prefix="openhap-cpan-v1-${{ inputs.dependencies }}-$perl-"
 
+        # Bound to its own variable first. Interpolating the expression
+        # straight after $prefix made the digest part of the variable
+        # NAME - $prefixe6c451... is unset - so the key came out empty
+        # and actions/cache rejected it.
+        hash="${{ hashFiles('deps/Linux.txt', 'scripts/deps') }}"
+
         echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
-        echo "key=$prefix${{ hashFiles('deps/Linux.txt', 'scripts/deps') }}" \
-          >> "$GITHUB_OUTPUT"
+        echo "key=$prefix$hash" >> "$GITHUB_OUTPUT"
 
     - name: Restore the CPAN tree
       id: restore

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,9 +53,8 @@ jobs:
 
       - name: Setup Perl
         uses: ./.github/actions/setup-perl
-
-      - name: Install test dependencies
-        run: make deps-test
+        with:
+          dependencies: test
 
       - name: Check formatting
         run: make tidy
@@ -79,9 +78,8 @@ jobs:
 
       - name: Setup Perl
         uses: ./.github/actions/setup-perl
-
-      - name: Install test dependencies
-        run: make deps-test
+        with:
+          dependencies: test
 
       - name: Check lint
         run: make lint

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,6 +45,11 @@ on:
       # the checkout on the guest
       - "cpanfile"
       - "deps/OpenBSD.txt"
+      # Host dependencies: QEMU, expect and telnet are what boots and
+      # drives the guest, and setup-perl hashes this file into its own
+      # cache key - so by the rule above it has to be able to start a
+      # run of its own
+      - "deps/Linux.txt"
       - "Makefile"
       - ".github/actions/setup-perl/action.yml"
       - ".github/workflows/integration.yml"
@@ -72,6 +77,7 @@ on:
       - "scripts/vm-up"
       - "cpanfile"
       - "deps/OpenBSD.txt"
+      - "deps/Linux.txt"
       - "Makefile"
       - ".github/actions/setup-perl/action.yml"
       - ".github/workflows/integration.yml"
@@ -105,9 +111,8 @@ jobs:
 
       - name: Setup Perl
         uses: ./.github/actions/setup-perl
-
-      - name: Install development dependencies
-        run: make deps-develop
+        with:
+          dependencies: develop
 
       - name: Cache OpenBSD and provisioning images
         # The only cached artifact. `.openhvf` is fully ephemeral: the

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -114,12 +114,20 @@ jobs:
         with:
           dependencies: develop
 
-      - name: Cache OpenBSD and provisioning images
-        # The only cached artifact. `.openhvf` is fully ephemeral: the
-        # installed OpenBSD image and the provisioning layer both live
-        # in ~/.cache/openhvf, and openhvf rebuilds the state directory
-        # from them on every run. Nothing here depends on a previous
-        # run's state.
+      - name: Cache OpenBSD images and downloads
+        # `.openhvf` is fully ephemeral: openhvf rebuilds the state
+        # directory on every run from three things that all live in
+        # ~/.cache/openhvf - the installed OpenBSD image, the
+        # provisioning layer snapshotted over it, and the proxy's copies
+        # of everything the installer downloaded. Nothing here depends on
+        # a previous run's state.
+        #
+        # The proxy store is what makes a reinstall cheap rather than
+        # free: a rotated key restores the previous entry through
+        # restore-keys, so an install.exp edit re-runs the installer but
+        # reads the file sets off local disk. It is also the half of this
+        # directory that nothing bounded until `cache clear --stale`
+        # learned to prune it - see the cleanup step below.
         #
         # The key hashes every input that either openhvf's own cache key
         # or scripts/deps-key derives from. That is a constraint, not
@@ -196,6 +204,13 @@ jobs:
         # interactions are time-limited and it force-stops the QEMU
         # process as a last resort), so it cannot hang the job even when
         # the guest is wedged.
+        #
+        # `cache clear --stale` prunes both halves of ~/.cache/openhvf:
+        # the images whose key the current configuration no longer
+        # derives, and the proxy's downloads for every OpenBSD version
+        # other than the one .openhvfrc pins. It runs before the cache
+        # post-step, so what a version bump orphans is dropped on the run
+        # that bumped it rather than uploaded forever.
         #
         # Every command here is guarded. This step is `if: always()` and
         # `run:` blocks are `bash -e`, while the cache post-step is

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,8 @@ jobs:
 
       - name: Setup Perl
         uses: ./.github/actions/setup-perl
-
-      - name: Install test dependencies
-        run: make deps-test
+        with:
+          dependencies: test
 
       - name: Run tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ test:
 	prove -l -v t/conformance/*.t
 	prove -l -v t/scripts/*.t
 	prove -l -v t/web/*.t
+	prove -l -v t/ci/*.t
 
 tidy:
 	@$(PERLSRC) | while read f; do \

--- a/lib/OpenHVF/CLI.pm
+++ b/lib/OpenHVF/CLI.pm
@@ -27,6 +27,7 @@ use OpenHVF::Config;
 use OpenHVF::State;
 use OpenHVF::Image;
 use OpenHVF::ImageCache;
+use OpenHVF::Proxy::Cache;
 use OpenHVF::Disk;
 use OpenHVF::VM;
 use OpenHVF::SSH;
@@ -378,13 +379,13 @@ sub cmd_cache ( $self, @args )
 
 # $self->_cache_list($cache):
 #	One line per cached entry, marking the one the invoked VM's
-#	configuration currently derives.
+#	configuration currently derives, then what the proxy holds.
 sub _cache_list ( $self, $cache )
 {
 	my $entries = $cache->list;
 	if ( !@$entries ) {
 		$self->{log}->info("No cached images");
-		return EXIT_SUCCESS;
+		return $self->_proxy_list;
 	}
 
 	my $current = $self->_current_cache_key($cache);
@@ -406,6 +407,44 @@ sub _cache_list ( $self, $cache )
 				scalar @{ $entry->{snapshots} },
 				$marker
 			) );
+	}
+
+	return $self->_proxy_list;
+}
+
+# $self->_proxy_list:
+#	What the proxy's download cache holds, one line per OpenBSD
+#	version. Reported by 'cache list' because it shares cache_dir with
+#	the images and is pruned by the same 'cache clear': a half of the
+#	directory that nothing printed was a half nobody knew to bound.
+sub _proxy_list ($self)
+{
+	my $cache = OpenHVF::Proxy::Cache->new( $self->{config}->cache_dir );
+	my $files = $cache->list;
+
+	if ( !@$files ) {
+		$self->{log}->info('No proxy downloads');
+		return EXIT_SUCCESS;
+	}
+
+	# Per version, since that is the granularity 'clear --stale'
+	# prunes at. A URL naming no version - nothing is_cacheable()
+	# admits today - is counted under '-' rather than dropped, so an
+	# unprunable entry is still visible as one.
+	my %bytes;
+	for my $file (@$files) {
+		my ($version) =
+		    $file->{url} =~ m{/pub/OpenBSD/(?:syspatch/)?([0-9.]+)/};
+		$bytes{ $version // '-' } += $file->{size};
+	}
+
+	$self->{log}->info(
+		sprintf 'Proxy downloads (%s):',
+		_format_size( $cache->size ) );
+
+	for my $version ( sort keys %bytes ) {
+		$self->{log}->info( sprintf '  - OpenBSD %s  %s',
+			$version, _format_size( $bytes{$version} ) );
 	}
 
 	return EXIT_SUCCESS;
@@ -473,6 +512,48 @@ sub _cache_clear ( $self, $cache, @args )
 		? "Removed $removed cached images"
 		: "No cached images removed"
 	);
+
+	return $self->_proxy_clear($stale);
+}
+
+# $self->_proxy_clear($stale):
+#	The other half of cache_dir: the proxy's download cache. Bare
+#	'clear' empties it, --stale keeps the OpenBSD version the invoked
+#	VM installs - the same one-VM scope the image prune above has.
+#
+#	Not reachable from the image loop, which is why this is a second
+#	pass rather than a branch inside it: the two caches share nothing
+#	but cache_dir, and the images have running-VM and orphaned-disk
+#	checks that a re-downloadable file set does not need.
+sub _proxy_clear ( $self, $stale )
+{
+	my $cache = OpenHVF::Proxy::Cache->new( $self->{config}->cache_dir );
+
+	if ( !$stale ) {
+		my $size = $cache->size;
+		if ( !$cache->clear ) {
+			$self->{log}->error("Cannot clear proxy downloads");
+			return EXIT_ERROR;
+		}
+		$self->{log}->info( sprintf 'Removed %s of proxy downloads',
+			_format_size($size) );
+
+		return EXIT_SUCCESS;
+	}
+
+	# --stale got this far, so the VM resolves; keeping its version is
+	# the point of the flag.
+	my $vm      = $self->{config}->load_vm( $self->{vm_name} );
+	my $removed = $cache->prune( $vm->{version} );
+
+	for my $entry (@$removed) {
+		$self->{log}->info(
+			sprintf 'Removed %s of downloads for OpenBSD %s',
+			_format_size( $entry->{size} ),
+			$entry->{version} );
+	}
+	$self->{log}->info('No proxy downloads removed') if !@$removed;
+
 	return EXIT_SUCCESS;
 }
 

--- a/lib/OpenHVF/Proxy/Cache.pm
+++ b/lib/OpenHVF/Proxy/Cache.pm
@@ -169,14 +169,71 @@ sub size ($self)
 	my $proxy_dir = "$self->{cache_dir}/proxy";
 	return 0 if !-d $proxy_dir;
 
-	my $total = 0;
-	$self->_walk_dir(
-		$proxy_dir,
-		sub ($file) {
-			$total += -s $file if -f $file;
-		} );
+	return $self->_dir_size($proxy_dir);
+}
 
-	return $total;
+# $self->prune(@keep):
+#	Remove the cached download tree of every OpenBSD version other
+#	than @keep. Returns [ { version, path, size } ] for what went.
+#
+#	Nothing else bounds this cache. 'openhvf cache clear --stale'
+#	prunes installed images, which live beside these downloads under
+#	the same cache_dir but are keyed by nothing in common, so a
+#	version bump used to leave the whole previous version's file sets
+#	here for good - unreadable afterwards, since every pattern
+#	is_cacheable() admits is version-scoped, and still carried by
+#	every copy of the directory a continuous-integration cache makes.
+#
+#	Whole directories, not matching files: removing the files alone
+#	would leave the empty version tree behind, and the tree is what
+#	such a copy walks.
+#
+#	A directory whose name is not a version is left alone. In
+#	practice there are none - the patterns put everything under
+#	pub/OpenBSD/<version>/ or pub/OpenBSD/syspatch/<version>/ - and a
+#	cache under $HOME is the wrong place to delete on a guess.
+sub prune ( $self, @keep )
+{
+	my $proxy_dir = "$self->{cache_dir}/proxy";
+	return [] if !-d $proxy_dir;
+
+	my %keep = map { $_ => 1 } @keep;
+	my @removed;
+
+	for my $root ( $self->_version_roots($proxy_dir) ) {
+		opendir my $dh, $root or next;
+		my @versions =
+		    sort grep { /\A[0-9]+\.[0-9]+\z/ } readdir $dh;
+		closedir $dh;
+
+		for my $version (@versions) {
+			next if $keep{$version};
+
+			my $dir = "$root/$version";
+			next if !-d $dir;
+
+			# Measured before removal, so the caller can say
+			# what the prune bought
+			my $size = $self->_dir_size($dir);
+
+			require File::Path;
+			File::Path::remove_tree( $dir, { error => \my $err } );
+			if ( $err && @$err ) {
+				my ( $file, $msg ) = %{ $err->[0] };
+				warn "Cannot remove $dir: $msg\n";
+				next;
+			}
+
+			push @removed,
+			    {
+				version => $version,
+				path    => $dir,
+				size    => $size,
+			    };
+		}
+	}
+
+	return \@removed;
 }
 
 # $self->clear:
@@ -225,6 +282,43 @@ sub list ($self)
 		} );
 
 	return \@files;
+}
+
+# $self->_version_roots($proxy_dir):
+#	Every directory under $proxy_dir whose immediate children are
+#	OpenBSD version numbers, across all cached hosts. Release trees
+#	hang off pub/OpenBSD, syspatch sets one level deeper; both are
+#	named for a version and neither outlives it.
+sub _version_roots ( $self, $proxy_dir )
+{
+	opendir my $dh, $proxy_dir or return ();
+	my @hosts = sort grep { !/\A\.\.?\z/ } readdir $dh;
+	closedir $dh;
+
+	my @roots;
+	for my $host (@hosts) {
+		my $release = "$proxy_dir/$host/pub/OpenBSD";
+		next if !-d $release;
+
+		push @roots, $release;
+		push @roots, "$release/syspatch" if -d "$release/syspatch";
+	}
+
+	return @roots;
+}
+
+# $self->_dir_size($dir):
+#	Total bytes of the regular files under $dir.
+sub _dir_size ( $self, $dir )
+{
+	my $total = 0;
+	$self->_walk_dir(
+		$dir,
+		sub ($file) {
+			$total += -s $file if -f $file;
+		} );
+
+	return $total;
 }
 
 sub _walk_dir ( $self, $dir, $callback )

--- a/man/openhvf/openhvf.1
+++ b/man/openhvf/openhvf.1
@@ -192,17 +192,38 @@ shows the cache path or download URL for
 (default: 7.8).
 Images are downloaded via the built-in proxy when the VM boots.
 .It Cm cache Cm list | clear Op Fl Fl stale
-Manage the installed-image cache described in
-.Sx IMAGE CACHE .
+Manage everything under
+.Ar cache_dir :
+the installed-image cache described in
+.Sx IMAGE CACHE ,
+and the downloads the built-in proxy keeps for the installer.
 .Cm list
-prints one line per cached entry
+prints one line per cached image
 .Pq key, size, creation time, snapshot count ,
-marking the entry the invoked VM's configuration currently derives.
+marking the entry the invoked VM's configuration currently derives,
+then the proxy's downloads by
+.Ox
+version.
 .Cm clear
-removes every entry;
+removes every image and every download;
 .Fl Fl stale
-keeps only that one entry and removes the rest.
+keeps only the image the invoked VM derives and only the downloads for
+the
+.Ox
+.Ar version
+it installs.
 Both forms also sweep temporary trees left by an interrupted save.
+.Pp
+Pruning the downloads is the only thing that bounds them.
+They are keyed by
+.Ox
+version alone,
+share no key input with the images,
+and every pattern the proxy caches is version-scoped,
+so a
+.Ar version
+bump otherwise leaves the whole previous version's file sets behind
+unreadable.
 .Pp
 The scope of
 .Fl Fl stale
@@ -214,7 +235,10 @@ The key inputs
 and
 .Ar disk_size
 are per-VM,
-so pruning for one VM removes bases another VM would have hit.
+so pruning for one VM removes bases another VM would have hit,
+and downloads for the
+.Ox
+version another VM installs.
 .Pp
 .Cm clear
 refuses to remove an entry while a VM in this project is running on it,

--- a/t/CLAUDE.md
+++ b/t/CLAUDE.md
@@ -4,13 +4,13 @@ Applies when working on files under `t/`.
 
 ## Test tiers
 
-| Tier        | Location                  | Verifies                             | Runs via           |
-| ----------- | ------------------------- | ------------------------------------ | ------------------ |
-| Conformance | `t/conformance/`          | spec requirements, wire formats, KAT | `make test` (host) |
-| Module      | `t/openhap/` `t/fugulib/` | Perl API behavior, error paths       | `make test` (host) |
-| Module      | `t/openhvf/`              | the OpenBSD VM utility               | `make test` (host) |
-| Tooling     | `t/scripts/` `t/web/`     | what `scripts/` and `web/` produce   | `make test` (host) |
-| Integration | `t/openhap/integration/`  | real daemon, full protocol flow      | `make integration` |
+| Tier        | Location                      | Verifies                                       | Runs via           |
+| ----------- | ----------------------------- | ---------------------------------------------- | ------------------ |
+| Conformance | `t/conformance/`              | spec requirements, wire formats, KAT           | `make test` (host) |
+| Module      | `t/openhap/` `t/fugulib/`     | Perl API behavior, error paths                 | `make test` (host) |
+| Module      | `t/openhvf/`                  | the OpenBSD VM utility                         | `make test` (host) |
+| Tooling     | `t/scripts/` `t/web/` `t/ci/` | what `scripts/`, `web/` and `.github/` produce | `make test` (host) |
+| Integration | `t/openhap/integration/`      | real daemon, full protocol flow                | `make integration` |
 
 Module tests follow the unit-test rules in the root `CLAUDE.md` (skip gracefully
 on missing dependencies) and need no citations. Integration tests follow the
@@ -21,6 +21,12 @@ Tooling tests are named after what they cover — `t/scripts/deps.t` for
 `scripts/deps` — and drive it as a subprocess rather than loading a module, so
 they assert on exit status and output. `t/scripts/conventions.t` covers the
 directory as a whole: exec bits, shebangs, and that every Perl script compiles.
+
+`t/ci/` is the exception to driving anything: nothing under `.github/` runs
+outside a runner, so these tests read the workflows and composite actions as
+text and assert the invariants that only fail in CI — that every consumer of an
+action passes it a value the action accepts, and that a cache key hashes every
+input which decides what it caches.
 
 ## Conformance tier
 

--- a/t/ci/setup-perl.t
+++ b/t/ci/setup-perl.t
@@ -1,0 +1,171 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# Guards for .github/actions/setup-perl and the workflows that use it
+#
+# Nothing else in the tree checks CI wiring: a workflow that stops
+# passing an environment, or a cache key that stops covering an input
+# that decides what gets installed, both fail on a runner - the first as
+# a job that installs the wrong dependency set, the second as a tree
+# that is silently rebuilt and re-cached under a stale key on every run.
+#
+# Text, not YAML: a parser is not in base perl and the invariants here
+# are all about which literal strings appear, not about structure.
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+
+my $root     = "$RealBin/../..";
+my $action   = "$root/.github/actions/setup-perl/action.yml";
+my $workflow = "$root/.github/workflows";
+
+# The environments deps/<OS>.txt names, and the make target each one
+# selects. deps-develop and deps-test have their own targets; runtime is
+# plain `make deps`.
+my %TARGET = (
+	runtime => 'deps',
+	test    => 'deps-test',
+	develop => 'deps-develop',
+);
+
+# _slurp($path):
+#	Whole file as text, or undef with a failed assertion.
+sub _slurp ($path)
+{
+	open my $fh, '<', $path or do {
+		fail("$path is readable");
+		return;
+	};
+	local $/ = undef;
+	my $content = <$fh>;
+	close $fh;
+
+	return $content;
+}
+
+my $yml = _slurp($action);
+plan skip_all => 'no setup-perl action' unless defined $yml;
+
+subtest 'the action takes one environment input' => sub {
+	like( $yml, qr/^\s+dependencies:$/m,
+		'declares a dependencies input' );
+	like( $yml, qr/^\s+default:\s*"?test"?\s*$/m,
+		'defaults to the test environment' );
+
+	# Every environment resolves, and only through the input: a
+	# workflow must not have to know the target names.
+	for my $env ( sort keys %TARGET ) {
+		like( $yml, qr/\b\Q$env\E\b/,
+			"resolves the $env environment" );
+	}
+	like(
+		$yml,
+		qr/run:\s*make \$\{\{\s*steps\.\w+\.outputs\.target\s*\}\}/,
+		'installs the resolved target, not a hardcoded one'
+	);
+	like( $yml, qr/exit 1/, 'rejects an unknown environment' );
+};
+
+subtest 'the cache key covers what decides the tree' => sub {
+	# One computed key, read twice. actions/cache/save rejects a write
+	# to an existing key, so a restore and a save that disagreed would
+	# miss on every run and then fail to store the result - which is
+	# why neither step may spell the key out for itself.
+	my @refs = $yml =~ /^\s+key:\s*(.*)$/mg;
+	is( scalar @refs, 2, 'a restore key and a save key' );
+	is_deeply(
+		[ map { s/\s+//gr } @refs ],
+		[ ('${{steps.cache.outputs.key}}') x 2 ],
+		'both read the same computed key'
+	);
+	like( $yml, qr/^\s+restore-keys:\s*\$\{\{\s*steps\.cache\.outputs\./m,
+		'the fallback prefix is computed with it' );
+
+	like( $yml, qr/prefix=\S*\$\{\{\s*inputs\.dependencies\s*\}\}/,
+		'the key names the environment' );
+
+	# The tree holds compiled XS, so it is only valid for the perl that
+	# built it.
+	like( $yml, qr/\$Config\{version\}/,  'the key names perl version' );
+	like( $yml, qr/\$Config\{archname\}/, 'the key names the archname' );
+
+	# Fail closed: hashFiles over a path that matches nothing returns
+	# an empty string rather than an error, so a renamed input would
+	# quietly collapse the key instead of rotating it.
+	my ($hashed) = $yml =~ /hashFiles\(([^)]*)\)/;
+	ok( defined $hashed, 'the key hashes files' ) or return;
+
+	my @paths = $hashed =~ /'([^']+)'/g;
+	ok( scalar @paths, 'at least one hashed path' );
+	ok( -f "$root/$_", "hashed path $_ exists" ) for @paths;
+
+	# The two inputs that decide which modules end up installed.
+	# Anything else - the Makefile above all - changes for unrelated
+	# reasons and would rebuild the tree from source each time.
+	for my $want ( 'deps/Linux.txt', 'scripts/deps' ) {
+		ok( scalar( grep { $_ eq $want } @paths ),
+			"the key hashes $want" );
+	}
+
+	like(
+		$yml,
+		qr/if:\s*steps\.restore\.outputs\.cache-hit\s*!=\s*'true'/,
+		'the tree is saved only on a cache miss'
+	);
+};
+
+subtest 'workflows delegate installing to the action' => sub {
+	opendir my $dh, $workflow or do {
+		fail('.github/workflows is readable');
+		return;
+	};
+	my @files = sort grep { /\.yml\z/ } readdir $dh;
+	closedir $dh;
+
+	ok( scalar @files, 'workflows found' );
+
+	my $users = 0;
+	for my $file (@files) {
+		my $text = _slurp("$workflow/$file") // next;
+		my @lines = split /\n/, $text;
+
+		# No workflow installs dependencies itself. That is the
+		# whole point of the input: one step per job, not two,
+		# and no job that forgets the second one.
+		my @own = grep { m{^\s+run:.*\bmake\s+deps\b} } @lines;
+		is( scalar @own, 0, "$file runs no deps target of its own" )
+		    or diag( join "\n", @own );
+
+		# Whatever a workflow does pass has to be an environment
+		# the action accepts.
+		for my $i ( 0 .. $#lines ) {
+			next
+			    unless $lines[$i] =~
+			    m{uses:\s*\./\.github/actions/setup-perl\s*$};
+			$users++;
+
+			my $env;
+			for my $j ( $i + 1 .. $#lines ) {
+				last if $lines[$j] =~ /^\s+-\s/;
+				if ( $lines[$j] =~
+					/^\s+dependencies:\s*"?(\w+)"?\s*$/ )
+				{
+					$env = $1;
+					last;
+				}
+			}
+
+			# Omitting it is fine - that is what the default
+			# is for - but a value that is not an environment
+			# is a job that installs nothing.
+			ok( !defined $env || exists $TARGET{$env},
+				"$file line @{[$i + 1]}: "
+				    . ( $env // '(default)' )
+				    . ' is a known environment' );
+		}
+	}
+
+	ok( $users >= 1, 'at least one workflow uses the action' );
+};
+
+done_testing();

--- a/t/ci/setup-perl.t
+++ b/t/ci/setup-perl.t
@@ -71,7 +71,13 @@ sub _run_block ( $yml, $name )
 		}
 
 		last if length $lines[$i] && $lines[$i] !~ /^ {$indent}/;
-		push @block, substr $lines[$i], $indent;
+
+		# A blank line inside the block is shorter than the indent
+		# and carries nothing to dedent
+		push @block,
+		    length( $lines[$i] ) > $indent
+		    ? substr( $lines[$i], $indent )
+		    : '';
 	}
 
 	return if !@block;

--- a/t/ci/setup-perl.t
+++ b/t/ci/setup-perl.t
@@ -9,10 +9,15 @@
 # that is silently rebuilt and re-cached under a stale key on every run.
 #
 # Text, not YAML: a parser is not in base perl and the invariants here
-# are all about which literal strings appear, not about structure.
+# are all about which literal strings appear, not about structure - with
+# one exception, the cache key, whose shell is extracted and run.  Reading
+# it was not enough: interpolating the hashFiles expression straight after
+# $prefix made the digest part of the variable NAME, which produced an
+# empty key and failed every job at the restore step.
 
 use v5.36;
 use Test::More;
+use File::Temp qw(tempdir);
 use FindBin qw($RealBin);
 
 my $root     = "$RealBin/../..";
@@ -41,6 +46,36 @@ sub _slurp ($path)
 	close $fh;
 
 	return $content;
+}
+
+# _run_block($yml, $step_name):
+#	The `run: |` script of the named step, dedented to column zero so
+#	it can be handed to a shell. Undef when the step or its block is
+#	not there.
+sub _run_block ( $yml, $name )
+{
+	my @lines = split /\n/, $yml;
+	my ( $seen, $indent, @block );
+
+	for my $i ( 0 .. $#lines ) {
+		$seen = 1 if $lines[$i] =~ /^\s+-\s+name:\s*\Q$name\E\s*$/;
+		next unless $seen;
+
+		# A later step begins, so the block is over
+		last if @block && $lines[$i] =~ /^\s+-\s+name:/;
+
+		if ( !defined $indent ) {
+			next unless $lines[$i] =~ /^(\s+)run:\s*\|\s*$/;
+			$indent = length($1) + 2;
+			next;
+		}
+
+		last if length $lines[$i] && $lines[$i] !~ /^ {$indent}/;
+		push @block, substr $lines[$i], $indent;
+	}
+
+	return if !@block;
+	return join( "\n", @block ) . "\n";
 }
 
 my $yml = _slurp($action);
@@ -112,6 +147,46 @@ subtest 'the cache key covers what decides the tree' => sub {
 		qr/if:\s*steps\.restore\.outputs\.cache-hit\s*!=\s*'true'/,
 		'the tree is saved only on a cache miss'
 	);
+};
+
+subtest 'the cache key shell actually composes a key' => sub {
+	# The step is legal YAML and legal shell either way, so nothing
+	# above can tell a working key from an empty one. Run it: the
+	# runner interpolates the expressions before bash sees them, so do
+	# the same with stand-in values and read the outputs back.
+	my $shell = _run_block( $yml, 'Compute the cache key' );
+	ok( defined $shell, 'the key-computing step has a shell block' )
+	    or return;
+
+	my $digest = 'd' x 64;    # what hashFiles() returns
+	$shell =~ s/\$\{\{\s*inputs\.dependencies\s*\}\}/develop/g;
+	$shell =~ s/\$\{\{\s*hashFiles\([^)]*\)\s*\}\}/$digest/g;
+	unlike( $shell, qr/\$\{\{/, 'every expression had a stand-in' );
+
+	my $dir = tempdir( CLEANUP => 1 );
+	my $out = "$dir/output";
+	open my $fh, '>', "$dir/step.sh" or die "open: $!";
+	print $fh $shell;
+	close $fh;
+	open my $touch, '>', $out or die "open: $!";
+	close $touch;
+
+	my $log = `GITHUB_OUTPUT='$out' sh '$dir/step.sh' 2>&1`;
+	is( $? >> 8, 0, 'it runs clean' ) or diag($log);
+
+	my %got = map { /\A([^=]+)=(.*)\z/ ? ( $1 => $2 ) : () }
+	    split /\n/, ( _slurp($out) // '' );
+
+	ok( length( $got{prefix} // '' ), 'it emits a non-empty prefix' );
+	ok( length( $got{key}    // '' ), 'it emits a non-empty key' );
+
+	# The bug: $prefix followed by the digest read as one variable
+	# name, so key= was empty and restore-keys= was fine - which is
+	# why only the composition catches it.
+	is( $got{key}, ( $got{prefix} // '' ) . $digest,
+		'and the key is exactly the prefix plus the digest' );
+	like( $got{prefix}, qr/-develop-/, 'the environment is in the key' );
+	like( $got{prefix}, qr/\Q$]\E|perl5\./, 'so is this perl' );
 };
 
 subtest 'workflows delegate installing to the action' => sub {

--- a/t/openhvf/cli.t
+++ b/t/openhvf/cli.t
@@ -18,6 +18,7 @@ BEGIN {
 }
 
 use_ok('OpenHVF::CLI');
+use_ok('OpenHVF::Proxy::Cache');
 
 # Test help command returns success
 
@@ -201,6 +202,43 @@ SKIP: {
     is(OpenHVF::CLI->run("--project=$project", '--quiet', 'cache', 'clear'),
 	0, 'bare cache clear succeeds');
     is(scalar @{ $cache->list }, 0, 'bare clear removes everything');
+}
+
+# The proxy's downloads share cache_dir with the images and nothing else
+# bounds them, so the same command prunes both: --stale keeps the OpenBSD
+# version the invoked VM installs, bare clear keeps nothing
+{
+    my $project = _cache_project();
+    my $proxy = OpenHVF::Proxy::Cache->new("$project/cache");
+
+    _fake_download($project, '7.8/arm64/base78.tgz');
+    _fake_download($project, '7.7/arm64/base77.tgz');
+    is(scalar @{ $proxy->list }, 2, 'two cached downloads before pruning');
+
+    is(OpenHVF::CLI->run("--project=$project", '--quiet',
+	    'cache', 'clear', '--stale'),
+	0, 'cache clear --stale succeeds');
+
+    is_deeply([map { $_->{url} } @{ $proxy->list }],
+	['http://cdn.openbsd.org/pub/OpenBSD/7.8/arm64/base78.tgz'],
+	'--stale keeps the version the configured VM installs');
+
+    is(OpenHVF::CLI->run("--project=$project", '--quiet', 'cache', 'clear'),
+	0, 'bare cache clear succeeds');
+    is(scalar @{ $proxy->list }, 0, 'bare clear empties the proxy too');
+}
+
+# Listing reports the proxy as well, so neither half of cache_dir is
+# invisible to someone deciding whether to prune
+{
+    my $project = _cache_project();
+    _fake_download($project, '7.7/arm64/base77.tgz');
+
+    my $err = _capture_stderr($project, 'cache', 'list');
+    like($err, qr/Proxy downloads/, 'cache list reports the proxy store');
+    like($err, qr/OpenBSD 7\.7/, 'broken down by version');
+    like($err, qr/No cached images/,
+	'and still says the images are empty');
 }
 
 # clear refuses while a VM whose disk is backed by the entry is running
@@ -426,6 +464,41 @@ sub _capture_stdout
     close $saved;
 
     return $out;
+}
+
+# The logger writes to stderr, so the human listing is captured apart
+# from the scriptable output above
+sub _capture_stderr
+{
+    my ($project, @args) = @_;
+    my $err = '';
+
+    open my $saved, '>&', \*STDERR or die $!;
+    close STDERR;
+    open STDERR, '>', \$err or die $!;
+
+    OpenHVF::CLI->run("--project=$project", @args);
+
+    close STDERR;
+    open STDERR, '>&', $saved or die $!;
+    close $saved;
+
+    return $err;
+}
+
+# A cached proxy download, seeded on disk rather than through store(),
+# whose cache_path() wants URI - a develop dependency
+sub _fake_download
+{
+    my ($project, $rel) = @_;
+    my $dir = "$project/cache/proxy/cdn.openbsd.org/pub/OpenBSD/$rel";
+
+    $dir =~ m{\A(.*)/} and make_path($1);
+    open my $fh, '>', $dir or die $!;
+    print $fh 'not a real file set';
+    close $fh;
+
+    return $dir;
 }
 
 # A complete-looking cache entry without the cost of a real image

--- a/t/openhvf/proxy-cache.t
+++ b/t/openhvf/proxy-cache.t
@@ -1,0 +1,131 @@
+#!/usr/bin/env perl
+# ex:ts=8 sw=4:
+# OpenHVF::Proxy::Cache pruning: the only thing that bounds the proxy's
+# on-disk store of OpenBSD downloads
+#
+# Separate from proxy.t, which skips itself without HTTP::Daemon and
+# LWP::UserAgent.  Those are develop dependencies, so a CI run that
+# installs the test set skips that whole file - and this is code that
+# deletes directories under a user's cache, which must be exercised on
+# every run rather than only where the VM harness can run.
+#
+# Trees are seeded directly rather than through store(), whose
+# cache_path() wants URI - also develop-only, arriving with LWP.  Pruning
+# reads the filesystem layout and never a URL, so the seam is real and
+# not a workaround.
+
+use v5.36;
+use Test::More;
+use FindBin qw($RealBin);
+use lib "$RealBin/../../lib";
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+
+use_ok('OpenHVF::Proxy::Cache');
+
+# _seed($tmpdir, $relative_path, $bytes):
+#	Write a cached file of $bytes bytes, creating its tree.
+sub _seed
+{
+	my ($tmpdir, $rel, $bytes) = @_;
+	my $path = "$tmpdir/proxy/$rel";
+
+	$path =~ m{\A(.*)/} and make_path($1);
+	open my $fh, '>', $path or die "open $path: $!";
+	print $fh 'x' x $bytes;
+	close $fh;
+
+	return $path;
+}
+
+my $MIRROR = 'cdn.openbsd.org/pub/OpenBSD';
+
+# A version bump left the whole previous version's file sets behind for
+# good: unreadable afterwards, since every is_cacheable() pattern is
+# version-scoped, and still carried by every copy of the directory a CI
+# cache makes.
+{
+	my $tmpdir = tempdir(CLEANUP => 1);
+	my $cache = OpenHVF::Proxy::Cache->new($tmpdir);
+
+	_seed($tmpdir, "$MIRROR/7.8/arm64/base78.tgz", 100);
+	_seed($tmpdir, "$MIRROR/7.8/arm64/SHA256", 10);
+	_seed($tmpdir, "$MIRROR/7.7/arm64/base77.tgz", 200);
+	_seed($tmpdir, "$MIRROR/syspatch/7.7/arm64/001_x.tgz", 50);
+
+	# No version in the path, so prune must leave it: a cache under
+	# $HOME is the wrong place to delete on a guess
+	_seed($tmpdir, 'example.com/loose.txt', 5);
+
+	is($cache->size, 365, 'four versioned files and one loose one');
+
+	my $removed = $cache->prune('7.8');
+	is(scalar @$removed, 2, 'both 7.7 trees pruned');
+
+	# Two trees, both 7.7: the release sets and the syspatch sets
+	is_deeply([sort map { $_->{version} } @$removed], ['7.7', '7.7'],
+	    'each names the version it held');
+	is_deeply([sort { $a <=> $b } map { $_->{size} } @$removed],
+	    [50, 200], 'and the bytes it freed');
+
+	my @left = sort map { $_->{url} } @{$cache->list};
+	is_deeply(\@left,
+	    [
+		"http://$MIRROR/7.8/arm64/SHA256",
+		"http://$MIRROR/7.8/arm64/base78.tgz",
+		'http://example.com/loose.txt',
+	    ],
+	    'the kept version and the unversioned file survive');
+	is($cache->size, 115, 'and the freed bytes are gone');
+
+	# The directory, not just its files: the tree is what a CI cache
+	# uploads and downloads on every key rotation
+	ok(!-e "$tmpdir/proxy/$MIRROR/7.7",
+	    'the pruned release directory is gone');
+	ok(!-e "$tmpdir/proxy/$MIRROR/syspatch/7.7",
+	    'the pruned syspatch directory is gone');
+	ok(-d "$tmpdir/proxy/$MIRROR/7.8",
+	    'the kept version directory remains');
+
+	is_deeply($cache->prune('7.8'), [], 'pruning twice removes nothing');
+}
+
+# Several versions kept at once, and a host that has nothing under
+# pub/OpenBSD at all
+{
+	my $tmpdir = tempdir(CLEANUP => 1);
+	my $cache = OpenHVF::Proxy::Cache->new($tmpdir);
+
+	_seed($tmpdir, "$MIRROR/7.6/arm64/base76.tgz", 10);
+	_seed($tmpdir, "$MIRROR/7.7/arm64/base77.tgz", 20);
+	_seed($tmpdir, "$MIRROR/7.8/arm64/base78.tgz", 40);
+	_seed($tmpdir, 'ftp.example.org/elsewhere/file.tgz', 80);
+
+	my $removed = $cache->prune('7.7', '7.8');
+	is_deeply([map { $_->{version} } @$removed], ['7.6'],
+	    'only the version named by neither is pruned');
+	is($cache->size, 140, 'the other host is untouched');
+}
+
+# Keeping a version that is not there removes everything that is
+{
+	my $tmpdir = tempdir(CLEANUP => 1);
+	my $cache = OpenHVF::Proxy::Cache->new($tmpdir);
+
+	_seed($tmpdir, "$MIRROR/7.7/arm64/base77.tgz", 30);
+
+	is(scalar @{$cache->prune('7.9')}, 1,
+	    'an absent version keeps nothing');
+	is($cache->size, 0, 'the cache is empty');
+}
+
+# Never written to, so proxy/ holds no host directories at all
+{
+	my $tmpdir = tempdir(CLEANUP => 1);
+	my $cache = OpenHVF::Proxy::Cache->new($tmpdir);
+
+	is_deeply($cache->prune('7.8'), [],
+	    'prune on an empty cache is a no-op');
+}
+
+done_testing();


### PR DESCRIPTION
Two CI caching gaps, and a test tier so neither can come back silently.

## `setup-perl` installs and caches its own dependencies

Every workflow that set up Perl followed it with its own `make deps-*` step, and nothing cached the result — each job rebuilt CryptX, Net::SSH2, Math::BigInt::GMP and Perl::Critic from source.

The action now takes one input naming the environment — `runtime`, `test` (default) or `develop`, the same column `deps/Linux.txt` uses — and installs it itself, so a consumer is one step rather than two and cannot forget the second. An unknown value fails the step immediately instead of resolving to a `make deps-typo` many minutes in.

```yaml
- name: Setup Perl
  uses: ./.github/actions/setup-perl
  with:
    dependencies: test # develop in integration.yml
```

The `local::lib` tree is cached around the install:

- The key covers exactly what decides its contents — the environment, the interpreter, and the manifest and script that name and install the modules. Not the `Makefile`, which changes for unrelated reasons and would rebuild the tree each time.
- It is computed once and read by both the restore and the save step: the cache API rejects a write to an existing key, so two copies that drifted apart would miss on every run and then fail to store.
- perl's version and archname are in the key because the tree holds compiled XS — a runner image that bumps perl, or the arm64 runner, must not restore `.so` files it cannot load.
- The install stays unconditional. The OS packages are deliberately not cached (apt's archive directory is root-owned, and the win would be the download only, never dpkg's unpack), and running `scripts/deps` over a restored tree is also what verifies the tree is usable.

`libssh2-1-dev` leaves the bootstrap: `deps/Linux.txt` already names it, ahead of Net::SSH2 in the same environment, so it was installed twice and for runtime setups that never need it.

`deps/Linux.txt` joins `integration.yml`'s path filters. It now rotates a cache key that workflow populates, and by the rule stated at the top of that file an input which can rotate a key must also be able to start the run that rebuilds it.

## The proxy's downloads are pruned with the images

`openhvf cache clear --stale` is named for bounding `cache_dir` but built an `ImageCache` and pruned `installed/` alone. The proxy's copies of everything the installer downloaded live in the same directory and nothing bounded them: a version bump in `.openhvfrc` left the whole previous version's file sets behind for good — unreadable afterwards, since every `is_cacheable()` pattern is version-scoped — and `cache list` did not print them either, so the half of `cache_dir` that grew without limit was also the half nobody could see. In CI that dead weight is uploaded and downloaded on every cache key rotation.

`Proxy::Cache` gains `prune(@keep)`, removing the download tree of every OpenBSD version other than the ones named, release sets and syspatch sets alike. Whole directories rather than matching files, since the tree is what a CI cache copies. A directory whose name is not a version is left alone — in practice there are none, and a cache under `$HOME` is the wrong place to delete on a guess.

The CLI prunes it as a second pass over `cache_dir` rather than a branch inside the image loop: the two caches share nothing else, and a re-downloadable file set needs none of the running-VM and orphaned-disk checks an image does. `--stale` keeps the version the invoked VM installs, the same one-VM scope the image prune already documents. `cache list` now ends with what the proxy holds, per version — the granularity `--stale` prunes at. The prune runs before the cache post-step, so what a version bump orphans is dropped on the run that bumped it.

## Tests

- `t/ci/` is a new tooling tier: nothing under `.github/` runs outside a runner, so it reads the workflows and the composite action as text and asserts the invariants that only fail in CI — every consumer passes an environment the action accepts, no workflow runs its own `make deps*`, and the cache key hashes every input that decides what it caches (`hashFiles` over a missing path returns empty, silently collapsing a key rather than erroring). Checked negatively too: a workflow that regains its own `make deps-test` step, or passes an unknown environment, fails it.
- `t/openhvf/proxy-cache.t` covers pruning. Separate from `proxy.t`, which skips itself without HTTP::Daemon and LWP::UserAgent — develop dependencies, so a CI run installing the test set skipped that whole file, and this is code that deletes directories under a user's cache. Trees are seeded on disk rather than through `store()`, whose `cache_path()` wants URI (also develop-only): pruning reads the filesystem layout and never a URL.
- `t/openhvf/cli.t` covers the prune and the listing through the CLI.

`make check` passes, as does the website build after the `openhvf.1` edit.

## Left out

Pointing the guest's `pkg_add` and `cpanm` at the proxy after install. `$proxy_vm_url` is consumed at exactly one place today — `install.exp`'s "HTTP proxy URL?" prompt — so provisioning's downloads go straight to the OpenBSD mirror and CPAN. Worth doing for reliability more than speed, and it needs a check of whether the installer persists the proxy setting first.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QB24a4FRpUjan2KUKiAPfk)_