### PR TITLE
docs(daemon): revise plan 005 after cold-subagent review

### DIFF
--- a/plans/005-pledge-unveil/design.md
+++ b/plans/005-pledge-unveil/design.md
@@ -31,11 +31,14 @@ hold it.
    citing it, like every other protocol in the tree.
 5. Failures fail closed: an unappliable restriction on OpenBSD is fatal.
 6. The restrictions are proven by tests that fail if they are silently absent.
+7. **No new startup failure.** Every configuration that starts today still
+   starts. An unveil inventory lists what the daemon may reach; a path that is
+   legitimately absent must not become a refusal to boot.
 
 ## Non-goals
 
 - **Two-stage or per-phase pledges.** One promise set, applied once; tightening
-  after pairing is a later refinement. Correctness now beats minimality now.
+  after pairing is a later refinement.
 - **Privilege separation** into helper processes (`TODO.md:489`), and **pledging
   `hapctl`** — both follow-ups, the latter cheap once `FuguLib::Sandbox` exists.
 - **Weakening the documentation.** `README.md`, `CLAUDE.md` and `web/` keep
@@ -43,6 +46,11 @@ hold it.
 - **Fixing `pv=1`.** `HAP.pm:1087` sends protocol version `1`, not `1.1`,
   because mdnsd splits TXT strings on `.` with no escape. A native client hands
   mdnsd the same payload, so the constraint is unchanged.
+- **Fixing SIGHUP.** `etc/rc.d/openhapd:16-18` reloads by sending SIGHUP, which
+  `bin/openhapd:177` registers as a graceful _exit_ — so `rcctl reload` stops
+  the daemon today. Pre-existing bug, out of scope; phase 5 records it in
+  `TODO.md`. Nothing in this design may justify itself by a reload that does not
+  exist.
 - **A full mdnsd client.** Browse, resolve and lookup are specified in phase 1
   because they share the framing and the enum, but only publish is implemented.
 - Bonjour/Avahi backends; mDNS stays OpenBSD-only, exactly as today.
@@ -50,41 +58,58 @@ hold it.
 ## Should the mDNS client be a fourth sub-project?
 
 No. The precedent splits on **lifecycle and audience**, not subject matter:
-OpenHVF earned a namespace by being a separate _program_, with its own entry
-point, config format and man page section, development-only and never installed.
-An mdnsd client is the other shape, FuguLib's — a shipped library with no CLI,
-no config, no user of its own — and so is a pledge wrapper. A fourth namespace
-buys nothing and costs `install` rules, a man-page rename loop, a test
-directory, a `CLAUDE.md` and web index wiring, for two modules. Precedent also
-says FuguLib _absorbs_: `OpenHAP::Log` became `FuguLib::Log`, and this design
-does the same to `OpenHAP::MDNS`. Revisit when the client grows what OpenHVF has
-— consumers outside this repo, or a `bin/` tool.
+OpenHVF earned a namespace by being a separate _program_ — own entry point,
+config format and man page section, development-only, never installed. An mdnsd
+client is FuguLib's shape, and so is a pledge wrapper: a shipped library with no
+CLI, no config, no user of its own. Precedent also says FuguLib _absorbs_
+(`OpenHAP::Log` became `FuguLib::Log`). Revisit when the client grows consumers
+outside this repo, or a `bin/` tool.
+
+FuguLib going from six modules to nine is a documentation change too:
+`CLAUDE.md:14-15` enumerates the namespace's concerns and
+`web/fugulib.body.html:8` states "Six modules". Phase 5 owns both.
 
 ## Architecture
 
 Three new `FuguLib` modules — `Sandbox` (pledge/unveil) and `MDNS` (the mdnsd
-group protocol) over `Imsg` (framing) — a new `spec/MDNS*.md` family, one
-deletion, one new call site.
+group protocol) over `Imsg` (framing) — a new hand-authored `spec/MDNS*.md`
+family, one deletion, one new call site.
 
 ### The mDNS protocol reference
 
-Implementing a wire protocol makes this a protocol reference's job, so phase 1
-extracts one into `spec/` before any client code exists: `MDNS.md` (index),
-`MDNS-Imsg.md` (framing) and `MDNS-Control.md` (control socket, `imsg_type`
-enum, group publish sequence, `struct mdns_service` ABI, TXT encoding). A new
-`spec-mdns` skill owns them, reading openmdns from `external/` plus measurements
-taken on the installed port — the same shape as `spec-hap` and `spec-mqtt`.
-Hand-writing them would make them the first hand-maintained files in a directory
-whose `CLAUDE.md` forbids exactly that.
+Implementing a wire protocol against another daemon's in-memory struct layout
+makes this a protocol reference's job, so phase 1 writes one into `spec/` before
+any client code exists: `MDNS.md` (index), `MDNS-Imsg.md` (framing) and
+`MDNS-Control.md` (control socket, `imsg_type` enum, publish sequence,
+`struct mdns_service` ABI, TXT encoding).
 
-It is also the right answer to the ABI coupling, this design's principal risk:
-the `IMSG_CTL_GROUP_ADD_SERVICE` payload is a raw `struct mdns_service`, binding
-us to mdnsd's in-memory layout, padding and all. A spec section recording the
+Hand-authored and hand-maintained, per `spec/CLAUDE.md:24` ("These are
+hand-maintained documents. Edit them in place"), with every claim citing the
+upstream file and line — exactly how `HAP.md` and `MQTT.md` are maintained.
+There is no generator skill: the spec-generation and reference-fetching skills
+were removed in `2da2b57`, and `spec/` is curated by hand.
+
+That is the right answer to the ABI coupling, this design's principal risk: the
+`IMSG_CTL_GROUP_ADD_SERVICE` payload is a raw `struct mdns_service`, binding us
+to mdnsd's in-memory layout, padding and all. A spec section recording the
 measured offsets plus a byte-exact conformance test citing it turns a hidden
 assumption into a checked one. `spec/HAP-mDNS.md` does not absorb this and must
 not: it says _what_ HomeKit requires be advertised, while `MDNS-*.md` says _how_
-to advertise it on OpenBSD — different upstreams, different owning skills, and
-`spec-hap` would overwrite anything added to the former.
+to advertise it on OpenBSD.
+
+### Measure before implementing
+
+Headers give field lists, not offsets, padding, or what a real client puts on
+the wire — and for one part of the protocol, reading upstream suggests our
+intended sequence may not work at all. Phase 1 measures inside the OpenBSD VM
+(task 1.2 has the detail); phase 2 is written against the measurements, not
+against this document. Three **gate phase 2's API**: the `imsg_hdr` layout from
+the installed header (its field set changed in the 2024 imsg rework, so any
+layout written here is a guess); whether same-socket `GROUP_RESET` actually
+replaces a TXT record, or silently re-announces the stale one, or crashes mdnsd;
+and whether the group name must equal the service instance name. Phase 1 also
+captures a byte-exact publish conversation, the `struct mdns_service` offsets,
+and the daemon's real path set — the last being phase 4's input.
 
 ### `FuguLib::Imsg` and `FuguLib::MDNS`
 
@@ -101,38 +126,54 @@ sequenceDiagram
     Note over openhapd,mdnsd: socket held open for the daemon's lifetime
 ```
 
-`FuguLib::Imsg` is the framing layer — a 16-byte native-endian header plus
-payload, and buffered reads yielding whole messages; pure serialisation,
-unit-testable with no daemon present. `FuguLib::MDNS` is the protocol layer:
-`connect`, `publish_service`, `update_txt` (`GROUP_RESET` → `GROUP_ADD_SERVICE`
-→ `GROUP_COMMIT` on the same socket, no reconnect), `withdraw` (close), and
-translation of the reply and error types into logged outcomes.
+`FuguLib::Imsg` is the framing layer — a native-endian header (layout from the
+installed `imsg.h`) plus payload, and buffered reads yielding whole messages;
+pure serialisation, unit-testable with no daemon present. `FuguLib::MDNS` is the
+protocol layer: `connect`, `publish_service`, `update_txt`, `withdraw` (close),
+`is_published`, and translation of reply and error types into reported outcomes.
+
+`update_txt`'s mechanism is decided by measurement. If same-socket `GROUP_RESET`
+does not work it reconnects and republishes — which is what `MDNS.pm:176-183`
+does today, and which keeps `unix` in the promise set for a reason that outlives
+startup.
+
+**Neither module logs.** FuguLib's convention is that the caller decides:
+`Privdrop` dies, `Process` reports through `on_error`/`on_success` callbacks,
+and no module under `lib/FuguLib/` references a logger. These two follow
+`Process`, so `lib/FuguLib/` never names `$OpenHAP::logger` and `t/fugulib/*.t`
+needs no OpenHAP globals.
 
 `OpenHAP::MDNS` and its `.pod` are deleted. `bin/openhapd` and
-`HAP::update_txt_records` (`HAP.pm:148`) talk to `FuguLib::MDNS`; the
-HAP-specific `_hap`/`tcp`/TXT knowledge stays where it already lives, in
-`HAP::get_mdns_txt_records`.
+`HAP::_refresh_mdns` (`HAP.pm:148`) talk to `FuguLib::MDNS`. The HAP-specific
+`hap`/`tcp` knowledge and the TXT _formatting_ — `key=value` pairs joined in
+sorted order, currently `MDNS.pm:85-87` — move into `OpenHAP::HAP` beside
+`get_mdns_txt_records`, which today returns only a bare hashref. `FuguLib::MDNS`
+takes `txt` as a formatted string and knows nothing of HomeKit.
 
 ### `FuguLib::Sandbox`
 
 One module covering both mechanisms, because they are one decision applied at
 one point; a module named `Pledge` that also unveils would misname itself.
 
-- `is_supported()` — true only on OpenBSD.
+- `is_supported()` — true only on OpenBSD. This, not a log line, is how a caller
+  or test tells enforcement from emulation.
 - `pledge(promises => $string)` — 1 on success, `die` on failure.
-- `unveil(path => $perms, ...)` — applies each pair, `die` on failure.
-- `unveil_lock()` — `unveil(undef, undef)`; no path can be added afterwards.
+- `unveil(paths => [[$path, $perms], ...])` — applies pairs **in order**,
+  reporting which failed. An ordered list, not a hash: unveil replaces rather
+  than merges a path's permissions, so parent/child order is load-bearing.
+  Entries carry a required/optional disposition (see the unveil view).
+- `unveil_lock()` — calls `OpenBSD::Unveil::unveil()` with **no arguments**.
+  Passing two `undef`s reaches the C layer as `unveil("", "")` and fails with
+  `ENOENT`.
 
 On OpenBSD the base-system `OpenBSD::Pledge`/`OpenBSD::Unveil` load at `use`
 time and failing to load is fatal — there, their absence means a broken Perl,
 not an unsupported system. Off OpenBSD every method returns 1 having done
-nothing, logging once at debug so a misread test cannot mistake a no-op for
-enforcement.
+nothing.
 
 ### The promise set
 
-One string, applied after mDNS registration and before `$hap->run()`. Every
-promise is there for a reason that outlives startup:
+One string, applied after mDNS registration and before `$hap->run()`:
 
 ```
 stdio rpath wpath cpath fattr flock inet dns unix
@@ -147,61 +188,93 @@ stdio rpath wpath cpath fattr flock inet dns unix
 | `flock`       | `Storage.pm:62,82,139,155`                                       |
 | `inet`        | listen socket built in `HAP::run` (`HAP.pm:158`), MQTT reconnect |
 | `dns`         | MQTT reconnect resolving `mqtt_host` when it is a name           |
-| `unix`        | the held `/var/run/mdnsd.sock` connection                        |
+| `unix`        | reconnecting to mdnsd, **if** `update_txt` must republish        |
+
+`unix` is the one conditional entry. An already-connected socket needs only
+`stdio` to read and write — `PLEDGE_UNIX` gates `socket`, `connect` and `bind`,
+all of which happen before the pledge — so `unix` is required exactly when
+measurement says `update_txt` reconnects. If same-socket replacement works, it
+comes out; phase 3 does not carry a promise nothing exercises.
 
 Deliberately absent: `proc exec` (phase 2 removes the only `exec`), `prot_exec`
 (below), `getpw` and `id` (`getpwnam` and privdrop precede pledge),
 `sendfd recvfd`. Syslog needs none — `Sys::Syslog` in native mode reaches
-`sendsyslog(2)`, always permitted. The constraint on future work is the point:
-SIGHUP-as-reload (`TODO.md:141`) must not re-exec, or `exec` returns and the
-benefit goes.
+`sendsyslog(2)`, always permitted.
 
 ### Late loading, and why `prot_exec` stays out
 
-Perl loads code lazily, and two such loads happen _after_ the pledge point:
-`Math::BigInt` pulls in `Math::BigInt::GMP` on first use — during pairing — and
-`OpenHAP::MQTT` `require`s `Net::MQTT::Simple`, which a failed startup
-connection defers to the first reconnect. `dlopen` of an XS object needs
-`prot_exec`, so both are handled beforehand: **preload** every XS dependency and
-force one GMP-backed `Math::BigInt` operation, and **unveil `@INC` read-only**
-so pure-Perl lazy loads still resolve. That second half is the deliberate
-simplicity trade — weaker than proving every load is preloaded, far more robust
-than discovering a missed `require` in production.
+`prot_exec` is excluded because **nothing dlopens after startup**. Every XS
+dependency is pulled in by a compile-time `use` on the graph reachable from
+`bin/openhapd:7` — the five crypto modules at `Crypto.pm:5-10`, `JSON::XS` and
+`Digest::SHA` at `HAP.pm:6,8`, and `Math::BigInt try => 'GMP'` at `SRP.pm:9` via
+`HAP.pm:13` → `Pairing.pm:5`. `Math::BigInt` resolves its backend inside
+`import`, not at first arithmetic, so GMP's shared object is open before
+`GetOptions` runs; there is no pairing-time load to preload.
+
+The one genuine late load is `require Net::MQTT::Simple` at `MQTT.pm:50`,
+deferred to the first reconnect when the startup connection fails. It is **pure
+Perl**, so it needs no `prot_exec` — only `rpath` and a reachable library tree.
+So: unveil the library directories read-only, and resolve it before the pledge
+under `eval` so its transitive dependencies load while loading is unrestricted.
+It stays optional — the only `cpan` runtime line in `deps/OpenBSD.txt`, and
+`bin/openhapd:88-97` deliberately keeps serving HomeKit without it. Unveiling
+the library tree read-only is the deliberate simplicity trade: weaker than
+proving no module ever loads late, far more robust than discovering a missed
+`require` in production.
 
 ### The unveil view
 
-Read-only for the config file, `/dev/urandom`, the resolver files and the `@INC`
-directories; read-write-create for `$db_path`; write for the daemon log;
-read-write for `/var/run/mdnsd.sock`, because `connect(2)` needs write
-permission on the path. Then `unveil_lock()`, then `pledge`; the inventory is in
-`plan-4.md`. Both come after privdrop: unveil only removes reachability, so
-applying it as `_openhap` keeps the root-only `chown` loop
-(`bin/openhapd:118-137`) working.
+Read-only for the config file, `/dev/urandom`, the resolver files and the Perl
+library directories; read-write-create for `$db_path`; write for the daemon log;
+read-write for `/var/run/mdnsd.sock` if `update_txt` reconnects. Then
+`unveil_lock()`, then `pledge`. The inventory is in `plan-4.md`, derived from
+measurement rather than from reading code. Two rules it obeys:
+
+- **Per-path disposition.** Each entry is _required_ (absent means a broken
+  install: `$db_path`, `/dev/urandom`, the library directories) or _optional_
+  (legitimately absent: the config file, the log file, the mdnsd socket, the
+  resolver files). Required paths are fatal when missing; optional paths are
+  skipped. Without this split goal 7 fails — a missing `/etc/openhapd.conf`, an
+  `mdnsd` that is not running, or a first `openhapd -f` on a fresh box would
+  each refuse to start where they work today.
+- **Library directories are enumerated, not derived from live `@INC`.**
+  `bin/openhapd:4-5` prepends `"$RealBin/../lib"`, which on an installed layout
+  is `/usr/local/lib` — every third-party library under `/usr/local`, not a Perl
+  tree. And `MQTT.pm:42-45` mutates `@INC` inside `mqtt_connect`, so a derived
+  set depends on whether the startup connect has run.
+
+Both come after privdrop: unveil only removes reachability, so applying it as
+`_openhap` keeps the root-only `chown` loop (`bin/openhapd:118-137`) working.
 
 ## Contracts
 
 - On OpenBSD, `openhapd` never reaches `HAP::run` without both restrictions
   applied; failing to apply either is fatal first. Off OpenBSD, behaviour is
   byte-identical to today.
+- Every configuration that starts today still starts. A missing optional path
+  degrades or is skipped; it never refuses to boot.
 - The socket to mdnsd is the advertisement's lifetime. Closing it withdraws the
   service — that is how shutdown unregisters. No signal, no child, no kill.
 - A `FuguLib::MDNS` failure stays non-fatal, exactly as `OpenHAP::MDNS` failure
-  is today: HAP still serves, discovery is degraded, a warning is logged.
+  is today: HAP still serves, discovery is degraded, a warning is logged by the
+  caller. `OpenHAP::HAP` must not drive TXT updates onto an unpublished handle —
+  today that guard lives at `MDNS.pm:181`, inside the module being deleted.
+- `FuguLib` modules do not log. They return outcomes; callers log.
 - mDNS advertisement is lost if `mdnsd` restarts and is not re-established until
-  `openhapd` restarts. Parity with today — the `mdnsctl` child dies the same way
-  — so it is documented, not fixed.
-- The `struct mdns_service` layout lives in `spec/MDNS-Control.md` and is
-  verified by a conformance test citing it, failing loudly rather than
-  truncating silently.
-- `spec/MDNS*.md` are generated, not hand-maintained: `spec-mdns` is how they
-  change, and citations that rot are caught by `make spec-coverage`.
+  `openhapd` restarts. Parity with today, so it is documented, not fixed.
+- The `struct mdns_service` and `imsg_hdr` layouts live in `spec/MDNS-*.md` as
+  measured on a named OpenBSD release and architecture, verified by conformance
+  tests citing them, failing loudly rather than truncating silently.
+- `spec/MDNS*.md` are hand-maintained, like the rest of `spec/`; citations that
+  rot are caught by `make spec-coverage`.
 
 ## Strategy
 
-Five phases, each with its own `plan-N.md`: (1) the mDNS protocol reference, (2)
-the mDNS client without exec, (3) `FuguLib::Sandbox` and pledge, (4) unveil, (5)
-proof and operability. Phases 1–2 must precede 3 — `proc exec` cannot leave the
-promise set while a child is spawned.
+Five phases, each with its own `plan-N.md`: (1) the protocol reference and the
+measurements, (2) the mDNS client without exec, (3) `FuguLib::Sandbox` and
+pledge, (4) unveil, (5) proof and operability. Phases 1–2 must precede 3 —
+`proc exec` cannot leave the promise set while a child is spawned — and phase
+1's measurements gate phase 2's API.
 
 Once a phase lands, the code, tests, spec, and man pages are the source of
 truth.

--- a/plans/005-pledge-unveil/plan-1.md
+++ b/plans/005-pledge-unveil/plan-1.md
@@ -1,56 +1,95 @@
-# Phase 1 — The mDNS protocol reference
+# Phase 1 — The mDNS protocol reference and the measurements
 
-Extract the mdnsd control protocol into `spec/` before writing a line of client
-code, and teach the coverage tooling to see it. Independently shippable: it adds
-a protocol reference and the citation support for it, with no behaviour change.
+Write the mdnsd control protocol into `spec/` before writing a line of client
+code, teach the coverage tooling to see it, and take the measurements phase 2's
+API depends on. Independently shippable: it adds a protocol reference, permanent
+citation support for it, and a recorded set of measurements, with no behaviour
+change.
 
 This phase exists because phase 2 implements a wire protocol against another
 daemon's in-memory struct layout. Deriving that from a header while writing the
-client would bury the assumptions in Perl comments. Extracting it first puts
+client would bury the assumptions in Perl comments. Writing it down first puts
 them in the one place this repo already trusts for protocol facts.
 
 ## Tasks
 
-### 1.1 Add openmdns to `external/`
+### 1.1 Read the upstream sources
 
-`.claude/skills/fetch-external/SKILL.md` clones five reference sources; add a
-sixth:
+The spec-generation and reference-fetching skills were removed in `2da2b57`, and
+`external/` is gitignored and not required to exist. Clone what you need locally
+and cite it; nothing in this phase depends on a fetcher skill or on a populated
+`external/`:
 
 ```sh
 git clone --depth 1 https://github.com/haesbaert/mdnsd external/openmdns
 ```
 
-- Add `external/openmdns/mdnsd/mdns.h` and `external/openmdns/libmdns/mdnsl.c`
-  to the skill's "verify the key paths exist" list.
-- Add a Source Map row: openmdns — mdnsd control protocol,
-  `struct mdns_service`, the `imsg_type` enum — best for the mdnsd IPC protocol.
-- Note in the skill that `haesbaert/mdnsd` is upstream but the OpenBSD
-  `net/openmdns` port may carry patches, and **the installed port is
-  authoritative for us**. `cynix/openmdns` is a maintained fork; if the port
-  tracks it, clone that instead and say so in the provenance.
+The sources that matter are `mdnsd/mdns.h` (the `imsg_type` enum, the structs,
+the socket path), `mdnsd/control.c` (the server side of the group state machine
+— `control_group_add`, `control_group_reset`, `control_group_add_service`,
+`control_group_commit`, `control_notify_pg`, `pg_get`), `libmdns/mdnsl.c`
+(client sequences and payload shapes) and `mdnsctl/` (what a real client sends).
 
-### 1.2 Measure the ABI on the installed port
+`haesbaert/mdnsd` is upstream, but the OpenBSD `net/openmdns` port may carry
+patches and **the installed port is authoritative for us**. `cynix/openmdns` is
+a maintained fork; if the port tracks it, read that instead and say so in the
+provenance. Base-system `imsg` framing is not in openmdns at all — the installed
+`/usr/include/imsg.h` is its authority.
 
-Upstream source gives the field list; it does not give offsets, padding, or what
-`mdnsctl` actually puts on the wire. Both measurements happen inside the OpenBSD
-VM (`make integration`, or the `openhvf` skill for an interactive shell) and
-their output is what the spec records:
+### 1.2 Take the measurements
 
-1. Compile a short C program against the installed `/usr/local/include/mdns.h`
-   printing `sizeof(struct mdns_service)` and `offsetof` for every field.
-2. `ktrace -i mdnsctl publish ...` then `kdump`, to capture the `write(2)`
-   payloads on the control socket. The first four messages are the conversation
-   phase 2 replicates.
+Six measurements, all inside the OpenBSD VM (`make integration`, or the
+`openhvf` skill for an interactive shell). Their output is what the spec
+records, and items 2, 4 and 5 **gate phase 2's API** — phase 2 does not start
+until they are settled.
 
-Capture 2 settles three things no header can: whether `app` carries `hap` or
-`_hap` (`mdnsctl/parser.c` may normalise what `MDNS.pm:93` passes as `hap`),
-what `mdnsctl` puts in `target`/`addr`, and what `priority`/`weight` default to.
+1. **`struct mdns_service` ABI.** Compile a short C probe against the installed
+   `/usr/local/include/mdns.h` printing `sizeof` and `offsetof` for every field.
+2. **`imsg_hdr` layout**, from the installed `/usr/include/imsg.h`. Do not
+   assume it: the 2024 imsg rework widened `len` to `uint32_t` and removed
+   `flags`, so a release before and after that change have different headers.
+   Record the field set, the widths, whether `len` includes the header,
+   `MAX_IMSGSIZE`, and the maximum _payload_ that follows from it
+   (`MAX_IMSGSIZE` bounds the whole message, so the payload bound is
+   `MAX_IMSGSIZE - sizeof(imsg_hdr)`).
+3. **A byte-exact publish conversation.** `ktrace -i mdnsctl publish ...` then
+   `kdump`, capturing the `write(2)` payloads on the control socket. This
+   settles what no header can: whether `app` carries `hap` or `_hap`
+   (`mdnsctl/parser.c` may normalise what `MDNS.pm:93` passes as `hap`), what
+   `mdnsctl` puts in `target`/`addr`, and what `priority`/`weight` default to.
+   Note which bytes are sender-specific — the header carries the sender's pid —
+   because those cannot be replayed literally by a different process.
+4. **Whether same-socket TXT replacement works.** Send `GROUP_RESET` →
+   `GROUP_ADD_SERVICE` → `GROUP_COMMIT` on a held connection and check whether
+   the advertised TXT actually changes, by browsing from outside.
+   `control_group_reset` looks its group up with `pg_get(0, msg, NULL)` while
+   `control_group_add` created it with `pg_get(1, msg, c)`, and `pg_get` matches
+   on `pg->c == c` — so on upstream the reset may never find a
+   controller-created group, leaving it `PG_STA_COMMITED`, making
+   `control_group_add_service` reject it (it requires `PG_STA_NEW`), and leaving
+   `control_group_commit` to re-announce the **old** records while still
+   replying PROBING/ANNOUNCING/PUBLISHED. A client would read that as success
+   with a stale record. If the port fixed that lookup, check the other branch:
+   `pg_kill` frees the group, so the following commit may reach
+   `control_notify_pg(c, NULL, ...)` and dereference `pg->name`, killing mdnsd
+   and mDNS for the whole host. **Do this measurement in the VM, never against a
+   host you care about.** Whatever the outcome, record it — including
+   "same-socket reset does not work, republish instead", which is what
+   `MDNS.pm:176-183` does today.
+5. **Whether the group name must equal the service instance name.**
+   `control_group_add_service` appears to look the group up under the
+   _service's_ name, and `libmdns` appears to enforce
+   `strcmp(group, ms->name) != 0`. If so, `FuguLib::MDNS` must not expose them
+   as independent parameters.
+6. **The real path set**, for phase 4's unveil inventory: `kdump` a full pairing
+   plus an MQTT broker restart and list every path the daemon opens. This is the
+   only reliable way to catch resolver files (`/etc/hosts`, `/etc/resolv.conf`,
+   `/etc/services`, `/etc/protocols`), `/etc/localtime`, and whatever
+   `Net::MQTT::Simple` touches on reconnect. Record it here even though phase 4
+   consumes it — the VM run is the expensive part and this phase is already in
+   the VM.
 
-Also record the OpenBSD version of `/usr/include/imsg.h` — imsg framing is base
-system, not openmdns, and is not in `external/`. The installed header is the
-authority for it.
-
-Derived layout to check the measurement against (LP64; `MAXLABELLEN` 64,
+Derived layout to check measurement 1 against (LP64; `MAXLABELLEN` 64,
 `MAXPROTOLEN` 4, `MAXHOSTNAMELEN` 256, `MAXCHARSTR` = `MAXHOSTNAMELEN`):
 
 | offset | field      | C type           | bytes |
@@ -68,110 +107,121 @@ Derived layout to check the measurement against (LP64; `MAXLABELLEN` 64,
 | 860    | `addr`     | `struct in_addr` | 4     |
 
 864 bytes total. The `LIST_ENTRY` is mdnsd's own list linkage, two pointers
-wide, and goes on the wire as zeros. If the measurement disagrees, the
-measurement wins and the table in the spec is the measured one — this table is a
-cross-check, not a source.
+wide, and goes on the wire as zeros. **If the measurement disagrees, the
+measurement wins** and the table in the spec is the measured one — this table is
+a cross-check, not a source. Note that the two-pointer `LIST_ENTRY` and the 864
+total are LP64-specific; record the architecture measured on, because phase 2's
+encoder derives its size from the spec.
 
-### 1.3 The `spec-mdns` skill
+### 1.3 Write the spec files
 
-New `.claude/skills/spec-mdns/SKILL.md`, modelled on `spec-mqtt`: objective,
-preconditions (`fetch-external` first), primary sources, what to document, scope
-boundaries, output structure, formatting guidelines.
+Three hand-authored files, per `spec/CLAUDE.md`. **Numbered `##`/`###` headings
+throughout** — the inventory regex in `scripts/spec-coverage:81` matches only
+`##` and `###` with a leading number, so a `####` heading cannot be cited and a
+heading whose number is missing is invisible. Anything a conformance test needs
+to cite must be `##` or `###`.
 
-Points specific to this skill:
-
-- Primary sources are `external/openmdns/mdnsd/mdns.h` (enum, structs, socket
-  path), `external/openmdns/libmdns/mdnsl.c` (client sequences), and
-  `external/openmdns/mdnsctl/` (what a real client sends).
-- The ABI measurements from 1.2 are an input the skill cannot derive by reading
-  code. The skill must say so, and say that regeneration without a fresh
-  measurement carries the previous one forward with its provenance intact.
-- Scope: the control-socket protocol only. Not the mDNS wire protocol on the
-  network (RFC 6762/6763) — mdnsd owns that, and `spec/HAP-mDNS.md` already
-  covers what HomeKit needs advertised.
-- Provenance block near the top of `MDNS.md`, matching `MQTT.md`'s: extraction
-  date, `git -C external/openmdns rev-parse --short HEAD`, the installed port
-  version (`pkg_info -Q openmdns`), the OpenBSD release measured on, and the
-  `/usr/include/imsg.h` version.
-
-### 1.4 Write the spec files
-
-Three files, per the design. **Numbered `##`/`###` headings throughout** — the
-inventory regex in `scripts/spec-coverage:80` matches only `##` and `###` with a
-leading number, so a `####` heading cannot be cited and a heading whose number
-is missing is invisible. Anything a conformance test needs to cite must be `##`
-or `###`.
+Every claim cites the upstream file and line it came from, as the surrounding
+`spec/` files do. A provenance block near the top of `MDNS.md`, matching
+`MQTT.md`'s: the upstream repository and commit read, the installed port version
+(`pkg_info -Q openmdns`), the OpenBSD release and architecture measured on, and
+the `/usr/include/imsg.h` version. Measurements that a later edit does not redo
+carry forward with their provenance intact — say so explicitly, so a reader
+knows which numbers were re-measured and which were inherited.
 
 - `spec/MDNS.md` — index and overview. Glossary (imsg, control socket, group,
   service, probing, announcing, collision), the publish flow end to end, links
   to the topic files, provenance. Unhyphenated, so `spec-coverage` treats it as
   an index and does not count its sections.
-- `spec/MDNS-Imsg.md` — framing. Header field layout and byte order, `len`
-  counting the header, `MAX_IMSGSIZE`, partial reads and message boundaries,
-  `peerid`/`pid` semantics, and the fd-passing facility with an explicit note
-  that we do not use it and why (it would need `sendfd`/`recvfd` in the pledge).
-- `spec/MDNS-Control.md` — the control protocol. Socket path and permissions
-  (root:wheel, hence the `wheel` requirement at `bin/openhapd:116`), the full
-  `imsg_type` enum with its ordinal values, the group publish sequence, reply
-  and error semantics, the `struct mdns_service` ABI as measured, TXT string
-  encoding including the `.` delimiter and its no-escaping consequence, and
-  field length limits. Specify browse/resolve/lookup message shapes too — they
-  share the enum and framing, cost a paragraph each, and stop the file from
-  looking like it describes the whole protocol when it describes a third of it.
+- `spec/MDNS-Imsg.md` — framing, **as measured in 1.2 item 2**. Header field
+  layout and byte order, whether `len` counts the header, `MAX_IMSGSIZE` and the
+  derived payload bound, partial reads and message boundaries, `peerid`/`pid`
+  semantics (including that `pid` is sender-specific), and the fd-passing
+  facility with an explicit note that we do not use it and why (it would need
+  `sendfd`/`recvfd` in the pledge).
+- `spec/MDNS-Control.md` — the control protocol. Socket path and permissions,
+  the full `imsg_type` enum with ordinal values, the group publish sequence,
+  reply and error semantics, the `struct mdns_service` ABI as measured with its
+  architecture noted, TXT string encoding including the `.` delimiter and its
+  no-escaping consequence, field length limits, and — from measurements 4 and 5
+  — a section on TXT replacement and a section on the group/instance name
+  relationship. Specify browse/resolve/lookup message shapes too: they share the
+  enum and framing, cost a paragraph each, and stop the file from looking like
+  it describes the whole protocol when it describes a third of it.
 
-Include a byte-exact worked example of a full publish conversation, taken from
-the 1.2 capture. That example is what phase 2's conformance test replays.
+Include a byte-exact worked example of a full publish conversation from the 1.2
+item 3 capture, with the sender-specific bytes marked as such. That example is
+what phase 2's conformance test replays.
 
-### 1.5 Teach the tooling about the new family
+### 1.4 Teach the tooling about the new family
 
 - `scripts/spec-coverage:109` — extend the citation pattern from
   `(?:HAP|MQTT)[A-Za-z0-9-]*` to include `MDNS`. Without this, `[MDNS-Imsg §2]`
   never matches: the citation is not counted, and — worse — is not stale-checked
-  either, so it silently rots when the spec is regenerated.
-- `t/CLAUDE.md:58` documents that grep pattern; update it in lockstep, and
+  either, so it silently rots when the spec changes.
+- `t/CLAUDE.md:70` documents that grep pattern; update it in lockstep, and
   mention the new topic ↔ test mapping in the conformance section.
-- `spec/CLAUDE.md` — add the `MDNS.md` / `MDNS-*.md` bullet naming `spec-mdns`
-  as the owning skill.
-- `.claude/skills/fetch-external/SKILL.md` — the description line lists the
-  sources it fetches and the skills that need it; add openmdns and `spec-mdns`.
-- Check whether `.claude/skills/compliance-hap/SKILL.md` should learn about the
-  new spec family. It audits against `spec/HAP*.md`; an mdnsd-transport audit is
-  a separate concern and probably should not be folded in, but decide
-  deliberately rather than by omission.
+- `spec/CLAUDE.md` — add the `MDNS.md` / `MDNS-*.md` bullet to the Purpose list.
+  Do **not** name an owning skill: that file states these are hand-maintained
+  documents edited in place, and there is no `spec-mdns` skill.
 
 No `Makefile` change: `spec-coverage` globs `spec/*.md` and picks the new files
 up on its own.
 
-### 1.6 Verify the tooling actually sees them
+### 1.5 Cover the new regex branch permanently
 
-`make spec-coverage` must list the two new topic files. Coverage will read 0/N
-until phase 2 — that is correct and non-fatal (the script exits nonzero only on
-stale citations), and it is what makes this phase shippable alone.
+`t/scripts/spec-coverage.t` already drives the script as a subprocess against a
+fixture tree built in a `tempdir` and asserts coverage counts, `--quiet`,
+`--uncovered`, and both `STALE` classes. Add an `MDNS-*` fixture stem to it, so
+the new alternation in the citation regex is covered by `make check` from the
+moment it lands.
 
-Prove the wiring rather than assuming it: add a temporary citation to a real
-section, confirm it counts, then a citation to a nonexistent section, confirm
-`make spec-coverage` exits nonzero with `STALE`. Remove both before committing.
+Follow the existing convention exactly: the fixture stems are assembled at
+runtime from split string literals (`my $STEM = 'HAP-' . 'Fixture8'`) precisely
+so that `spec-coverage`, when run over the real `t/` tree, does not treat the
+test's own source as a citation. An `MDNS-` fixture stem must be split the same
+way or it will report itself as a stale citation against the real `spec/`.
+
+This replaces the throwaway verification the earlier draft of this plan
+prescribed — add a temporary citation, confirm it counts, add a bogus one,
+confirm `STALE`, then delete both. That ritual does this file's job by hand and
+then destroys the evidence, shipping the new branch with no permanent coverage;
+`t/CLAUDE.md`'s tooling tier already mandates the subprocess-and-assert shape.
+
+### 1.6 Verify the tooling sees the new files
+
+`make spec-coverage` must list the two new topic files. Coverage reads 0/N until
+phase 2 — that is correct and non-fatal: `scripts/spec-coverage:200` is
+`exit(@stale ? 1 : 0)`, so low coverage never fails the tool. That is what makes
+this phase shippable alone.
 
 ## Deliverables
 
 - `spec/MDNS.md`, `spec/MDNS-Imsg.md`, `spec/MDNS-Control.md`
-- `.claude/skills/spec-mdns/SKILL.md`
-- Changes to `.claude/skills/fetch-external/SKILL.md`, `scripts/spec-coverage`,
+- The six measurements from 1.2, recorded in the spec files with provenance
+- Changes to `scripts/spec-coverage`, `t/scripts/spec-coverage.t`,
   `t/CLAUDE.md`, `spec/CLAUDE.md`
 
 ## Acceptance criteria
 
-- The `struct mdns_service` layout in `spec/MDNS-Control.md` is the measured
-  one, and the spec says which OpenBSD release and port version it was measured
-  on.
+- The `struct mdns_service` layout and the `imsg_hdr` layout in the spec are the
+  measured ones, and the spec names the OpenBSD release, architecture and port
+  version they were measured on.
+- `spec/MDNS-Control.md` records what measurement 4 found about same-socket TXT
+  replacement and what measurement 5 found about the group/instance name
+  relationship, in numbered citable sections. Phase 2's API depends on both.
 - `spec/MDNS-Control.md` contains a byte-exact publish conversation captured
-  from a real `mdnsctl`, sufficient for phase 2 to replay without re-deriving
-  anything.
+  from a real `mdnsctl`, with sender-specific bytes marked, sufficient for phase
+  2 to replay without re-deriving anything.
 - Every section a conformance test will cite is a numbered `##` or `###`
   heading.
 - `make spec-coverage` lists both topic files, reports 0 covered sections, and
-  exits zero; a deliberately bogus citation makes it exit nonzero with `STALE`.
-- `make prettier` clean. `make check` unaffected — no Perl and no tests change,
-  and `scripts/spec-coverage` is not in `lint`'s file list, so run it directly.
-- Regenerating with `spec-mdns` on a populated `external/` reproduces the files
-  modulo the provenance block and the carried-forward measurements.
+  exits zero.
+- `t/scripts/spec-coverage.t` covers the `MDNS` citation branch and passes; the
+  fixture stem is split so it does not self-match.
+- `make check` green. This phase **does** change Perl that `make check` gates:
+  `PERLSRC` (`Makefile:36`) globs `lib bin scripts` for `*.pm` or a perl
+  shebang, and `scripts/spec-coverage` begins `#!/usr/bin/env perl`, so both
+  `make lint` and `make tidy` cover it — expect perltidy to reflow the citation
+  regex.
+- `make prettier` clean.

--- a/plans/005-pledge-unveil/plan-2.md
+++ b/plans/005-pledge-unveil/plan-2.md
@@ -6,10 +6,11 @@ no security posture on its own; it removes the only `exec` in the daemon, which
 is what lets phase 3 pledge without `proc exec`. Independently shippable: it
 deletes a child process, a log file, and a kill-on-shutdown path.
 
-Depends on phase 1 for `spec/MDNS-Imsg.md` and `spec/MDNS-Control.md` — the
-measured `struct mdns_service` layout, the `imsg_type` ordinals, and the
-byte-exact publish conversation all come from there, and the conformance tests
-cite it.
+Depends on phase 1 for `spec/MDNS-Imsg.md` and `spec/MDNS-Control.md`, and
+specifically on measurements 2, 4 and 5 from task 1.2 — the `imsg_hdr` layout,
+whether same-socket TXT replacement works, and whether the group name must equal
+the instance name. **Those three decide this phase's API. Do not start until
+they are recorded in the spec.**
 
 ## Tasks
 
@@ -19,22 +20,44 @@ Framing only, no mdnsd knowledge:
 
 - `new(fh => $fh)` over an already-connected handle, so tests can use a
   `socketpair` and the module never opens anything itself.
-- `send(type => $n, data => $bytes)` — 16-byte native-endian header (`type` u32,
-  `len` u16 **including** the header, `flags` u16 zero, `peerid` u32 zero, `pid`
-  u32 `$$`) followed by payload. Refuse payloads that would exceed
-  `MAX_IMSGSIZE` (16384) rather than truncating.
+- `send(type => $n, data => $bytes)` — header **as recorded in
+  `spec/MDNS-Imsg.md`** from the installed `/usr/include/imsg.h`, followed by
+  payload. Do not hardcode a layout from this plan: the field set changed in the
+  2024 imsg rework (`len` widened to `uint32_t`, `flags` removed), so a
+  plan-time guess would be wrong on one side of that change. Pin the field
+  widths and order as named constants in one place, with a comment citing the
+  spec section.
+- Refuse payloads that exceed the **payload** bound rather than truncating.
+  `MAX_IMSGSIZE` bounds the whole message, so the bound is
+  `MAX_IMSGSIZE - sizeof(imsg_hdr)`, not `MAX_IMSGSIZE`.
 - `recv(timeout => $seconds)` — buffered, returns `{ type, data }` for one whole
   message, `undef` on timeout or clean EOF; short reads accumulate across calls.
   `IO::Select` for the timeout, never `alarm`.
+- **`$SIG{PIPE}`.** Writing to a socket the peer has closed raises SIGPIPE,
+  which Perl does not ignore by default and `IO::Socket::UNIX` does not
+  suppress. `send` must localise `$SIG{PIPE} = 'IGNORE'` and return `undef` with
+  `$!` set to `EPIPE`, or a peer that closes mid-conversation kills the whole
+  process — which is exactly what the EOF test in 2.2 exercises.
+- A private encoder seam. The conformance test in 2.3 has to assert encoded
+  bytes against a literal, and none of the public methods returns them, so
+  expose the header encoder as a testable internal (`_encode_header`) rather
+  than leaving the test to scrape a socketpair.
 - No fd passing (`SCM_RIGHTS`): the mdnsd group protocol does not use it, and
   omitting it keeps `sendfd`/`recvfd` out of the promise set.
 
+**No logging.** No module under `lib/FuguLib/` references a logger, and the
+convention is that the caller decides — `Privdrop` dies, `Process` reports
+through `on_error`/`on_success` callbacks. Return outcomes; let `bin/openhapd`
+log. Reaching for `$OpenHAP::logger` from `lib/FuguLib/` would contradict the
+namespace split in `CLAUDE.md` and would die in `t/fugulib/*.t`, which sets no
+OpenHAP globals.
+
 Ships with `man/fugulib/Imsg.3p`, a `MAN3P` entry in the `Makefile`, and
 `t/fugulib/imsg.t`. The module test is platform-independent — round-trip over a
-`socketpair`, an oversized payload rejection, a truncated-header read, and a
-two-messages-in-one-read case. Byte-exact header assertions belong in the
-conformance test (2.3), not here; module tests verify API behaviour and error
-paths, the conformance tier verifies the wire format.
+`socketpair`, an oversized payload rejection, a truncated-header read, a
+two-messages-in-one-read case, and a write-after-peer-close returning `undef`
+rather than dying. Byte-exact header assertions belong in the conformance test
+(2.3), not here.
 
 The man page documents the API. It does not restate the framing — that is
 `spec/MDNS-Imsg.md`'s job — and points there instead.
@@ -47,32 +70,53 @@ The mdnsd group protocol, OpenHAP-agnostic:
   so pin all of `IMSG_NONE`(0) through `IMSG_CTL_GROUP_PUBLISHED`(17) in order,
   taken from `spec/MDNS-Control.md` rather than re-read from the header, with a
   comment citing the section.
-- `new(socket_path => ..., group => ...)` defaulting to `/var/run/mdnsd.sock`.
-- `connect()` — `IO::Socket::UNIX` `SOCK_STREAM`; returns `undef` with a warning
-  when the socket is missing or unreadable, matching how `MDNS.pm:70` treats a
-  missing `mdnsctl` today.
-- `publish_service(name =>, app =>, proto =>, port =>, txt =>)` — `GROUP_ADD`,
-  `GROUP_ADD_SERVICE`, `GROUP_COMMIT`, then read replies with a bounded timeout
-  (2s) until `GROUP_PUBLISHED`, an error type, or timeout. `GROUP_PROBING` and
-  `GROUP_ANNOUNCING` are logged at debug and are not terminal.
-- `update_txt(txt => ...)` — `GROUP_RESET`, `GROUP_ADD_SERVICE`, `GROUP_COMMIT`
-  on the **same** socket. No reconnect, no withdraw-and-republish.
+- `new(socket_path => ...)` defaulting to `/var/run/mdnsd.sock`. **No separate
+  `group` parameter** if measurement 5 confirmed that mdnsd looks the group up
+  under the service's name and `libmdns` enforces `group == name`: in that case
+  the group name is derived from the instance name inside `publish_service`, and
+  the unusable combination is simply not expressible. If measurement 5 refuted
+  it, keep `group` and say so.
+- `connect()` — `IO::Socket::UNIX` `SOCK_STREAM`; returns `undef` when the
+  socket is missing or unreachable, matching how `MDNS.pm:70` treats a missing
+  `mdnsctl` today. The caller logs.
+- `publish_service(name =>, app =>, proto =>, port =>, txt =>, timeout =>)` —
+  `GROUP_ADD`, `GROUP_ADD_SERVICE`, `GROUP_COMMIT`, then read replies until
+  `GROUP_PUBLISHED`, an error type, or timeout. `GROUP_PROBING` and
+  `GROUP_ANNOUNCING` are not terminal. `timeout` defaults to 2s but **must be a
+  parameter**: with it hardcoded, the timeout subtest is an unavoidable 2-second
+  wall-clock wait in every `make check` run and cannot be made resilient to
+  timing variation as `CLAUDE.md` requires.
+- `txt` is a **formatted string**, already `key=value` pairs joined per the
+  encoding section of `spec/MDNS-Control.md`. `FuguLib::MDNS` does not know what
+  a TXT key means. See 2.4 for where the formatting lives.
+- `update_txt(txt => ...)` — mechanism **per measurement 4**. If same-socket
+  `GROUP_RESET` → `GROUP_ADD_SERVICE` → `GROUP_COMMIT` was shown to work, do
+  that. If it was shown to re-announce the stale record or to crash mdnsd — the
+  likely outcome from reading `control_group_reset`'s `pg_get(0, msg, NULL)`
+  lookup — then `update_txt` closes and republishes, which is what
+  `MDNS.pm:176-183` does today and what `control_close` cleans up correctly.
+  Retain `name`/`app`/`proto`/`port` from `publish_service` so `update_txt` can
+  re-send `GROUP_ADD_SERVICE` without them being passed again. Whichever path is
+  taken, comment it with the spec citation, because the wrong one fails
+  silently.
 - `withdraw()` — close the socket; that is the entire operation.
-- `is_published()`.
-- TXT records join with `.`, per the encoding section of `spec/MDNS-Control.md`;
-  the man page points at that section so the `pv=1` workaround at `HAP.pm:1087`
-  has something to cite.
+- `is_published()` — used by `OpenHAP::HAP` to avoid driving updates onto an
+  unpublished handle (2.4).
 - Group-name and instance-name inputs longer than the field are an error, not a
   silent truncation.
 - The `struct mdns_service` field offsets and size come from the spec, as named
   constants in one place, so an openmdns change is a one-line edit next to a
-  citation.
+  citation. Include the architecture the layout was measured on in that comment
+  — the `LIST_ENTRY` width and the 864-byte total are LP64-specific.
+- No logging, for the reasons in 2.1.
 
 Ships with `man/fugulib/MDNS.3p`, a `MAN3P` entry, and `t/fugulib/mdns.t`. The
 module test stands up a temporary `AF_UNIX` listener as a fake mdnsd and drives
 the reply paths — `PUBLISHED`, `ERR_COLLISION`, `ERR_DOUBLE_ADD`, EOF
-mid-conversation, a reply timeout, and an over-length name — on Linux and Darwin
-unchanged, which is where CI exercises it.
+mid-conversation, a short reply timeout, and an over-length name — on Linux and
+Darwin unchanged, which is where CI exercises it. The EOF case depends on 2.1's
+`$SIG{PIPE}` handling and the timeout case on the `timeout` parameter; neither
+is testable without them.
 
 ### 2.3 Conformance tests
 
@@ -86,68 +130,140 @@ wire examples are replayed byte-exactly, vectors live inline with no network and
 no `external/`, `Test::More` + `subtest`, `skip_all` on missing CPAN
 dependencies.
 
-- `mdns-imsg.t` — header encoding field by field against `[MDNS-Imsg §…]`: byte
-  order, `len` counting the header, `MAX_IMSGSIZE` refusal, message-boundary
-  handling on a split read.
+- `mdns-imsg.t` — header encoding field by field against `[MDNS-Imsg §…]`, via
+  2.1's `_encode_header` seam: field widths and order as measured, whether `len`
+  counts the header, the payload-bound refusal, and message-boundary handling on
+  a split read. Do not assert "byte order" against a little-endian capture while
+  the encoder uses native-endian `pack` — that assertion is tautological on
+  every host this repo runs on and protects nothing. Assert the field _layout_,
+  which is what can actually be wrong.
 - `mdns-control.t` — the `imsg_type` ordinals; `struct mdns_service` encoded
   byte-exactly, including the zeroed `LIST_ENTRY`, the internal padding, and NUL
-  padding of each fixed field; TXT `.` joining; the full publish conversation
-  from the spec's worked example, replayed byte-for-byte; and the reply/error
-  type meanings.
+  padding of each fixed field; TXT `.` joining; the reply/error type meanings;
+  and the publish conversation from the spec's worked example.
 
-The struct assertion is the one that matters most: it is the only thing standing
-between an openmdns layout change and a daemon that silently advertises garbage.
-Assert the whole 864-byte buffer against a literal, not field by field — a
-field-by-field check passes even when the total size or padding is wrong.
+Two constraints on "byte-exact" that the spec's worked example must respect:
+
+- **The header carries the sender's pid.** The captured conversation holds
+  `mdnsctl`'s pid; our encoder writes the test process's. Assert the
+  sender-specific bytes are _well-formed_ (the pid field equals `$$`) and the
+  rest byte-for-byte, and say so in the subtest name. Claiming a literal
+  whole-message match would be a criterion no implementation can meet.
+- **Assert the whole `struct mdns_service` buffer against a literal**, not field
+  by field — a field-by-field check passes even when the total size or padding
+  is wrong. This is the assertion that matters most: it is the only thing
+  standing between an openmdns layout change and a daemon that silently
+  advertises garbage. Guard it on LP64 so it fails as a skip with a reason on a
+  32-bit OpenBSD rather than as a mysterious 8-byte mismatch.
 
 `make spec-coverage` should now report real coverage for both topic files where
 it reported 0 in phase 1.
 
-### 2.4 Rewire `openhapd` and delete `OpenHAP::MDNS`
+### 2.4 Rewire `openhapd`, move the TXT formatting, and delete `OpenHAP::MDNS`
 
+- **Move the TXT formatting into `OpenHAP::HAP`.** `plan-2`'s earlier draft
+  claimed this knowledge "already lives in `HAP::get_mdns_txt_records`". It does
+  not: `HAP.pm:1085-1106` returns a bare hashref, and the `key=value` formatting
+  _and_ the deterministic `sort keys` ordering live at `MDNS.pm:85-87`, inside
+  the module being deleted. Add a method beside `get_mdns_txt_records` that
+  returns the formatted string, and keep the ordering deterministic — mdnsd's
+  TXT delimiter makes ordering observable, and `t/openhap/mdns.t:239` tests it
+  today. That test's successor lives in `t/openhap/hap.t`.
 - `bin/openhapd`: replace the `OpenHAP::MDNS->new(...)` construction
   (`:108-112`) with `FuguLib::MDNS`, and `register_service` (`:157`) with
-  `connect` + `publish_service`, passing `hap`/`tcp` and
-  `$hap->get_mdns_txt_records` from the call site.
-- `OpenHAP::HAP`: `set_mdns` keeps its signature; `update_txt_records`
-  (`HAP.pm:148`) calls `update_txt`.
+  `connect` + `publish_service`, passing `hap`/`tcp` and the formatted TXT
+  string from the call site. Log the outcome here — the module does not.
+- **`OpenHAP::HAP` must guard on `is_published`.** `set_mdns` keeps its
+  signature, but `$hap->set_mdns($mdns)` runs at `bin/openhapd:113`, long before
+  the connect, and `HAP::_refresh_mdns` (`HAP.pm:138-153`) guards only on
+  `defined $self->{mdns}` before calling the update at `:148`. Today that is
+  safe _only_ because `OpenHAP::MDNS::update_txt_records` short-circuits with
+  `return 1 unless $self->{registered}` (`MDNS.pm:181`) — a guard inside the
+  deleted module. Without a replacement, a daemon that started with `mdnsd` down
+  writes to a closed handle the first time a user pairs. Add the `is_published`
+  check in `_refresh_mdns`, and make `update_txt` a no-op when unpublished as
+  well: two guards, because this one kills the daemon at pairing time. (Note:
+  there is no `HAP::update_txt_records` sub — `HAP.pm:148` is a _call_ into the
+  mdns object from `HAP::_refresh_mdns`.)
 - The shutdown cleanup (`bin/openhapd:166-176`) calls `withdraw` instead of
   `unregister_service`.
-- Delete `lib/OpenHAP/MDNS.pm`, `lib/OpenHAP/MDNS.pod`, and `t/openhap/mdns.t`
-  (or move whatever coverage in it is not mdnsctl-specific).
 - Remove the `$db_path/mdnsctl.log` machinery and the now-unused `log_dir`
   plumbing. Check whether `FuguLib::Process` retains any other caller; if
   `spawn_command`/`terminate` become dead code, say so in the commit message and
   leave removal to a separate change — `FuguLib` is a library and its API is not
   ours to prune on the way past.
 
-### 2.5 Ordering, privileges, and documentation
+### 2.5 The full consumer inventory
 
-- `/var/run/mdnsd.sock` is root:wheel, so the existing requirement that
-  `_openhap` be in `wheel` (`bin/openhapd:116`) still holds, and the connection
-  can still be made after privdrop. Keep the current ordering — privdrop, then
-  advertise — and update the stale comment at `:115-117` that explains it in
-  terms of killing a child process.
-- `man/openhap/openhapd.8`: the daemon no longer spawns a child, no longer
-  writes `mdnsctl.log`, and needs `mdnsd(8)` running rather than `mdnsctl(8)`
-  installed. Add `mdnsd(8)` to SEE ALSO.
+Deleting `lib/OpenHAP/MDNS.pm` and `.pod` breaks five other files. Every one
+needs a disposition **in this phase**, or neither `make check` nor
+`make integration` can be green as the acceptance criteria require:
+
+| file                                   | disposition                                                                                                                                                                                                                                                        |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `t/openhap/mdns.t`                     | Delete. Move the TXT-ordering coverage (`:239`) to `t/openhap/hap.t` against the new formatter.                                                                                                                                                                    |
+| `t/conformance/hap-mdns.t`             | **Rewrite, do not delete.** `:23` does `use_ok('OpenHAP::MDNS')` and `:37`, `:94`, `:181`, `:190` construct it. Re-point those four subtests at `OpenHAP::HAP`'s TXT formatter and the `FuguLib::MDNS` call arguments. See the note below.                         |
+| `t/openhap/integration/mdns-cleanup.t` | **Rewrite or delete — its premise is inverted.** `:32` asserts `mdnsctl_count > 0` and `:37` asserts captured mdnsctl PIDs. Integration tests never skip, so this fails deterministically after this phase. Fold whatever survives into the new assertions in 2.6. |
+| `t/openhap/integration/mdns.t`         | `:19-22` dies unless the `mdnsctl` _binary_ exists. Change the precondition to `mdnsd` running; `mdnsctl` is now only a test tool for browsing.                                                                                                                    |
+| `scripts/integration`                  | Still `pkill`s `mdnsctl` as pre-run cleanup (`:41-49`) and greps for it in failure diagnostics (`:98`). Both become dead; remove them.                                                                                                                             |
+
+`t/conformance/hap-mdns.t` deserves care beyond "make it compile":
+**`[HAP-mDNS §10]` is cited nowhere else in the tree** — only at
+`t/conformance/hap-mdns.t:89`, inside one of the four subtests that constructs
+the deleted module. `[HAP-mDNS §4]` and `[HAP-mDNS §6]` are likewise cited there
+and otherwise only in `t/openhap/integration/mdns.t`, which moves them out of
+`make check` and into the VM. So a careless rewrite silently lowers HAP-mDNS
+coverage, and phase 5's "coverage no lower than phase 2 left it" would then
+measure against an already-regressed baseline. **Record HAP-mDNS coverage before
+and after this phase and keep it equal.**
+
+### 2.6 Ordering, privileges, and documentation
+
+- Keep the current ordering — privdrop, then advertise — and update the stale
+  comment at `bin/openhapd:115-117`, which explains it in terms of killing a
+  child process.
+- **Do not assert the wheel privilege model without measuring it.** The comment
+  at `:116` says `_openhap` must be in `wheel` to reach `/var/run/mdnsd.sock`
+  (root:wheel 0660). But `FuguLib::Privdrop::drop_privileges` calls only
+  `POSIX::setgid`/`setuid` and never `setgroups`/`initgroups`, and Perl's
+  `$) = $gid` assignment at `Privdrop.pm:73` itself invokes `setgroups` — which
+  would _drop_ wheel rather than keep it. Whatever actually grants access today,
+  it is not obviously the stated mechanism. Measure it in the VM (`id` as the
+  running daemon, plus an `unveil`-free connect attempt) and write down what is
+  true. Phase 5 documents this in `openhapd.8`, so a false claim here becomes a
+  false claim about a privilege boundary in an installed man page.
+- `man/openhap/openhapd.8`: the daemon no longer spawns a child and needs
+  `mdnsd(8)` running rather than `mdnsctl(8)` installed. Add `mdnsd(8)` to SEE
+  ALSO. Note that neither this page nor `.claude/skills/openhapd/SKILL.md`
+  currently mentions `mdnsctl` or `mdnsctl.log`, so there is no stale text to
+  fix there — only the new requirement to state.
 - `deps/OpenBSD.txt` keeps `openmdns` — the daemon is still required; only the
-  CLI is no longer invoked.
-- `.claude/skills/openhapd/SKILL.md`: update any procedure that greps for the
-  `mdnsctl` child or reads `mdnsctl.log`.
+  CLI is no longer invoked by `openhapd`. It remains a test dependency for
+  browsing.
+- `.github/workflows/`: the workflows filter on explicit path includes
+  (`81baa1b`). Confirm `lib/FuguLib/**`, `t/fugulib/**`, `t/conformance/**` and
+  `spec/**` are covered, or the new tests silently never run in CI.
 
-### 2.6 Integration coverage
+### 2.7 Integration coverage
 
 Extend `t/openhap/integration/` (which never skips — see
 `t/openhap/integration/CLAUDE.md`) to assert, inside the VM:
 
 - `mdnsctl browse _hap._tcp` sees the advertised service after `openhapd`
   starts.
-- No `mdnsctl` process is a child of `openhapd`, and no `mdnsctl.log` is
-  created.
-- The TXT record changes after a pairing state change (`sf` flips).
+- No child process at all: `pgrep -P $(pgrep openhapd)` is empty, and no
+  `mdnsctl.log` is created.
+- The TXT record changes after a pairing state change (`sf` flips). This is the
+  assertion that catches a broken `update_txt` — and given measurement 4, it is
+  the most important test in this phase, because the failure mode is a _silent_
+  stale record with a successful-looking reply sequence. Assert the browsed TXT,
+  never the return value.
 - The advertisement disappears within a few seconds of `openhapd` exiting, which
   is the socket-close contract.
+- The daemon starts and serves with `mdnsd` stopped, logging a warning.
+
+Assert on observable behaviour, not on log contents —
+`t/openhap/integration/CLAUDE.md` forbids parsing logs.
 
 ## Deliverables
 
@@ -155,6 +271,10 @@ Extend `t/openhap/integration/` (which never skips — see
 - `man/fugulib/Imsg.3p`, `man/fugulib/MDNS.3p`, `Makefile` `MAN3P` entries
 - `t/fugulib/imsg.t`, `t/fugulib/mdns.t`
 - `t/conformance/mdns-imsg.t`, `t/conformance/mdns-control.t`
+- A TXT formatter on `OpenHAP::HAP` plus its test in `t/openhap/hap.t`
+- Rewritten `t/conformance/hap-mdns.t`; rewritten or deleted
+  `t/openhap/integration/mdns-cleanup.t`; changed
+  `t/openhap/integration/mdns.t`, `scripts/integration`
 - New integration assertions in `t/openhap/integration/`
 - Changes to `bin/openhapd`, `lib/OpenHAP/HAP.pm`, `man/openhap/openhapd.8`
 - Deleted: `lib/OpenHAP/MDNS.pm`, `lib/OpenHAP/MDNS.pod`, `t/openhap/mdns.t`
@@ -162,16 +282,17 @@ Extend `t/openhap/integration/` (which never skips — see
 ## Acceptance criteria
 
 - `t/conformance/mdns-control.t` asserts the whole encoded `struct mdns_service`
-  against a literal and replays the spec's publish conversation byte-for-byte;
-  changing any offset constant makes it fail.
+  against a literal; changing any offset constant makes it fail.
 - `make spec-coverage` reports non-zero coverage for `MDNS-Imsg` and
-  `MDNS-Control`, and exits zero — no stale citations.
-- `mdnsctl browse` in the VM sees the service, its TXT updates on pairing state
-  change, and it disappears when the daemon exits.
+  `MDNS-Control`, exits zero, and **HAP-mDNS coverage is unchanged from before
+  this phase**.
+- `mdnsctl browse` in the VM sees the service, the browsed TXT updates on a
+  pairing state change, and the advertisement disappears when the daemon exits.
 - `openhapd` spawns no child process at all: `pgrep -P $(pgrep openhapd)` is
   empty.
 - A missing or unreachable `/var/run/mdnsd.sock` logs a warning and leaves the
-  HAP server serving, exactly as a missing `mdnsctl` does today.
+  HAP server serving; pairing while unpublished does not kill the daemon.
 - `make check` green on Linux (tests use `socketpair`/`AF_UNIX` and need no
-  mdnsd); `make integration` green on OpenBSD.
+  mdnsd); `make integration` green on OpenBSD — which requires every row of 2.5
+  to have been carried out.
 - `mandoc -Tlint -W warning` clean for both new man pages.

--- a/plans/005-pledge-unveil/plan-3.md
+++ b/plans/005-pledge-unveil/plan-3.md
@@ -12,67 +12,119 @@ One module, both mechanisms, three platforms. The whole point is that callers
 never write `if ($^O eq 'openbsd')`.
 
 ```perl
-FuguLib::Sandbox->is_supported;                 # 1 on OpenBSD, '' elsewhere
-FuguLib::Sandbox->pledge(promises => $string);  # 1, or die
-FuguLib::Sandbox->unveil(paths => \@pairs);     # 1, or die
-FuguLib::Sandbox->unveil_lock;                  # 1, or die
+FuguLib::Sandbox->is_supported;                       # 1 on OpenBSD, '' elsewhere
+FuguLib::Sandbox->pledge(promises => $string);        # 1, or die
+FuguLib::Sandbox->unveil(paths => [[$path, $perms]]); # 1, or die
+FuguLib::Sandbox->unveil_lock;                        # 1, or die
 ```
 
 - On OpenBSD, `OpenBSD::Pledge` and `OpenBSD::Unveil` are loaded at compile
   time. They are base-system modules; failing to load them there means a broken
   Perl, so that is fatal at `use` time rather than a runtime fallback to "no
   protection".
-- Off OpenBSD every method is a no-op returning 1, and logs **once** at debug
-  (`'sandbox: %s is a no-op on %s'`). Once, not per call, so a daemon that
-  re-pledges does not flood the log; and at debug rather than silence so a test
-  reading logs can tell enforcement from emulation.
+- Off OpenBSD every method is a no-op returning 1.
 - `pledge` and `unveil` failures `die` with the promise string or path and `$!`.
   Fail closed: there is no `force => 0` and no warn-and-continue mode. A daemon
   that cannot restrict itself must not start.
-- `unveil(paths => [[$path, $perms], ...])` applies pairs in order and reports
-  which pair failed. `$path` that does not exist is a failure, not a skip — a
-  typo'd path silently accepted is the failure mode that makes unveil useless.
-- `unveil_lock` calls `OpenBSD::Unveil::unveil()` with no arguments.
+- `unveil(paths => [[$path, $perms], ...])` takes an **ordered list of pairs**,
+  applies them in order, and reports which pair failed. Not a flat
+  `path => $perms` hash: hash key order is randomised, duplicate paths are
+  inexpressible, and unveil _replaces_ rather than merges a path's permissions,
+  so parent-then-child ordering is load-bearing.
+- Each pair may be marked optional (a third element, or a `{ optional => 1 }`
+  form — pick one and document it). A missing **required** path is a failure,
+  not a skip: a typo'd path silently accepted is the failure mode that makes
+  unveil useless. A missing **optional** path is skipped and reported to the
+  caller. Phase 4 needs both, because three of its paths are legitimately absent
+  on a working system.
+- `unveil_lock` calls `OpenBSD::Unveil::unveil()` with **no arguments**. Not
+  `unveil(undef, undef)`: the XS defaults to `NULL` only when the arguments are
+  _absent_, so two `undef` SVs arrive as `""` and the call fails with `ENOENT` —
+  which, under the die-on-failure rule above, would stop the daemon from
+  starting at all.
 - Keep it stateless: class methods, no object. It wraps two syscalls that are
   themselves process-global.
+- **No logging.** No module under `lib/FuguLib/` references a logger, and a
+  stateless class has nowhere to keep a "logged once" flag anyway. The caller
+  logs. `is_supported` is how a caller or a test distinguishes enforcement from
+  emulation — a return value, not a log line to be grepped. This matters for
+  phase 5, whose integration tier is forbidden from parsing logs.
 
 Ships with `man/fugulib/Sandbox.3p`, a `MAN3P` entry, and `t/fugulib/sandbox.t`.
 
 The test must be meaningful on both kinds of platform, which needs care:
 
 - Everywhere: `is_supported` agrees with `$^O`; a no-op platform returns 1 from
-  every method and does not die.
-- On OpenBSD only: fork a child, `pledge('stdio')` in it, have it attempt
-  `socket(AF_INET)`, and assert it dies of `SIGABRT` — pledge violations abort,
-  they do not return `EPERM`. Assert in the **child**, never the parent, or the
-  test process pledges itself and takes the rest of the suite down.
-- On OpenBSD only: a child that unveils `$tmpdir` read-only, locks, and then
-  fails to open a file outside it.
+  every method and does not die; a malformed `paths` argument dies.
+- On OpenBSD only: **`pledge()` in a forked child, assert in the parent.** A
+  pledge violation goes through the kernel's `pledge_fail()`, which resets the
+  handler to `SIG_DFL` and delivers an uncatchable `SIGABRT` — the child is gone
+  at the moment of violation and cannot emit a TAP line about it. So the child
+  pledges `stdio`, attempts `socket(AF_INET)`, and `POSIX::_exit`s if it somehow
+  survives; the parent `waitpid`s and asserts `$? & 127 == SIGABRT`. Never
+  assert in the child: `Test::More` in a forked child duplicates the inherited
+  test counter and interleaves TAP on the same fd, which `prove` reports as a
+  plan mismatch, and the parent must never pledge itself or it takes the rest of
+  the suite down.
+- **Suppress the core dump.** The abort drops `perl.core` into the test's cwd —
+  the repo root under `prove -l` — against `CLAUDE.md`'s "leave no partial
+  files". Set `RLIMIT_CORE` to 0 in the child before pledging. `BSD::Resource`
+  is in neither `deps/OpenBSD.txt` nor `cpanfile`, so either add it as an
+  OpenBSD test dependency (`p5-BSD-Resource`) or set the limit by running the
+  child under `sh -c 'ulimit -c 0; ...'`. Decide before writing the test, and
+  clean up any core file the test does produce.
+- On OpenBSD only: a child that unveils `$tmpdir` read-only, locks, then fails
+  to open a file outside it and succeeds inside it — same child/parent split.
 - A bogus promise string dies rather than being accepted.
 
-Guard the OpenBSD-only cases with `plan skip_all` at the file level only if the
-whole file is OpenBSD-specific; here it is not, so guard per-subtest and make
-the skip message name the reason.
+Guard the OpenBSD-only cases per-subtest with a skip message naming the reason;
+the file as a whole is not OpenBSD-specific, so no file-level `skip_all`.
 
-### 3.2 Preload everything that would `dlopen` later
+### 3.2 Resolve the one genuinely late load
 
-`prot_exec` stays out of the promise set, so no shared object may be opened
-after the pledge. Two known offenders load lazily (see the design), and both are
-handled in `bin/openhapd` before pledging:
+`prot_exec` stays out of the promise set. The earlier draft of this plan
+justified that with a preload block covering "the XS runtime dependencies" and a
+forced `Math::BigInt` modular exponentiation. **Both premises were wrong**, and
+the block shrinks accordingly:
 
-- Explicitly `use`/`require` the XS runtime dependencies: `Crypt::Ed25519`,
-  `Crypt::Curve25519`, `Crypt::AuthEnc::ChaCha20Poly1305`,
-  `Crypt::KeyDerivation`, `Digest::SHA`, `JSON::XS`, `Net::MQTT::Simple`,
-  `Sys::Syslog`.
-- Force `Math::BigInt` to load its GMP backend by performing one modular
-  exponentiation. `Math::BigInt::GMP` is pulled in on first use, and first use
-  is otherwise during SRP at pairing time — long after the pledge.
-- Call `localtime` once so the zone file is cached.
+- Every XS dependency is already loaded by a compile-time `use` on the graph
+  reachable from `bin/openhapd:7`: `Crypt::Curve25519`, `Crypt::Ed25519`,
+  `Crypt::AuthEnc::ChaCha20Poly1305`, `Crypt::KeyDerivation` and `Digest::SHA`
+  at `Crypto.pm:5-10`; `JSON::XS` at `HAP.pm:6`; `Digest::SHA` at `HAP.pm:8`.
+  `Sys::Syslog` is loaded unconditionally at `FuguLib/Log.pm:22`. Nothing to
+  preload.
+- `Math::BigInt` resolves its backend inside `import`, not at first arithmetic,
+  so `use Math::BigInt try => 'GMP'` at `SRP.pm:9` — reached at compile time via
+  `HAP.pm:13` → `Pairing.pm:5` — has GMP's shared object open before
+  `GetOptions` runs. A forced modexp would be dead code, and an acceptance
+  criterion resting on it could not fail.
 
-Put this in one clearly commented block — a `_preload` sub in `bin/openhapd` —
-with a comment saying _why_, because the next person to read it will otherwise
-delete it as redundant `use` statements. Note in the comment that adding an XS
-dependency means adding it here.
+What remains is one real late load: `require Net::MQTT::Simple` at `MQTT.pm:50`,
+which a failed startup connection defers to the first reconnect. It is **pure
+Perl**, so it needs no `prot_exec` — only `rpath` and a reachable library tree,
+which phase 4's unveil provides. Resolve it before the pledge anyway, so its own
+transitive dependencies load while loading is unrestricted:
+
+```perl
+# Resolve the one module the daemon loads lazily, before the pledge and
+# unveil restrict us.  Net::MQTT::Simple is pure Perl, so this is not
+# about prot_exec -- it is about its transitive dependencies (sockets,
+# and whatever getprotobyname touches) being resolved while @INC is
+# still fully reachable.  It stays optional: it is the only cpan runtime
+# dependency, and openhapd serves HomeKit without it.
+eval { require Net::MQTT::Simple; 1 };
+```
+
+**Keep it non-fatal.** An unguarded `use`/`require` would make the absence of
+the only `cpan` runtime dependency (`deps/OpenBSD.txt`) a startup failure, where
+`bin/openhapd:88-97` currently logs "MQTT broker not available, will retry in
+background" and keeps serving. That would violate `CLAUDE.md`'s "`require`
+optional dependencies so they stay optional" and falsify this phase's own
+byte-identical-behaviour criterion.
+
+Comment it as above, because the next reader will otherwise delete it as a
+redundant `require`. And note the standing rule: **if a future change introduces
+a module that loads lazily, it belongs here.**
 
 ### 3.3 Apply the pledge in `bin/openhapd`
 
@@ -86,31 +138,41 @@ stdio rpath wpath cpath fattr flock inet dns unix
 Derivation is in the design; the code carries a comment per promise so a future
 reader can shrink the set safely. Also:
 
-- Both `-f`/foreground and daemon mode pledge identically. Foreground differs
-  only in where the log goes, which is already an open fd by then.
+- **`unix` is conditional on phase 1's measurement 4.** It is needed only if
+  `update_txt` reconnects to mdnsd. An already-connected socket needs just
+  `stdio` to read and write — `PLEDGE_UNIX` gates `socket`, `connect` and
+  `bind`, all of which happen before the pledge. If measurement 4 showed
+  same-socket `GROUP_RESET` works and `FuguLib::MDNS` never reconnects, drop
+  `unix` and say so in the comment. Do not carry a promise nothing exercises.
+- Both `-f`/foreground and daemon mode pledge identically.
 - `-n`/`--check` exits at `bin/openhapd:34-37`, before any of this. Leave it
   alone; a config check is not a long-running process.
-- Log at info that the pledge was applied, naming the promise set. On a no-op
-  platform, log nothing at info — the debug line from 3.1 is enough — so the
-  absence of that info line is itself a signal.
+- Log at info that the pledge was applied, naming the promise set — from
+  `bin/openhapd`, not from `FuguLib::Sandbox`. On a no-op platform log nothing,
+  so a reader of the log can tell the two apart. Tests use `is_supported`, not
+  the log.
 
 ### 3.4 Documentation
 
 - `man/fugulib/Sandbox.3p` is the API reference for the module (FuguLib is
-  documented in man3p, not in sidecars).
+  documented in man3p, not in sidecars). Document the ordered-pairs form, the
+  required/optional distinction, the die-on-failure contract, and the lock
+  semantics.
 - `man/openhap/openhapd.8`: state the promise set and that OpenBSD is the only
   platform where it is enforced. The full SECURITY section lands in phase 5,
   once unveil is in place; here, one accurate paragraph.
 - Do not touch `README.md`, `CLAUDE.md`, or `web/` — their claims become fully
   true at the end of phase 4, and hedging them for one phase then unhedging them
-  is churn.
+  is churn. Phase 5 owns the FuguLib module-count corrections.
 
 ## Deliverables
 
 - `lib/FuguLib/Sandbox.pm`, `man/fugulib/Sandbox.3p`, `Makefile` `MAN3P` entry
 - `t/fugulib/sandbox.t`
-- Changes to `bin/openhapd` (preload block, pledge call)
+- Changes to `bin/openhapd` (the lazy-load resolution, the pledge call)
 - `man/openhap/openhapd.8` paragraph
+- Possibly `deps/OpenBSD.txt` + `cpanfile` (`p5-BSD-Resource`), if that is how
+  the core dump gets suppressed
 
 ## Acceptance criteria
 
@@ -119,10 +181,11 @@ reader can shrink the set safely. Also:
   matters most: reconnection is the one code path that resolves names and loads
   `Net::MQTT::Simple` after the pledge point, and it is the likeliest thing to
   abort in production rather than in a test.
-- A full SRP pairing completes under the pledge, proving the `Math::BigInt::GMP`
-  preload works. Without it this aborts, and only at pairing time.
-- `t/fugulib/sandbox.t` proves a pledge violation aborts a child process on
-  OpenBSD, and proves the no-op contract elsewhere.
+- `openhapd` starts and serves with `Net::MQTT::Simple` **not installed**,
+  exactly as it does today — the preload does not make it mandatory.
+- `t/fugulib/sandbox.t` proves a pledge violation aborts a forked child on
+  OpenBSD, asserting in the parent on the wait status, and proves the no-op
+  contract elsewhere. It leaves no core file behind.
 - `make check` green on Linux and Darwin with behaviour byte-identical to
   before.
 - `kdump`/`ktrace` of a running `openhapd` shows no `pledge` violation and no

--- a/plans/005-pledge-unveil/plan-4.md
+++ b/plans/005-pledge-unveil/plan-4.md
@@ -1,53 +1,122 @@
 # Phase 4 — unveil(2)
 
 Restrict the filesystem view. Depends on phase 3 for `FuguLib::Sandbox`, which
-already carries the `unveil` and `unveil_lock` API; this phase only builds the
-path inventory and calls them. At the end of this phase the claims in
-`README.md` and `web/index.body.html` are true.
+already carries the `unveil` and `unveil_lock` API and the required/optional
+distinction; this phase builds the path inventory and calls them. It also
+depends on phase 1's measurement 6 — the `kdump` of the real path set — because
+an inventory derived by reading code is a guess.
+
+At the end of this phase the claims in `README.md` and `web/index.body.html` are
+true.
 
 ## Tasks
 
 ### 4.1 The path inventory
 
-Assembled in `bin/openhapd` from configuration, not hardcoded — `$config_file`,
-`$db_path` and the log path are all variable.
+Assembled in `bin/openhapd` from configuration where it is configurable. Every
+row carries a **disposition**: _required_ means absent is a broken install and
+startup fails with the path in the message; _optional_ means legitimately absent
+on a working system, so it is skipped with a debug line.
 
-| path                    | perms | needed for                            |
-| ----------------------- | ----- | ------------------------------------- |
-| `$config_file`          | `r`   | re-read after a future SIGHUP reload  |
-| `$db_path`              | `rwc` | pairings, device state (`Storage.pm`) |
-| `/var/log/openhapd.log` | `w`   | daemon-mode log (`Daemon::daemonize`) |
-| `/var/run/mdnsd.sock`   | `rw`  | `connect(2)` needs `w` on the path    |
-| `/dev/urandom`          | `r`   | `Crypto.pm:35`                        |
-| `/etc/resolv.conf`      | `r`   | resolver, on MQTT reconnect           |
-| `/etc/hosts`            | `r`   | resolver, on MQTT reconnect           |
-| each `@INC` directory   | `r`   | lazy `require` of pure-Perl modules   |
+The disposition column is the whole point of this task. Without it, three paths
+that are routinely absent would turn configurations that start today into
+startup failures — which design goal 7 forbids.
 
-Notes that matter:
+| path                      | perms | disp.    | needed for                                      |
+| ------------------------- | ----- | -------- | ----------------------------------------------- |
+| `$db_path`                | `rwc` | required | pairings, device state (`Storage.pm`)           |
+| `/dev/urandom`            | `r`   | required | `Crypto.pm:35`                                  |
+| library directories (4.2) | `r`   | required | lazy `require` of pure-Perl modules             |
+| `$config_file`            | `r`   | optional | re-read on a future reload; **absent is legal** |
+| `/var/log/openhapd.log`   | `w`   | optional | daemon-mode log; **absent under `-f`**          |
+| `/var/run/mdnsd.sock`     | `rw`  | optional | reconnect, if `update_txt` republishes          |
+| `/etc/resolv.conf`        | `r`   | optional | resolver, on MQTT reconnect                     |
+| `/etc/hosts`              | `r`   | optional | resolver, on MQTT reconnect                     |
+| `/etc/services`           | `r`   | optional | resolver; the third file `dns` grants           |
+| `/etc/protocols`          | `r`   | optional | `getprotobyname` on the reconnect path          |
+| `/etc/localtime`          | `r`   | optional | `localtime` in log timestamps                   |
 
-- **`@INC` read-only is a deliberate choice**, and the design says why: Perl's
-  lazy loading makes "prove nothing loads late" a claim no test can hold over
-  time, while unveiling the library tree read-only is one line and cannot
-  regress. The comment in the code must say this, or someone will "tighten" it
-  and break pairing three months later.
-- Skip `@INC` entries that are not directories (`.`, code refs from any future
-  loader hooks) rather than failing on them.
-- `/var/log/openhapd.log` is already an open fd by unveil time, so this entry
-  exists for log rotation and reopen, not for the current write path. Keep it —
-  the cost is one line and the alternative is a surprise later.
-- `/etc/resolv.conf` and `/etc/hosts` are only needed when `mqtt_host` is a
-  name. Unveil them unconditionally: conditionally-restricted is harder to
-  reason about than uniformly-restricted, and neither file is sensitive to this
-  daemon.
-- No `x` anywhere. Phase 2 removed the only `exec`, and an unveil that grants
-  `x` while pledge withholds `exec` is a confusing contradiction in the source.
+**Add whatever measurement 6 found that this table does not list.** The table is
+a starting point, not the authority — that is the same discipline phase 1
+applies to the mdnsd ABI.
 
-### 4.2 Call site and ordering
+Why each optional row is optional, since getting this wrong is the failure mode:
+
+- **`$config_file`** — `bin/openhapd:32` is
+  `$config->load() if -f $config_file`. Running on defaults is supported, and
+  `Makefile:130` installs the sample to `$(SYSCONFDIR)/examples/openhapd.conf`,
+  never to `/etc/openhapd.conf`; `INSTALL.md:35` tells the operator to copy it.
+  A fresh `make install` + `rcctl start` has no config file at all. Note also
+  that the justification is weaker than the earlier draft claimed: SIGHUP is
+  currently wired to graceful _exit_ (`bin/openhapd:177`), so the "future
+  reload" this row serves does not exist yet. Keep the row — it costs one line
+  and reload is a real intention — but do not let it be fatal for a feature that
+  is not there.
+- **`/var/log/openhapd.log`** — created only by `daemonize`
+  (`FuguLib/Daemon.pm:55`), which `bin/openhapd:41` skips entirely under `-f`.
+  On any host that has only ever run `openhapd -f` — the documented development
+  path — the file does not exist. It is also already an open fd by unveil time
+  in daemon mode, so the row exists for rotation and reopen, not the current
+  write path. (The path is a hardcoded literal at `bin/openhapd:42`, not
+  configuration, despite what the earlier draft's preamble said; the inventory
+  builder takes it as a constant.)
+- **`/var/run/mdnsd.sock`** — exists only while `mdnsd(8)` runs. Making it fatal
+  would contradict `design.md`'s contract that a `FuguLib::MDNS` failure stays
+  non-fatal and phase 2's criterion that a missing socket leaves the HAP server
+  serving. It is also only needed at all if measurement 4 put a reconnect in
+  `update_txt`; if it did not, drop the row entirely along with the `unix`
+  promise.
+- **The resolver files** — only needed when `mqtt_host` is a name. Unveil them
+  unconditionally-as-optional rather than conditionally on the config: uniformly
+  restricted is easier to reason about than conditionally restricted, and none
+  is sensitive to this daemon. `/etc/services` is the third file pledge's `dns`
+  promise grants alongside `hosts` and `resolv.conf`; the earlier draft dropped
+  it without a reason. `/etc/protocols` is on the reconnect path because
+  `IO::Socket::IP` calls `getprotobyname` on every `new()` with a non-numeric
+  `Proto`, uncached — the HAP listener at `HAP.pm:158` escapes this only because
+  `IO::Socket::INET` pre-populates its proto table from `Socket::IPPROTO_TCP`.
+
+No `x` anywhere. Phase 2 removed the only `exec`, and an unveil that grants `x`
+while pledge withholds `exec` is a confusing contradiction in the source.
+
+### 4.2 Enumerate the library directories; do not derive them from `@INC`
+
+The earlier draft said "each `@INC` directory, skipping non-directories". That
+is wrong twice over:
+
+- `bin/openhapd:4-5` prepends `"$RealBin/../lib"`. `Makefile:101` installs the
+  daemon to `$(BINDIR)` with `PREFIX ?= /usr/local`, so on a real deployment
+  that entry is **`/usr/local/lib`** — a directory that exists, so a
+  non-directory skip does not catch it, containing every third-party library
+  under `/usr/local` rather than a Perl tree. The Perl modules actually live in
+  `/usr/local/libdata/perl5/site_perl` (`Makefile:6`). Unveiling all of
+  `/usr/local/lib` read-only is a substantial and unintended widening, and it is
+  unreviewable when the inventory just says "each `@INC` directory".
+- `MQTT.pm:42-45` `unshift`s `/usr/local/libdata/perl5/site_perl` onto `@INC`
+  _inside_ `mqtt_connect`. Today that runs at `bin/openhapd:88`, before this
+  inventory is built, so the directory happens to be present. Defer the startup
+  connect — a natural follow-up when the broker may be down — and a derived set
+  silently loses it, `unveil_lock` seals it out, and the reconnect-path
+  `require` fails permanently. That is a hidden ordering dependency the plan
+  must not rely on.
+
+So: build an **explicit list** — the perl core library directories, the
+site_perl directory, and the daemon's own `lib` when running from a source
+checkout — and unveil those. Note in the comment why it is a list and not
+`@INC`, or someone will "simplify" it back.
+
+Keep the `@INC`-read-only trade-off itself, and say why in the code: Perl's lazy
+loading makes "prove nothing loads late" a claim no test can hold over time,
+while unveiling the library tree read-only is a few lines and cannot regress.
+The comment must say this, or someone will "tighten" it and break the MQTT
+reconnect three months later.
+
+### 4.3 Call site and ordering
 
 In `bin/openhapd`, between the mDNS advertisement and the pledge from phase 3:
 
-1. Preload (phase 3, task 3.2) — before unveil, because it reads from `@INC` and
-   `dlopen`s.
+1. Resolve the lazy load (phase 3, task 3.2) — before unveil, because it reads
+   from the library tree.
 2. `FuguLib::Sandbox->unveil(paths => \@paths)`.
 3. `FuguLib::Sandbox->unveil_lock`.
 4. `FuguLib::Sandbox->pledge(promises => ...)`.
@@ -62,36 +131,43 @@ correctly so.
 Add a short comment block naming the four steps and their order, because the
 ordering is load-bearing and not locally obvious.
 
-### 4.3 Tests
+### 4.4 Tests
 
 `t/openhap/openhapd.t`-style coverage cannot exercise unveil without running the
 daemon, so split the work:
 
+- **The inventory builder is a unit test.** Factor path assembly into a small
+  testable sub that takes the config values and returns the ordered pair list
+  with dispositions, so the library-directory enumeration, the disposition
+  assignment and the config-derived paths can be asserted on any platform
+  without unveiling anything. Assert specifically that a missing `$config_file`
+  yields an optional entry (or none) and never a required one — that is the
+  regression that would reintroduce the startup failure.
 - `t/fugulib/sandbox.t` (extended from phase 3): on OpenBSD, a forked child
   unveils a temp directory `r`, locks, then fails to read a file outside it and
-  succeeds inside it. Also assert that unveiling a nonexistent path dies.
-- A unit test for the inventory builder: factor path assembly into a small
-  testable sub (or `FuguLib::Sandbox` helper) that takes the config values and
-  returns the pair list, so the `@INC` filtering and the config-derived paths
-  can be asserted on any platform without unveiling anything.
+  succeeds inside it — asserting in the parent, per phase 3. Also assert that a
+  missing **required** path dies and a missing **optional** path does not.
 - Integration (phase 5 expands this): the daemon runs, pairs, and serves with
-  unveil active.
+  unveil active — and starts successfully with no config file, with `mdnsd`
+  stopped, and in `-f` mode on a host with no log file.
 
-### 4.4 Documentation
+### 4.5 Documentation
 
-- `man/openhap/openhapd.8`: list the unveiled paths in the FILES section, and
-  note that `openhapd` cannot read anything else — an operator debugging "why
-  can't it read my file" needs this to be findable.
-- `man/fugulib/Sandbox.3p`: document `unveil`'s die-on-missing-path behaviour
-  and the lock semantics.
-- `README.md`, `CLAUDE.md`, `web/`: unchanged. As of this phase they are
-  accurate.
+- `man/openhap/openhapd.8`: list the unveiled paths in the FILES section,
+  marking which are required and which are optional, and note that `openhapd`
+  cannot read anything else — an operator debugging "why can't it read my file"
+  needs this to be findable.
+- `man/fugulib/Sandbox.3p`: document the required/optional semantics and the
+  lock behaviour (phase 3 introduces them; this phase is their first real user).
+- `README.md`, `CLAUDE.md`, `web/`: unchanged here. As of this phase the
+  pledge/unveil claims are accurate; phase 5 audits them and fixes the FuguLib
+  module count.
 
 ## Deliverables
 
-- Changes to `bin/openhapd` (inventory, unveil, lock, ordering comment)
-- Possibly a small helper in `lib/FuguLib/Sandbox.pm` for `@INC` filtering
-- Extended `t/fugulib/sandbox.t`, new inventory unit test
+- Changes to `bin/openhapd` (inventory builder, unveil, lock, ordering comment)
+- The inventory builder factored into a testable sub, with its unit test
+- Extended `t/fugulib/sandbox.t`
 - `man/openhap/openhapd.8` FILES section, `man/fugulib/Sandbox.3p` updates
 
 ## Acceptance criteria
@@ -101,8 +177,14 @@ daemon, so split the work:
   broker, all with unveil locked. The MQTT restart is the sharpest test: it is
   the path that touches the resolver files and lazily `require`s
   `Net::MQTT::Simple`.
+- **Every configuration that started before this phase still starts**: no config
+  file, `mdnsd` stopped, and `openhapd -f` on a host with no
+  `/var/log/openhapd.log`. Verified in the VM, not asserted in prose.
 - A file outside the unveiled set is unreadable by the running daemon, verified
-  from inside the VM rather than asserted in prose.
-- Unveiling a nonexistent path is fatal at startup with the path in the message.
+  from inside the VM.
+- A missing _required_ path is fatal at startup with the path in the message; a
+  missing _optional_ path is not.
+- The unveiled library directories are the enumerated list, not raw `@INC`:
+  `/usr/local/lib` is not in the view on an installed layout.
 - `make check` green on Linux and Darwin, behaviour unchanged.
 - `mandoc -Tlint -W warning` clean.

--- a/plans/005-pledge-unveil/plan-5.md
+++ b/plans/005-pledge-unveil/plan-5.md
@@ -9,55 +9,90 @@ The motivating risk is specific. `FuguLib::Sandbox` is a no-op on Linux and
 Darwin by design, which is exactly the shape of a bug that hides: if a refactor
 makes `is_supported` return false on OpenBSD, or a `pledge` call is dropped from
 `bin/openhapd`, every existing test still passes. Nothing in phases 1–4 catches
-that. Something has to.
+that. Something has to — and it has to be something that actually fails when the
+call is removed.
 
 ## Tasks
 
-### 5.1 Negative integration tests
+### 5.1 Tests that fail when the restriction is absent
 
-In `t/openhap/integration/` (which never skips — see
-`t/openhap/integration/CLAUDE.md`), inside the OpenBSD VM:
+In `t/openhap/integration/` (which never skips, and **never parses logs** — see
+`t/openhap/integration/CLAUDE.md`), inside the OpenBSD VM.
 
-- **Pledge is really on.** Start `openhapd`, then confirm from outside that the
-  process is pledged. `ps -o pledge` is not available; the reliable signal is
-  that a pledge violation aborts. Two workable approaches, in order of
-  preference:
-  1. A test-only helper invocation that pledges with the production promise set
-     and then deliberately violates it, asserting `SIGABRT`. This proves the
-     promise string in the daemon is a real pledge, not an empty string.
-  2. `ktrace -p $(pgrep openhapd)` during a normal pairing and `kdump` asserting
-     no `pledge` violations — a regression net for promise-set drift, since a
-     missing promise shows up here before it shows up in production.
-- **Unveil is really on.** Assert the daemon cannot read a file outside its
-  unveiled set. Create `/tmp/openhap-unveil-probe` and drive the daemon down a
-  path that would read an operator-supplied path; if no such path exists, use
-  the helper from the pledge test to unveil the production inventory and then
-  probe.
+The design constraint that shapes all of these: **a pledge violation kills the
+process.** So "the daemon is still alive and its trace shows no violation" is
+satisfied identically by a correctly pledged daemon and by a completely
+unpledged one. Any test built on the absence of violations is a null test. What
+is observable is the _syscall itself_.
+
+- **The daemon really pledges, with the right promise set.** Start `openhapd`
+  under `ktrace` from exec — `ktrace -di -f <file> rcctl start openhapd`, or
+  start the daemon directly under `ktrace` — then `kdump` and assert that a
+  `pledge` syscall appears **and that its promise-string argument is exactly the
+  production set**. `kdump` prints the string, so this asserts far more than
+  presence: an empty string, a typo, or a stray `proc exec` all fail. Remove the
+  `FuguLib::Sandbox->pledge` call from `bin/openhapd` and the syscall is simply
+  absent — the test fails. This is the assertion the earlier draft's two
+  approaches could not make: a test-only helper that pledges itself proves
+  nothing about the daemon, and "no violations in the trace" proves nothing at
+  all.
+- **The daemon really unveils, with the right paths.** Same trace, same method:
+  assert `unveil` calls appear with the expected path and permission arguments,
+  and that a final argument-less `unveil` (the lock) follows them. Removing the
+  unveil call or the lock makes this fail.
+- **Unveil actually restricts.** The syscall trace proves the call was made;
+  this proves it took effect. Assert from inside the VM that a file outside the
+  view is unreachable to the daemon's uid _through the daemon_, using whatever
+  operator- supplied path the daemon reads. If no such path exists — likely —
+  then say so plainly and rely on `t/fugulib/sandbox.t`'s forked-child unveil
+  test (phase 3, extended in phase 4) for the enforcement semantics, plus the
+  trace assertion above for the daemon's participation. Do not invent a
+  log-parsing probe: the integration tier forbids it, and a file the daemon
+  failed to open produces no other observable artifact.
 - **No child processes.** `pgrep -P $(pgrep openhapd)` is empty. This is phase
   2's contract, and it is what keeps `proc exec` out of the promise set; without
-  a test it can regress the moment anyone adds a `system()` call.
-- **Startup fails closed.** With a deliberately bogus promise string or a
-  nonexistent unveil path, `openhapd` exits nonzero and logs why, rather than
-  starting unrestricted. Drive this through a test-only flag or environment
-  override — not by editing the production string — and make sure the override
-  cannot loosen anything, only break startup.
+  a test it regresses the moment anyone adds a `system()` call.
+- **Startup still succeeds in every configuration that worked before.** From
+  phase 4: no config file, `mdnsd` stopped, and `-f` on a host with no log file.
+  These are the tests that catch a disposition regression in the inventory.
 
-Each of these must fail when the corresponding call is commented out of
+**No test-only flag or environment override in `bin/openhapd`.** The earlier
+draft wanted one to force a bogus promise string, with the caveat "make sure the
+override cannot loosen anything". No such mechanism exists: the first `pledge`
+call defines the sandbox absolutely, so an externally supplied superset
+(`... proc exec prot_exec`) is a _weaker_ sandbox that starts fine — "bogus" and
+"wider" are the same input class. It would put external input on the security
+decision path of a root-started daemon, against `CLAUDE.md`'s "never trust
+external input" and against `plan-3.md` 3.1's own "no `force => 0`, no
+warn-and-continue". Fail-closed behaviour is proven where it belongs, in
+`t/fugulib/sandbox.t`, by calling `FuguLib::Sandbox` directly with a bogus
+promise string and a nonexistent required path.
+
+Each test above must fail when the corresponding call is commented out of
 `bin/openhapd`. Verify that by actually commenting it out once during
-development; a test that cannot fail is not evidence.
+development; a test that cannot fail is not evidence. Where a test cannot meet
+that bar — the enforcement probe, if no operator-supplied read path exists — say
+so in the file's comments rather than letting it read as proof.
 
 ### 5.2 `openhapd.8` SECURITY section
 
-One place an operator can read to understand the daemon's posture. Contents:
+One place an operator can read to understand the daemon's posture:
 
 - The promise set, with a one-line gloss on why each promise is present, and the
-  explicit statement that `proc`, `exec`, and `prot_exec` are absent.
-- The unveiled paths and their permissions (cross-referencing FILES from phase
-  4).
+  explicit statement that `proc`, `exec`, and `prot_exec` are absent. Note
+  whether `unix` is present, since phase 3 makes it conditional on the mDNS
+  reconnect mechanism.
+- The unveiled paths and their permissions, marking required versus optional
+  (cross-referencing FILES from phase 4).
 - The privilege model: starts as root, `chown`s `$db_path`, drops to `_openhap`,
-  requires `wheel` membership for `/var/run/mdnsd.sock`, then unveils and
-  pledges. Say plainly that pledge and unveil are applied _after_ the privilege
-  drop and what that does and does not buy.
+  then unveils and pledges. Say plainly that pledge and unveil are applied
+  _after_ the privilege drop and what that does and does not buy. **Write only
+  what phase 2's measurement established** about `/var/run/mdnsd.sock` access.
+  The long-standing comment at `bin/openhapd:116` claims `_openhap` must be in
+  `wheel`, but `FuguLib::Privdrop` calls only `setgid`/`setuid` — never
+  `setgroups`/`initgroups` — and Perl's `$) = $gid` at `Privdrop.pm:73` itself
+  invokes `setgroups`, which would drop wheel rather than keep it. Do not
+  restate an unverified privilege boundary in an installed man page.
 - OpenBSD-only enforcement. Linux and Darwin are development platforms and the
   restrictions are no-ops there. An operator who reads only the README should
   not be able to conclude that a Linux deployment is hardened.
@@ -74,7 +109,7 @@ One place an operator can read to understand the daemon's posture. Contents:
   that finished entries say what landed.
 - The `Privilege separation` item (`TODO.md:489`) stays open, but update it: a
   pledged monolith changes what separation would buy, and the entry should say
-  so rather than reading as though nothing has happened.
+  so.
 - Add a `hapctl` pledge item. It is now cheap — `FuguLib::Sandbox` exists, and
   `hapctl` reads config and state and prints, so `stdio rpath` plus a handful of
   unveiled paths covers it — and leaving it undone while `openhapd` is pledged
@@ -88,32 +123,64 @@ One place an operator can read to understand the daemon's posture. Contents:
   with no implementation and no conformance citation is exactly what
   `make spec-coverage` is for, so record it rather than letting the coverage gap
   read as an oversight.
+- **Add an item for SIGHUP.** `etc/rc.d/openhapd:16-18` reloads with
+  `pkill -HUP`, but `bin/openhapd:177` registers HUP via
+  `setup_graceful_exit('INT','TERM','HUP')`, so `rcctl reload openhapd` _stops_
+  the daemon — and after phase 2 that also closes the held mdnsd socket,
+  withdrawing the advertisement, since the socket is the advertisement. This is
+  a pre-existing bug that plan 005 deliberately does not fix, and three parts of
+  the design lean on reload as future work, so it must be recorded. Note the
+  pledge constraint while recording it: a real reload must not re-exec, or
+  `exec` returns to the promise set and the benefit goes.
+- **Add an item for the `wheel` privilege model**, if phase 2's measurement
+  showed the comment at `bin/openhapd:116` does not describe what actually
+  grants socket access.
 
 ### 5.4 Verify the aspirational docs are now accurate
 
-No rewriting — checking. `README.md:16`, `CLAUDE.md:7`, `CLAUDE.md:103`, and
-`web/index.body.html:19-20` all claim pledge/unveil support. Read each one
-against what shipped and confirm it is now true rather than merely plausible. If
-any claim overreaches — for instance implying Linux is hardened too — fix that
-specific sentence, and only that one.
+No rewriting — checking. Read each claim against what shipped and confirm it is
+true rather than merely plausible. If any overreaches — for instance implying
+Linux is hardened too — fix that specific sentence, and only that one.
+
+- `README.md:16`, `CLAUDE.md:7`, `CLAUDE.md:107-108`,
+  `web/index.body.html:19-20` — the pledge/unveil claims. (The earlier draft
+  cited `CLAUDE.md:103`; that line is the `IO::Select` rule.)
+
+Two more that phases 2–4 falsify and no earlier phase is allowed to touch:
+
+- **`web/fugulib.body.html:8`** reads "It is deliberately small. Six modules, no
+  dependencies outside core Perl" and enumerates exactly six in a `<dl>`. This
+  plan adds `Imsg`, `MDNS` and `Sandbox` — nine. Update the count and add the
+  three entries. `t/web/site.t` will not catch this: its exhaustiveness
+  assertion counts only `/^(?:OpenHAP|OpenHVF)::.*\.3p\.html$/` against `.pod`
+  sidecars and deliberately excludes FuguLib.
+- **`CLAUDE.md:14-15`** scopes FuguLib as "generic OpenBSD-style daemon
+  utilities (daemonize, privilege drop, signals, logging, process, state)" — an
+  enumeration that an mdnsd protocol client and a pledge/unveil wrapper fall
+  outside of. Extend it.
 
 ## Deliverables
 
 - New/extended tests in `t/openhap/integration/`
 - `man/openhap/openhapd.8` SECURITY section
 - `TODO.md` updates
+- `web/fugulib.body.html` module count and entries
 - Any narrow corrections to `README.md`, `CLAUDE.md`, `web/index.body.html`
 
 ## Acceptance criteria
 
-- Every test in 5.1 provably fails when the corresponding `bin/openhapd` call is
-  removed — demonstrated, not assumed.
+- The pledge and unveil trace assertions fail when the corresponding call is
+  removed from `bin/openhapd` — demonstrated by removing it once, not assumed.
+  The pledge assertion checks the promise _string_, so a wrong or empty set
+  fails too.
+- Any test in 5.1 that cannot meet that bar says so in its own comments.
 - `make integration` green on OpenBSD; `make check` green on Linux and Darwin.
 - `openhapd.8` renders clean under `mandoc -Tlint -W warning` and answers,
-  without reference to the source: what is pledged, what is unveiled, what
-  happens on violation, and where enforcement applies.
-- `TODO.md` has no remaining claim that pledge or unveil is unimplemented.
+  without reference to the source: what is pledged, what is unveiled, which
+  paths are optional, what happens on violation, and where enforcement applies.
+- `TODO.md` has no remaining claim that pledge or unveil is unimplemented, and
+  records the SIGHUP reload bug.
+- `web/fugulib.body.html` no longer says six modules.
 - `make spec-coverage` exits zero with `MDNS-Imsg` and `MDNS-Control` coverage
-  no lower than phase 2 left it. This phase adds no spec citations, so the check
-  is a regression net: it catches a `spec/MDNS*.md` regeneration that moved
-  sections out from under phase 2's conformance tests.
+  no lower than phase 2 left it, and HAP-mDNS coverage no lower than before
+  phase 2. This phase adds no spec citations, so the check is a regression net.


### PR DESCRIPTION
Reviewed plan 005 with the fan-out of cold sub-agents `CLAUDE.md` prescribes — six angles (contracts, phase independence, security boundaries, testability, OpenBSD fit, omissions), each prompted to refute — then revised the design and all five phase plans against what survived cross-confirmation. Documents only; no code changes.

## Why

The plan landed at `46ff496`, one commit before `2da2b57` removed the spec and compliance skills and rewrote `spec/CLAUDE.md`. That left phase 1 unimplementable and inverted the design's own justification for it.

## Blocking defects fixed

- **Phase 1 targeted deleted files.** Tasks 1.1/1.3/1.5 edited `fetch-external`, `spec-mqtt` and `compliance-hap`, none of which exist; the design argued for a generator skill because `spec/CLAUDE.md` "forbids" hand-maintained specs, where that file now says "These are hand-maintained documents. Edit them in place". Rebased on hand-authored spec files with inline upstream citations.
- **Phase 2 named one test file for deletion; five bind to the interface it removes** — including `t/conformance/hap-mdns.t` (the sole citation site for `HAP-mDNS §10`) and `t/openhap/integration/mdns-cleanup.t`, which asserts the `mdnsctl` child *exists*. Each now has an explicit disposition. The TXT formatting and the unpublished-handle guard, both living in the deleted module, are given new homes instead of being assumed to exist already.
- **Phase 4's inventory made three legitimately-absent paths fatal** — a missing config file (`bin/openhapd:32`), a stopped `mdnsd`, and a first `openhapd -f` — so configurations that start today would refuse to boot. Paths now carry a required/optional disposition, and library directories are enumerated rather than derived from live `@INC`, which on an installed layout resolves to all of `/usr/local/lib`.
- **Phase 5's promise-string override is dropped.** The first `pledge` call defines the sandbox absolutely, so an externally supplied superset is a *weaker* sandbox, not a broken one — the override could not do what it claimed.

## Acceptance criteria that could not fail

- Every XS dependency is already loaded by compile-time `use`, and `Math::BigInt` resolves its backend in `import` — so the preload block reduces to the one genuinely lazy, pure-Perl `require`, `eval`-guarded to keep it optional.
- The pledge-violation test now asserts in the parent on the wait status; `SIGABRT` leaves the child nothing to say.
- Phase 5 proves pledge and unveil by asserting the syscalls *and their arguments* in a `kdump`, rather than by the absence of violations — which a wholly unpledged daemon satisfies identically. Log-parsing assertions removed per `t/openhap/integration/CLAUDE.md`.

## Also

Measurement now gates phase 2's API (imsg header layout, the `GROUP_RESET` sequence, the group-name invariant). `FuguLib` modules do not log, matching the namespace's existing convention. `design.md`'s `Sandbox` contract is corrected to match `plan-3.md`. Added to phase 5: the SIGHUP reload bug (`rcctl reload` currently stops the daemon), the unverified `wheel` privilege model, and `web/fugulib.body.html`'s "Six modules".

## Testing

`make prettier` clean. No Perl or tests changed. `make check`'s `lint`/`test` stages cannot run in this container (no Perl::Critic, Perl::Tidy or JSON::XS) and fail identically on a clean tree — verified by stashing.

`design.md` is 280 lines against `CLAUDE.md`'s 200-line aim, after two cutting passes; the review added seven contracts. Happy to trim further if you'd prefer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VjaePomqVedCMoDqM5hpW9)_