### PR TITLE
docs: remove overclaims from the README, website, man pages and pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Website and manuals: <https://www.openhap.org/>
 
 ## Features
 
-- **HomeKit**: Full HAP implementation with secure pairing
-- **Crypto**: SRP-6a, Ed25519, X25519, ChaCha20-Poly1305
-- **Thermostats**: Control Tasmota heaters with temperature sensors
-- **MQTT**: Connects HomeKit to MQTT-based devices
-- **OpenBSD**: Native with pledge(2)/unveil(2) support
+- Pairs with the iOS Home app over HAP, and keeps the session encrypted
+- Tasmota thermostats, heaters, switches, sensors, lightbulbs and dimmers,
+  declared in `openhapd.conf(5)`
+- MQTT for device control and state
+- Runs as `_openhap` from `rc.d`, under pledge(2) and unveil(2)
 
 ## Quick Start
 

--- a/lib/OpenHAP/Crypto.pod
+++ b/lib/OpenHAP/Crypto.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::Crypto - Cryptographic operations for HAP protocol
+OpenHAP::Crypto - crypto primitives for HAP, wrapping CPAN modules
 
 =head1 SYNOPSIS
 
@@ -23,14 +23,25 @@ OpenHAP::Crypto - Cryptographic operations for HAP protocol
 
 =head1 DESCRIPTION
 
-This module provides cryptographic primitives required by the HomeKit
-Accessory Protocol:
+Thin wrappers over the CPAN modules that do the actual work, giving
+callers one argument order and one place to look for which module
+provides what:
 
-- Ed25519 signatures
-- X25519 key exchange
-- ChaCha20-Poly1305 authenticated encryption
-- HKDF-SHA-512 key derivation
-- SRP-6a parameters
+=over 4
+
+=item * Ed25519 signatures - L<Crypt::Ed25519>
+
+=item * X25519 key exchange - L<Crypt::Curve25519>
+
+=item * ChaCha20-Poly1305 - L<Crypt::AuthEnc::ChaCha20Poly1305>
+
+=item * HKDF-SHA-512 - L<Crypt::KeyDerivation>
+
+=back
+
+The module also holds the SRP-6a group parameters from
+F<spec/HAP-Pairing.md> (the RFC 5054 3072-bit group, C<g> = 5) for
+L<OpenHAP::SRP>, and reads random bytes from F</dev/urandom>.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Daemon.pm
+++ b/lib/OpenHAP/Daemon.pm
@@ -40,7 +40,7 @@ sub daemonize ( $class, $logfile = '/var/log/openhapd.log' )
 #	Write current PID to file. Returns true on success.
 sub write_pidfile ( $class, $path )
 {
-	my $state = FuguLib::State->new( pidfile => $path );
+	my $state = FuguLib::State->new($path);
 	unless ( $state->write_pid($$) ) {
 		$OpenHAP::logger->error( 'Cannot write PID file %s', $path )
 		    if $OpenHAP::logger;
@@ -56,7 +56,7 @@ sub write_pidfile ( $class, $path )
 #	or cannot be read.
 sub read_pidfile ( $class, $path )
 {
-	my $state = FuguLib::State->new( pidfile => $path );
+	my $state = FuguLib::State->new($path);
 	my $pid   = $state->read_pid();
 	return $pid;
 }

--- a/lib/OpenHAP/Daemon.pod
+++ b/lib/OpenHAP/Daemon.pod
@@ -20,9 +20,11 @@ OpenHAP::Daemon - Daemonization and process management
 
 =head1 DESCRIPTION
 
-OpenHAP::Daemon provides utilities for daemonizing processes and managing
-PID files on OpenBSD. It handles forking, session creation, and file
-descriptor redirection following OpenBSD conventions.
+C<daemonize>, C<write_pidfile>, C<read_pidfile> and C<check_running> are
+a compatibility shim over L<FuguLib::Daemon> and L<FuguLib::State>,
+which document the behaviour; new code should call those directly.
+C<unveil_paths> is the part that belongs here, since the path list it
+assembles is specific to openhapd.
 
 =head1 CLASS METHODS
 
@@ -83,16 +85,9 @@ unveils F</usr/local/lib>. Pure assembly - nothing here changes the
 filesystem view - so it is unit-testable anywhere. C<perl_dirs>
 overrides the enumerated directories for tests.
 
-=head1 SECURITY CONSIDERATIONS
-
-The daemonize() method sets C<$DB::inhibit_exit = 0> after forking to
-ensure proper cleanup when running under the debugger.
-
-PID files should be stored in /var/run/ with appropriate permissions.
-
 =head1 SEE ALSO
 
-L<OpenHAP::Log>, L<daemon(3)>, L<rc.d(8)>
+L<FuguLib::Daemon>, L<FuguLib::State>, L<rc.d(8)>
 
 =head1 AUTHOR
 

--- a/lib/OpenHAP/DeviceLoader.pod
+++ b/lib/OpenHAP/DeviceLoader.pod
@@ -22,10 +22,9 @@ OpenHAP::DeviceLoader - Device configuration loading and instantiation
 
 =head1 DESCRIPTION
 
-OpenHAP::DeviceLoader handles loading device configurations, validating
-them, instantiating the appropriate device classes, and registering them
-with the HAP bridge. It centralizes device management logic and provides
-extensibility for adding new device types.
+Reads the device blocks from an L<OpenHAP::Config>, validates them,
+instantiates the matching device class, and registers each one with the
+HAP bridge.
 
 =head1 METHODS
 
@@ -92,48 +91,26 @@ Devices missing required fields are skipped with appropriate error logging.
 
 =head1 SUPPORTED DEVICES
 
-Currently supported device types:
+The only device type is C<tasmota>, with these subtypes:
 
 =over 4
 
-=item * B<tasmota/thermostat> - Tasmota-based thermostat devices
+=item * B<thermostat> - L<OpenHAP::Tasmota::Thermostat>
 
-=back
+=item * B<heater>, B<switch> - L<OpenHAP::Tasmota::Heater>
 
-Additional device types can be added by:
+=item * B<sensor> - L<OpenHAP::Tasmota::Sensor>
 
-=over 4
-
-=item 1. Adding type check to _is_supported_device()
-
-=item 2. Adding instantiation case to _instantiate_device()
-
-=item 3. Ensuring device class implements required interface
+=item * B<lightbulb>, B<dimmer>, B<rgblight>, B<ctlight> -
+L<OpenHAP::Tasmota::Lightbulb>
 
 =back
 
 =head1 ERROR HANDLING
 
-The loader uses eval blocks to catch errors during device instantiation
-and MQTT subscription. Errors are logged but don't stop processing of
-other devices. This ensures one misconfigured device doesn't prevent
-the entire system from starting.
-
-=head1 LOGGING
-
-The loader logs at various levels:
-
-=over 4
-
-=item * B<debug> - Device processing details, MQTT subscriptions
-
-=item * B<info> - Successfully loaded devices, summary counts
-
-=item * B<warning> - Missing optional fields, recoverable issues
-
-=item * B<error> - Invalid configurations, instantiation failures
-
-=back
+Device instantiation and MQTT subscription run inside C<eval>, so one
+misconfigured device is logged and skipped rather than stopping the
+daemon from starting.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/HAP.pod
+++ b/lib/OpenHAP/HAP.pod
@@ -8,7 +8,7 @@ OpenHAP::HAP - Main HAP server
 
     my $server = OpenHAP::HAP->new(
         port => 51827,
-        pin => '123-45-678',
+        pin => '9876-5432',
         name => 'My Bridge',
     );
 

--- a/lib/OpenHAP/MQTT.pod
+++ b/lib/OpenHAP/MQTT.pod
@@ -17,7 +17,9 @@ OpenHAP::MQTT - MQTT client wrapper for OpenHAP
 
 =head1 DESCRIPTION
 
-This module provides a simple MQTT client wrapper for OpenHAP.
+A wrapper around L<Net::MQTT::Simple>, which is loaded with C<require>
+so it stays optional: without it, the daemon starts and serves HomeKit
+but no device state moves. Connections are plaintext; there is no TLS.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/PIN.pod
+++ b/lib/OpenHAP/PIN.pod
@@ -7,28 +7,26 @@ OpenHAP::PIN - HomeKit Accessory Protocol PIN validation and normalization
     use OpenHAP::PIN qw(normalize_pin validate_pin);
 
     # Normalize PIN (strip dashes/spaces)
-    my $normalized = normalize_pin('1234-5678');  # Returns '12345678'
-    my $normalized = normalize_pin('1234 5678');  # Returns '12345678'
-    my $normalized = normalize_pin('12345678');   # Returns '12345678'
+    my $normalized = normalize_pin('9876-5432');  # Returns '98765432'
+    my $normalized = normalize_pin('9876 5432');  # Returns '98765432'
+    my $normalized = normalize_pin('98765432');   # Returns '98765432'
 
     # Validate PIN
-    if (validate_pin('1234-5678')) {
+    if (validate_pin('9876-5432')) {
         print "Valid PIN\n";
     }
 
-    if (!validate_pin('12345678')) {
+    if (!validate_pin('1234-5678')) {
         print "Invalid PIN (sequential pattern)\n";
     }
 
 =head1 DESCRIPTION
 
-This module provides utilities for handling HomeKit Accessory Protocol (HAP)
-setup codes (PINs). PINs are 8-digit numeric codes used during the pairing
-process.
+Handles HAP setup codes: 8-digit numeric codes used during pairing.
 
-Per the HAP specification, dashes and spaces in PINs are formatting characters
-only and are stripped before use. The PIN C<1234-5678> is equivalent to
-C<12345678>.
+Per the HAP specification, dashes and spaces are formatting characters only
+and are stripped before use, so C<9876-5432> and C<98765432> are the same
+setup code.
 
 =head1 FUNCTIONS
 
@@ -37,8 +35,8 @@ C<12345678>.
 Normalizes a PIN by stripping dashes and spaces, returning the 8-digit
 numeric string.
 
-    my $normalized = normalize_pin('1234-5678');
-    # Returns: '12345678'
+    my $normalized = normalize_pin('9876-5432');
+    # Returns: '98765432'
 
 Returns C<undef> if the input is not a valid format (not exactly 8 digits
 after normalization).
@@ -57,51 +55,17 @@ Validates a PIN meets HAP requirements:
 
 Returns C<1> if valid, C<undef> if invalid.
 
-    if (validate_pin('1234-5678')) {
+    if (validate_pin('9876-5432')) {
         # PIN is valid
     }
 
 =head1 INVALID PINS
 
-The following PINs are invalid per the HAP specification:
+The HAP specification rejects these setup codes:
 
     00000000  11111111  22222222  33333333  44444444
     55555555  66666666  77777777  88888888  99999999
     12345678  87654321
-
-These patterns are too simple and pose a security risk.
-
-=head1 PIN FORMAT
-
-PINs may be formatted with dashes for readability:
-
-=over 4
-
-=item * Format: C<XXXX-XXXX> where X is a digit 0-9
-
-=item * Examples: C<1234-5678>, C<9876-5432>
-
-=item * Dashes are optional and stripped during processing
-
-=back
-
-The canonical format used in configuration files and displays is C<XXXX-XXXX>,
-but the underlying 8-digit number is what matters for validation and
-cryptographic operations.
-
-=head1 SECURITY CONSIDERATIONS
-
-=over 4
-
-=item * Never use default or example PINs in production
-
-=item * Generate random PINs that are not trivial patterns
-
-=item * Store PINs securely with appropriate file permissions
-
-=item * Consider displaying PINs only on secure channels (local console)
-
-=back
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Pairing.pod
+++ b/lib/OpenHAP/Pairing.pod
@@ -7,7 +7,7 @@ OpenHAP::Pairing - HAP pairing protocol implementation
     use OpenHAP::Pairing;
 
     my $pairing = OpenHAP::Pairing->new(
-        pin => '123-45-678',
+        pin => '9876-5432',
         storage => $storage,
         accessory_ltsk => $ltsk,
         accessory_ltpk => $ltpk,

--- a/lib/OpenHAP/SRP.pod
+++ b/lib/OpenHAP/SRP.pod
@@ -19,7 +19,13 @@ OpenHAP::SRP - SRP-6a implementation for HAP pairing
 
 =head1 DESCRIPTION
 
-This module implements SRP-6a protocol for HomeKit pairing.
+The server (accessory) role of the SRP-6a exchange used by HAP
+pair-setup. The group parameters come from L<OpenHAP::Crypto>, the
+modular arithmetic from L<Math::BigInt> (with the GMP backend when it is
+installed, which matters: the pure-Perl backend takes seconds per
+exponentiation at 3072 bits).
+
+L<OpenHAP::Test::Controller::SRP> is the client side, for tests.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Test/Integration.pod
+++ b/lib/OpenHAP/Test/Integration.pod
@@ -20,11 +20,13 @@ OpenHAP::Test::Integration - Base module for OpenHAP integration tests
 
 =head1 DESCRIPTION
 
-Provides common setup, teardown, and utility functions for integration tests.
-Ensures environment is properly configured and dependencies are available.
+Setup, teardown, and helpers for the integration tests, which run against
+an installed openhapd on OpenBSD rather than against modules in the
+checkout.
 
-Integration tests must run in a properly configured OpenBSD environment with
-all dependencies installed. Tests fail (not skip) if requirements are not met.
+Unlike the unit tests, these fail rather than skip when a requirement is
+missing, since a silent skip in the VM would report a green run that
+tested nothing.
 
 =head1 ENVIRONMENT
 

--- a/man/fugulib/Sandbox.3p
+++ b/man/fugulib/Sandbox.3p
@@ -47,15 +47,13 @@ the restrictions are real,
 everywhere else every method is a no-op returning success,
 and
 .Fn is_supported
-\(em a return value, not a log line \(em is how a caller or a test
-tells enforcement from emulation.
+tells a caller or a test which of the two it got.
 .Pp
 All methods are class methods;
 there is no object,
 because the two syscalls being wrapped are process-global.
-Failures die with the offending promise string or path and the errno:
-there is no force flag and no warn-and-continue mode,
-since a daemon that cannot restrict itself must not start.
+Failures die with the offending promise string or path and the errno;
+there is no force flag and no warn-and-continue mode.
 The module never logs;
 callers decide what to report.
 .Pp

--- a/man/openhap/hapctl.8
+++ b/man/openhap/hapctl.8
@@ -29,9 +29,9 @@
 is a command-line utility for managing and querying the
 .Xr openhapd 8
 daemon.
-It provides commands for configuration validation,
-daemon status checks,
-and device management.
+It validates the configuration file,
+reports whether the daemon is running and paired,
+and lists the configured devices.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds

--- a/man/openhap/openhapd.8
+++ b/man/openhap/openhapd.8
@@ -27,8 +27,8 @@
 .Sh DESCRIPTION
 The
 .Nm
-daemon implements the HomeKit Accessory Protocol (HAP),
-enabling Apple HomeKit integration with MQTT-connected Tasmota devices
+daemon speaks the HomeKit Accessory Protocol (HAP)
+so that Apple HomeKit can control MQTT-connected Tasmota devices
 on
 .Ox .
 .Pp
@@ -38,20 +38,20 @@ and devices controlled via MQTT,
 translating HAP requests into MQTT commands and publishing device state
 changes back to HomeKit.
 .Pp
-The daemon implements the complete HAP specification including:
+Pairing and transport security follow the HAP specification:
 .Bl -bullet -compact
 .It
-Secure pairing using SRP-6a (Secure Remote Password)
+Pair-setup with SRP-6a (Secure Remote Password)
+.It
+Pair-verify with Curve25519 (X25519) key exchange
+.It
+Ed25519 signatures for accessory and controller identity
+.It
+HKDF-SHA-512 key derivation
 .It
 Session encryption with ChaCha20-Poly1305 AEAD
 .It
-Curve25519 (X25519) key exchange for session establishment
-.It
-Ed25519 digital signatures for authentication
-.It
-HKDF-SHA-512 for key derivation
-.It
-mDNS service advertisement
+Service advertisement over mDNS
 .El
 .Pp
 The service is advertised over mDNS by talking to
@@ -231,8 +231,8 @@ HomeKit Accessory Protocol Specification (Non-Commercial Version):
 .Lk https://developer.apple.com/homekit/
 .Sh STANDARDS
 .Nm
-implements the HomeKit Accessory Protocol Specification R2,
-including:
+follows the HomeKit Accessory Protocol Specification R2 for IP accessories.
+The cryptography it uses is specified in:
 .Bl -bullet -compact
 .It
 RFC 5054: Using the Secure Remote Password (SRP) Protocol for TLS Authentication
@@ -246,10 +246,9 @@ RFC 8032: Edwards-Curve Digital Signature Algorithm (EdDSA)
 RFC 7748: Elliptic Curves for Security (Curve25519)
 .El
 .Sh HISTORY
+The
 .Nm
-was written from scratch in 2025 for
-.Ox
-as a native implementation of the HomeKit Accessory Protocol.
+daemon first appeared in 2025.
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh CAVEATS
@@ -274,8 +273,8 @@ The directory should be owned by
 with mode 0700.
 .Sh BUGS
 .Nm
-currently only supports Tasmota devices.
-Additional device types and protocols may be added in future versions.
+only supports Tasmota devices over MQTT.
+HAP over Bluetooth Low Energy is not implemented.
 .Sh SECURITY CONSIDERATIONS
 .Nm
 starts as root to fix the ownership of

--- a/man/openhap/openhapd.conf.5
+++ b/man/openhap/openhapd.conf.5
@@ -45,8 +45,6 @@ Default: 51827.
 The 8-digit setup code used for pairing.
 Format: XXXX-XXXX where X is a digit 0-9.
 Dashes are for readability only and are stripped during processing.
-The PIN is validated as an 8-digit number.
-The PIN is validated as an 8-digit number.
 Certain values are invalid per the HAP specification
 (after stripping dashes):
 00000000, 11111111, 22222222, 33333333, 44444444,
@@ -238,5 +236,8 @@ or
 .Ic hap_pin
 after pairing may require re-pairing all controllers.
 .Pp
-MQTT passwords are stored in plain text.
-Consider using certificate-based authentication for production deployments.
+.Ic mqtt_pass
+is stored in plain text and is sent to the broker in the clear;
+.Xr openhapd 8
+does not speak MQTT over TLS.
+Keep the broker on the local machine or on a trusted network.

--- a/t/openhap/daemon.t
+++ b/t/openhap/daemon.t
@@ -152,4 +152,24 @@ use File::Temp qw(tempdir);
 	    'db_path is not optional to the builder');
 }
 
+# Test 5: the PID file shim round-trips through FuguLib::State
+{
+	use OpenHAP::Daemon;
+
+	my $tmpdir  = tempdir(CLEANUP => 1);
+	my $pidfile = "$tmpdir/openhapd.pid";
+
+	ok(OpenHAP::Daemon->write_pidfile($pidfile),
+	    'write_pidfile reports success');
+	is(OpenHAP::Daemon->read_pidfile($pidfile), $$,
+	    'read_pidfile returns the PID that was written');
+
+	# A path that cannot be opened is a recoverable error, not a die
+	my $unwritable = "$tmpdir/nonexistent/openhapd.pid";
+	is(OpenHAP::Daemon->write_pidfile($unwritable), undef,
+	    'write_pidfile returns undef on an unopenable path');
+	is(OpenHAP::Daemon->read_pidfile("$tmpdir/absent.pid"), undef,
+	    'read_pidfile returns undef for a missing file');
+}
+
 done_testing();

--- a/web/404.body.html
+++ b/web/404.body.html
@@ -4,5 +4,4 @@
 have moved when a manual was renamed.</p>
 
 <p>Start from <a href="index.html">the front page</a>, or go straight to the
-<a href="manuals.html">manuals</a> &mdash; everything on this site is one of
-those two things or is linked from them.</p>
+<a href="manuals.html">manuals</a>.</p>

--- a/web/fugulib.body.html
+++ b/web/fugulib.body.html
@@ -1,14 +1,13 @@
 <h1>FuguLib</h1>
 
-<p>FuguLib is the handful of things every OpenBSD daemon needs and the base
-system does not hand you in Perl: going into the background, writing a PID
-file, dropping privileges, reaping children, handling signals, logging to
-syslog or stderr depending on how you were started, restricting yourself with
-pledge and unveil, and advertising over mDNS without shelling out.</p>
+<p>FuguLib covers the parts of writing an OpenBSD-style daemon in Perl that the
+base system leaves to you: going into the background, writing a PID file,
+dropping privileges, reaping children, handling signals, logging to syslog or
+stderr depending on how the program was started, restricting itself with pledge
+and unveil, and advertising over mDNS without shelling out.</p>
 
-<p>It is deliberately small.  Nine modules, no dependencies outside core Perl,
-no framework, no configuration, and no opinion about what your daemon does.
-OpenHAP is built on it; nothing in it knows that.</p>
+<p>Nine modules, using only core Perl.  OpenHAP is built on it; nothing in it
+knows about OpenHAP.</p>
 
 <h2>The modules</h2>
 
@@ -20,7 +19,7 @@ written.</dd>
 
 <dt>FuguLib::Privdrop</dt>
 <dd>Drop from root to a named user and group, then verify that root cannot be
-regained &mdash; the check is the point.</dd>
+regained.</dd>
 
 <dt>FuguLib::Process</dt>
 <dd>Spawn, exec, verify a child actually survived start-up, terminate with a
@@ -66,6 +65,4 @@ listed under <a href="manuals.html#fugulib">FuguLib in the manuals</a>.</p>
 
 <h2>Name</h2>
 
-<p><em>Fugu</em> is the pufferfish: OpenBSD&rsquo;s mascot is a pufferfish, and
-the fish is famously safe only if prepared correctly.  Both readings are
-intended.</p>
+<p><em>Fugu</em> is the pufferfish, after OpenBSD&rsquo;s mascot.</p>

--- a/web/fugulib.body.html
+++ b/web/fugulib.body.html
@@ -43,8 +43,8 @@ on <code>FuguLib::Process</code>.</dd>
 <dd><a href="https://man.openbsd.org/pledge.2">pledge(2)</a> and
 <a href="https://man.openbsd.org/unveil.2">unveil(2)</a> as a platform
 abstraction: real on OpenBSD, a no-op everywhere else, so callers never test
-the operating system themselves.  Failures die &mdash; a daemon that cannot
-restrict itself must not start.</dd>
+the operating system themselves.  Failures die; there is no
+warn-and-continue mode.</dd>
 
 <dt>FuguLib::Imsg</dt>
 <dd>The base-system imsg framing &mdash; a fixed native-endian header and a

--- a/web/index.body.html
+++ b/web/index.body.html
@@ -2,13 +2,11 @@
 
 <p>OpenHAP puts MQTT-connected Tasmota devices into Apple&rsquo;s Home app.  An
 iPhone pairs with <code>openhapd</code> as if it were an accessory;
-<code>openhapd</code> speaks MQTT to the real ones.  Neither end needs to know
-the other exists.</p>
+<code>openhapd</code> speaks MQTT to the real ones.</p>
 
-<p>It is written in Perl against the base system.  There is no bridge
-appliance to buy, no cloud account, no container, and no vendor between the
-phone and the thermostat &mdash; a daemon, a configuration file, and
-<code>rcctl</code>.</p>
+<p>It is written in Perl against the base system: a daemon, a configuration
+file in <code>/etc</code>, and <code>rcctl</code>.  No cloud account, and no
+separate appliance.</p>
 
 <h2>Design</h2>
 
@@ -19,10 +17,12 @@ phone and the thermostat &mdash; a daemon, a configuration file, and
 <a href="https://man.openbsd.org/pledge.2">pledge(2)</a> and
 <a href="https://man.openbsd.org/unveil.2">unveil(2)</a>.</dd>
 
-<dt>The protocol, not a library binding</dt>
-<dd>Pairing and session setup are implemented directly: SRP-6a, Ed25519,
-X25519, ChaCha20-Poly1305, HKDF-SHA-512, and TLV8 carried over encrypted
-HTTP/1.1, advertised by mDNS.</dd>
+<dt>Pairing and sessions</dt>
+<dd>Pair-setup is an SRP-6a exchange over the RFC 5054 3072-bit group;
+pair-verify is X25519 with Ed25519 signatures.  Sessions are encrypted with
+ChaCha20-Poly1305 under keys from HKDF-SHA-512.  Messages are TLV8 and JSON
+over HTTP/1.1, advertised by <code>mdnsd</code>.  The SRP exchange and the
+framing are written here; the primitives come from CPAN modules.</dd>
 
 <dt>Devices as configuration</dt>
 <dd>Accessories are declared in <code>openhapd.conf(5)</code> and loaded at
@@ -30,8 +30,8 @@ start-up.  Thermostats, heaters, switches, sensors, lightbulbs and dimmers are
 supported today.</dd>
 
 <dt>Small enough to read</dt>
-<dd>Every module is documented, every behaviour is tested, and the whole
-thing is a checkout you can audit in an afternoon.</dd>
+<dd>Each module has a manual page or a POD sidecar, and the tests live
+beside the source in <code>t/</code>.</dd>
 </dl>
 
 <h2>Getting started</h2>
@@ -55,5 +55,5 @@ source.</p>
 neither is about HomeKit:
 <a href="fugulib.html">FuguLib</a>, the OpenBSD-style daemon utilities the
 server is built on, and <a href="openhvf.html">OpenHVF</a>, which installs and
-manages OpenBSD virtual machines under QEMU &mdash; useful to anyone who needs
-an OpenBSD machine on demand, and used here to run the tests.</p>
+manages OpenBSD virtual machines under QEMU, and is used here to run the
+tests.</p>

--- a/web/openhvf.body.html
+++ b/web/openhvf.body.html
@@ -6,9 +6,8 @@ answers the installer over the serial console, and hands you back a machine
 that accepts SSH.  One command, unattended, on a host that need not be running
 OpenBSD itself.</p>
 
-<p>Anyone who has installed OpenBSD by hand to test one thing knows why this
-exists.  OpenHVF turns that afternoon into <code>openhvf up</code>, and turns
-the result into something a <code>Makefile</code> can drive.</p>
+<p>It exists so that an install can be driven from a <code>Makefile</code>
+rather than answered by hand.</p>
 
 <h2>What it does</h2>
 
@@ -18,7 +17,7 @@ the result into something a <code>Makefile</code> can drive.</p>
 drives <code>bsd.rd</code> through the installer, and starts the machine.  It
 is idempotent: run it again and nothing happens.</dd>
 
-<dt>A project, not a global daemon</dt>
+<dt>Per-project state</dt>
 <dd>State lives beside the code, in an <code>.openhvfrc</code> file and an
 <code>.openhvf/</code> directory found by searching upward from the current
 directory.  Several machines can be defined per project, each with its own
@@ -29,12 +28,12 @@ release, memory, disk and forwarded ports.</dd>
 the guest through a built-in proxy, so the expensive download happens once
 rather than once per machine.</dd>
 
-<dt>Scriptable, with honest exit codes</dt>
+<dt>Scriptable</dt>
 <dd><code>openhvf ssh</code> runs a command in the guest and exits with its
 status; <code>openhvf expect</code> drives the serial console with an
-<a href="https://man.openbsd.org/expect.1">expect(1)</a> script; a distinct
-exit code per failure mode &mdash; not running, timed out, download failed
-&mdash; means a script can tell what went wrong.</dd>
+<a href="https://man.openbsd.org/expect.1">expect(1)</a> script; and there is a
+distinct exit code per failure mode &mdash; not running, timed out, download
+failed.</dd>
 
 <dt>Whatever accelerator is there</dt>
 <dd>HVF on macOS, KVM on aarch64 Linux, TCG everywhere else, chosen
@@ -46,13 +45,13 @@ automatically and overridable with <code>--emulate</code>.</dd>
 <p>OpenHVF was written to run OpenHAP's integration tests on the platform they
 are about: <a href="https://man.openbsd.org/pledge.2">pledge(2)</a>,
 <a href="https://man.openbsd.org/unveil.2">unveil(2)</a>, <code>rc.d</code> and
-<code>mdnsd</code> cannot be tested anywhere else.  Nothing in it knows that;
-it is a general utility, and this repository is simply its first user.</p>
+<code>mdnsd</code> cannot be tested anywhere else.  Nothing in it knows about
+OpenHAP; this repository is its first user.</p>
 
 <p>It ships with the OpenHAP source but not with OpenHAP: <code>make
 install</code> does not install it, and no release package contains it.</p>
 
 <h2>Reference</h2>
 
-<p>Every option, subcommand, exit code and configuration key is documented in
+<p>Options, subcommands, exit codes and configuration keys are documented in
 the <a href="manuals.html#openhvf">manual</a>.</p>


### PR DESCRIPTION
Audit of every user-facing document for claims larger than the code supports, and for the prose tics that come with generated text.

## The crypto claim

`Crypto.pm` is entirely passthrough — `Crypt::Ed25519`, `Crypt::Curve25519`, `Crypt::AuthEnc::ChaCha20Poly1305`, `Crypt::KeyDerivation`. Three documents said otherwise:

- `README.md` listed SRP-6a, Ed25519, X25519 and ChaCha20-Poly1305 under a **Crypto** heading.
- `web/index.body.html` had a `<dt>The protocol, not a library binding</dt>` heading asserting the primitives are "implemented directly" — when it is precisely a library binding.
- `Crypto.pod` said it "provides cryptographic primitives required by the HomeKit Accessory Protocol".

Each now names the module behind each primitive. What *is* written here — the SRP-6a exchange and the session framing — is said as such rather than removed.

## Claims that were measurably false

| Claim | Reality |
| --- | --- |
| `openhapd.8`: "implements the complete HAP specification" | `make spec-coverage` reports 166/194 sections (85%); no BLE transport |
| `openhapd.8` STANDARDS: "implements HAP R2, including" 5 RFCs | those algorithms come from CPAN modules |
| `openhapd.conf.5`: "Consider using certificate-based authentication" | `Net::MQTT::Simple`, no TLS — the advice pointed at a feature that does not exist |
| `web/index.body.html`: "every behaviour is tested", "audit in an afternoon" | unfalsifiable |
| `DeviceLoader.pod`: only `tasmota/thermostat` supported | eight subtypes are dispatched |
| `MDNS.pod` referenced `OpenHAP::Log` ×3 | gone since the FuguLib split |
| `hapctl.8`: "device management" | `devices` only lists |

`openhapd.conf.5` also had a line duplicated verbatim under `hap_pin`.

## Setup codes the validator rejects

`PIN.pod` showed `validate_pin('1234-5678')` printing "Valid PIN" three lines above `validate_pin('12345678')` printing "Invalid PIN" — the same code, since dashes are stripped, and it is on the HAP blocklist. `HAP.pod` and `Pairing.pod` both constructed servers with `pin => '123-45-678'`, which normalizes to that same rejected code. All now use `9876-5432`, which `validate_pin` accepts.

## Generated-prose tics removed

`MDNS.pod` had an OPENBSD CONVENTIONS section listing repository style rules ("Returns undef for recoverable errors, reserves die for programming errors") as if they were module API. `DeviceLoader.pod` had a LOGGING section enumerating log levels and an ERROR HANDLING section closing "This ensures one misconfigured device doesn't prevent the entire system from starting." `PIN.pod` had "These patterns are too simple and pose a security risk" plus a SECURITY CONSIDERATIONS list of generic advice. `Daemon.pod` filed a `$DB::inhibit_exit` debugger note under SECURITY CONSIDERATIONS.

Also cut: "the check is the point", "Both readings are intended", "honest exit codes", "turns that afternoon into `openhvf up`", and four headings in the "X, not a Y" shape.

## One code change

`OpenHAP::Daemon::write_pidfile` and `read_pidfile` called `FuguLib::State->new(pidfile => $path)`, but that constructor takes the path positionally, so both died with *Too many arguments for subroutine 'FuguLib::State::new' (got 3; expected 2)* on every call. Neither is reached from `bin/`, and `check_running` on the same class already used the positional form, so the daemon and `hapctl` were unaffected — but `Daemon.pod` documents both as returning a value, which they could not do. Fixed positionally, with a subtest that dies at the first assertion without the fix.

Rebased onto `main` after #24; `Daemon.pod` now reflects that `unveil_paths` is real logic rather than a shim, `MDNS.pod` went away with `OpenHAP::MDNS`, and the FuguLib page counts nine modules.

`make check` passes; the site builds and `t/web/site.t` passes (3010 assertions).

## Left alone deliberately

`openhapd.conf.5` documents only `thermostat`, `heater` and `sensor` as subtypes, and `lib/OpenHAP/Tasmota/Lightbulb.pm` ships without a `.pod` sidecar — both under-document `switch`, `lightbulb`, `dimmer`, `rgblight` and `ctlight`. That is missing coverage rather than an overclaim, so it is not in this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZWfGVJxnLt71QgkkxpU4k)_