### PR TITLE
docs: rewrite all documentation in ASD-STE100 Simplified Technical English

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # CLAUDE.md
 
+> **CRITICAL: Write all output and all artifacts in ASD-STE100 Simplified
+> Technical English.** This rule applies to the README, `INSTALL.md`, man pages,
+> `.pod` sidecars, website text, code comments, commit messages, and chat
+> replies. Use the active voice and the approved words. Keep each instruction
+> shorter than 20 words and each descriptive sentence shorter than 25 words.
+> Write one instruction in each sentence. Do not change technical names,
+> commands, or code examples.
+
 OpenHAP is a HomeKit Accessory Protocol (HAP) server for **OpenBSD**, written in
 Perl (v5.36, base-system Perl, minimal dependencies). It bridges MQTT-connected
 Tasmota devices to Apple HomeKit: SRP-6a pairing, Ed25519, X25519,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ This document tells you how to install OpenHAP on OpenBSD. See
 ## Dependencies
 
 The `make deps` command installs the runtime dependencies. The manifests under
-`deps/` list them for each platform, for example `deps/OpenBSD.txt`.
+`deps/` list them for each platform, for example, `deps/OpenBSD.txt`.
 
 ## Install
 
@@ -96,7 +96,7 @@ openhapd -n -c /etc/openhapd.conf  # Do a check of the configuration
 tail /var/log/daemon | grep openhap
 ```
 
-**The Home app does not show the bridge:**
+**The iOS Home app does not show the bridge:**
 
 ```sh
 rcctl check mdnsd

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,18 +1,18 @@
 # Installation
 
-This document provides installation instructions for OpenHAP on OpenBSD. For
-detailed configuration options, see `openhapd.conf(5)`. For command-line
-options, see `openhapd(8)` and `hapctl(8)`.
+This document tells you how to install OpenHAP on OpenBSD. See
+`openhapd.conf(5)` for the configuration options. See `openhapd(8)` and
+`hapctl(8)` for the command-line options.
 
 ## Requirements
 
-- OpenBSD 7.4+
-- Perl 5.36+ (base system)
+- OpenBSD 7.4 or a later version
+- Perl 5.36 or a later version (base system)
 
 ## Dependencies
 
-The `make deps` command installs the runtime dependencies listed in the
-per-platform manifests under `deps/` (e.g. `deps/OpenBSD.txt`).
+The `make deps` command installs the runtime dependencies. The manifests under
+`deps/` list them for each platform, for example `deps/OpenBSD.txt`.
 
 ## Install
 
@@ -26,37 +26,39 @@ doas make install
 ## Setup
 
 ```sh
-# Create system user
+# Create the system user
 doas useradd -c "OpenHAP" -d /var/empty -g =uid -r 100..999 -s /sbin/nologin _openhap
-doas usermod -G wheel _openhap  # Required for mdnsd socket access
+doas usermod -G wheel _openhap  # Necessary for access to the mdnsd socket
 doas chown _openhap:_openhap /var/db/openhapd
 
-# Configure
+# Configure the daemon
 doas cp /etc/examples/openhapd.conf /etc/openhapd.conf
 doas vi /etc/openhapd.conf
 
-# Test configuration
+# Do a check of the configuration
 doas openhapd -n
 
-# Enable mDNS (replace vio0 with your interface)
+# Enable mDNS (replace vio0 with the name of your interface)
 echo 'multicast=YES' | doas tee -a /etc/rc.conf.local
 echo 'mdnsd_flags=vio0' | doas tee -a /etc/rc.conf.local
 
-# Start services
+# Enable and start the services
 doas rcctl enable mosquitto mdnsd openhapd
 doas rcctl start mosquitto mdnsd openhapd
 ```
 
 ## Firewall
 
-Add to `/etc/pf.conf`:
+Add these rules to `/etc/pf.conf`:
 
 ```
 pass in on $lan_if proto tcp to port 51827  # HAP
 pass in on $lan_if proto udp to port 5353   # mDNS
 ```
 
-## Verify
+## Checks
+
+Make sure that the daemon runs and that it loaded the devices:
 
 ```sh
 hapctl status
@@ -79,22 +81,22 @@ doas rcctl stop openhapd
 doas rcctl disable openhapd
 cd openhap
 doas make uninstall
-# Optionally remove configuration and data
+# If it is necessary, remove the configuration and the data
 doas rm -f /etc/openhapd.conf
 doas rm -rf /var/db/openhapd
 doas userdel _openhap
 ```
 
-## Troubleshooting
+## Problems
 
-**Won't start:**
+**The daemon does not start:**
 
 ```sh
-openhapd -n -c /etc/openhapd.conf  # Check config
+openhapd -n -c /etc/openhapd.conf  # Do a check of the configuration
 tail /var/log/daemon | grep openhap
 ```
 
-**Not found in Home app:**
+**The Home app does not show the bridge:**
 
 ```sh
 rcctl check mdnsd
@@ -102,7 +104,7 @@ mdnsctl browse
 nc -zv <ip> 51827
 ```
 
-**MQTT issues:**
+**MQTT does not operate correctly:**
 
 ```sh
 rcctl check mosquitto

--- a/README.md
+++ b/README.md
@@ -2,18 +2,19 @@
 
 **HomeKit Accessory Protocol for OpenBSD**
 
-OpenHAP bridges MQTT-connected Tasmota devices to Apple HomeKit, enabling
-control via the iOS Home app.
+OpenHAP connects MQTT-connected Tasmota devices to Apple HomeKit. You can
+control the devices with the iOS Home app.
 
 Website and manuals: <https://www.openhap.org/>
 
 ## Features
 
-- Pairs with the iOS Home app over HAP, and keeps the session encrypted
-- Tasmota thermostats, heaters, switches, sensors, lightbulbs and dimmers,
-  declared in `openhapd.conf(5)`
-- MQTT for device control and state
-- Runs as `_openhap` from `rc.d`, under pledge(2) and unveil(2)
+- OpenHAP pairs with the iOS Home app through HAP and encrypts the session
+- You declare Tasmota thermostats, heaters, switches, sensors, lightbulbs, and
+  dimmers in `openhapd.conf(5)`
+- OpenHAP uses MQTT to control the devices and to read their state
+- The daemon runs as the `_openhap` user from `rc.d`, under pledge(2) and
+  unveil(2)
 
 ## Quick Start
 
@@ -26,18 +27,18 @@ rcctl enable mosquitto openhapd
 rcctl start mosquitto openhapd
 ```
 
-See [INSTALL.md](INSTALL.md) for complete installation instructions.
+See [INSTALL.md](INSTALL.md) for the complete installation instructions.
 
 ## Documentation
 
-- `openhapd(8)` - Daemon and command-line options
-- `openhapd.conf(5)` - Configuration file format
-- `hapctl(8)` - Control utility
+- `openhapd(8)` - the daemon and its command-line options
+- `openhapd.conf(5)` - the configuration file format
+- `hapctl(8)` - the control utility
 
 ## Development
 
-See [CLAUDE.md](CLAUDE.md) for development commands, coding style, and
-conventions.
+See [CLAUDE.md](CLAUDE.md) for the development commands, the coding style, and
+the conventions.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Website and manuals: <https://www.openhap.org/>
 
 ```sh
 make deps
-make install
-cp /etc/examples/openhapd.conf /etc/openhapd.conf
-vi /etc/openhapd.conf
-rcctl enable mosquitto openhapd
-rcctl start mosquitto openhapd
+doas make install
+doas cp /etc/examples/openhapd.conf /etc/openhapd.conf
+doas vi /etc/openhapd.conf
+doas rcctl enable mosquitto mdnsd openhapd
+doas rcctl start mosquitto mdnsd openhapd
 ```
 
 See [INSTALL.md](INSTALL.md) for the complete installation instructions.

--- a/lib/FuguVM/ImageCache.pod
+++ b/lib/FuguVM/ImageCache.pod
@@ -26,7 +26,7 @@ FuguVM::ImageCache - cache of installed OpenBSD disk images
 
 An installation of OpenBSD under TCG emulation takes tens of minutes.
 This module keeps the result, thus later runs do not do the
-installation again. The result is a pristine, compacted copy of the
+installation again. The result is a clean, compacted copy of the
 disk. The module makes this copy when the installation is complete.
 Later VMs use this copy as the backing image of a throwaway qcow2
 overlay.
@@ -75,7 +75,7 @@ L<FuguVM::Expect> drives the installer.
 The counter is a data file, not a constant in this module. Thus a
 continuous-integration cache key can hash the file too. Keep the file
 content to the bare number: the hash covers the whole content, and an
-edit to a comment rotates the key.
+edit to a comment changes the key.
 
 The memory settings and the port settings do not shape the disk, and
 the key intentionally excludes them. Thus a change to these settings
@@ -119,7 +119,7 @@ consistent.
 
 =item new($cache_dir)
 
-Construct a cache over C<$cache_dir>. The constructor expands a
+The constructor creates a cache over C<$cache_dir>. It expands a
 C<~> at the start of the path.
 
 =item cache_dir
@@ -134,46 +134,47 @@ These methods return locations. The paths do not have to exist.
 
 =item key($vm_config)
 
-Derive the cache key for a VM configuration hash. The method returns
-C<undef> when it cannot read an input. The caller then has no key, and
-thus no cache.
+The method derives the cache key for a VM configuration hash. It
+returns C<undef> when it cannot read an input. The caller then has no
+key, and thus no cache.
 
 =item lookup($key)
 
-Return C<< { key, dir, base, meta } >> for a complete entry. In other
-cases, the method returns C<undef>. A half-written entry is a miss,
-not an error.
+The method returns C<< { key, dir, base, meta } >> for a complete
+entry. In other cases, it returns C<undef>. A half-written entry is a
+miss, not an error.
 
 =item store($key, $disk_path, $meta)
 
-Compact C<$disk_path> into the cache as the base image for C<$key>,
-and write C<$meta> adjacent to it. Put the guest C<root_password> in
-C<$meta>. The method returns the path of the base image. It returns
-C<undef> on a failure, and a try to overwrite a populated key is one
-such failure. The caller then degrades to a standalone disk.
+The method compacts C<$disk_path> into the cache as the base image
+for C<$key>, and writes C<$meta> adjacent to it. Put the guest
+C<root_password> in C<$meta>. The method returns the path of the base
+image. It returns C<undef> on a failure, and a try to overwrite a
+populated key is one such failure. The caller then degrades to a
+standalone disk.
 
 =item list
 
-Return each complete entry, newest first, as
+The method returns each complete entry, newest first, as
 C<< { key, dir, base, meta, size, created_at, snapshots } >>.
 
 =item remove($key)
 
-Delete an entry and all data under it. The method returns true when
-the entry is gone.
+The method deletes an entry and all data under it. It returns true
+when the entry is gone.
 
 =item sweep_temp
 
-Remove the C<.tmp.*> trees that an interrupted C<store> left. This
-includes the trees of earlier processes. The method returns the count
-of removed trees.
+The method removes the C<.tmp.*> trees that an interrupted C<store>
+left. This includes the trees of earlier processes. The method
+returns the count of removed trees.
 
 =item key_for_path($path)
 
-Return the key of the entry that holds C<$path>. The path points to
-a base image or a snapshot. The method returns C<undef> when C<$path> is outside
-the cache. The method answers this question: "Which cached image is
-the base of this working disk?"
+The method returns the key of the entry that holds C<$path>. The
+path points to a base image or a snapshot. The method returns
+C<undef> when C<$path> is outside the cache. The method answers this
+question: "Which cached image is the base of this working disk?"
 
 =item snapshot_dir($key)
 
@@ -183,42 +184,43 @@ These methods return locations. The paths do not have to exist.
 
 =item valid_snapshot_name($name)
 
-Return true when C<$name> is usable. A name becomes a file name inside
-the cache. Thus a name must start with an alphanumeric character, it
-must hold only word characters, dots, and dashes, and it must have a
-bounded length.
+The method returns true when C<$name> is usable. A name becomes a
+file name inside the cache. Thus a name must start with an
+alphanumeric character, it must hold only word characters, dots, and
+dashes, and it must have a bounded length.
 
 =item snapshot_store($key, $name, $disk_path, $meta)
 
-Flatten the stopped working disk at C<$disk_path> onto the base image
-of C<$key>, and publish the result as the named layer. Put the state
-fields that the disk holds in C<$meta>: C<installed> and the installed
-SSH public key. With these fields, a restore can reseed
-L<FuguVM::State>. The method copies the root password from the
-metadata of the base itself, and it does not trust the caller for this
-value. The method returns the snapshot path, or C<undef> on a failure.
+The method flattens the stopped working disk at C<$disk_path> onto
+the base image of C<$key>, and publishes the result as the named
+layer. Put the state fields that the disk holds in C<$meta>:
+C<installed> and the installed SSH public key. With these fields, a
+restore can reseed L<FuguVM::State>. The method copies the root
+password from the metadata of the base itself, and it does not trust
+the caller for this value. The method returns the snapshot path, or
+C<undef> on a failure.
 
 When a caller saves the same name again, the method replaces the
 snapshot. This is the normal second run of a provisioning script.
 
 =item snapshot_lookup($key, $name)
 
-Return C<< { key, name, path, base, meta } >> for a snapshot whose
-image, metadata, and backing chain all resolve. In other cases, the
-method returns C<undef>. A snapshot with a removed base is a miss, not
-an error. Thus a caller can provision from scratch, and it does not
-fail hard.
+The method returns C<< { key, name, path, base, meta } >> for a
+snapshot whose image, metadata, and backing chain all resolve. In
+other cases, it returns C<undef>. A snapshot with a removed base is a
+miss, not an error. Thus a caller can provision from scratch, and it
+does not fail hard.
 
 =item snapshot_list($key)
 
-Return the sorted snapshots of an entry, as
+The method returns the sorted snapshots of an entry, as
 C<< { name, path, size, created_at, meta } >>.
 
 =item snapshot_remove($key, $name)
 
-Delete a snapshot and its metadata. Deletion in any order is safe,
-because each snapshot is a direct child of the base, never of a
-different snapshot.
+The method deletes a snapshot and its metadata. Deletion in any order
+is safe, because each snapshot is a direct child of the base, never
+of a different snapshot.
 
 =back
 
@@ -226,8 +228,8 @@ different snapshot.
 
 F<meta.json> is mode 0600, and it holds the generated guest root
 password, the same secret that the VM state directory keeps. The cache
-extends the life of this secret: the password stays after
-C<fuguvm destroy>, and it rotates only when the base key rotates.
+makes the life of this secret longer: the password stays after
+C<fuguvm destroy>, and it changes only when the base key changes.
 
 The guest permits root login with a password. QEMU forwards the SSH
 port and the serial console port of the guest on each host interface.

--- a/lib/FuguVM/ImageCache.pod
+++ b/lib/FuguVM/ImageCache.pod
@@ -24,68 +24,95 @@ FuguVM::ImageCache - cache of installed OpenBSD disk images
 
 =head1 DESCRIPTION
 
-Installing OpenBSD under TCG emulation costs tens of minutes. This module
-keeps the result so later runs skip it: a pristine, compacted copy of the
-disk taken the moment the installer finished, which subsequent VMs use as
-the backing image of a throwaway qcow2 overlay.
+An installation of OpenBSD under TCG emulation takes tens of minutes.
+This module keeps the result, thus later runs do not do the
+installation again. The result is a pristine, compacted copy of the
+disk. This copy is made at the moment when the installation completes.
+Later VMs use this copy as the backing image of a throwaway qcow2
+overlay.
 
-Entries live under the configured C<cache_dir>, beside the proxy cache that
-holds the miniroot and install sets:
+The entries are in the configured C<cache_dir>, adjacent to the proxy
+cache that holds the miniroot and the install sets:
 
     <cache_dir>/installed/<key>/base.qcow2              mode 0400
     <cache_dir>/installed/<key>/meta.json               mode 0600
     <cache_dir>/installed/<key>/snapshots/<name>.qcow2  mode 0400
     <cache_dir>/installed/<key>/snapshots/<name>.json   mode 0600
 
-Entries are immutable and write-once. C<store> builds one whole in a sibling
-C<.tmp.*> directory and publishes it by renaming that directory, so a reader
-never sees one installation's base image beside another installation's
-metadata - a mismatch that looks live and then wedges every later boot with
-a root password that does not open the image.
+The entries are immutable and write-once. C<store> builds a full entry
+in a sibling C<.tmp.*> directory, and then it publishes the entry with
+a rename of that directory. Thus a reader never sees the base image of
+one installation adjacent to the metadata of a different installation.
+Such a mismatch looks live, but it then stops every later boot,
+because the root password does not open the image.
 
 =head2 Cache keys
 
-C<key> returns C<< <version>-<arch>-<hash8> >>, where C<hash8> is a truncated
-SHA-256 over everything that shapes an installed disk: the OpenBSD version,
-the architecture, the disk size, the contents of the F<install.exp> script
-that L<FuguVM::Expect> resolves, and the contents of
-F<share/fuguvm/cache-generation>.
+C<key> returns C<< <version>-<arch>-<hash8> >>. C<hash8> is a
+truncated SHA-256 over each input that shapes an installed disk. These
+inputs are:
 
-That last file is a generation counter. Bump the number in it when the
-install driver changes in a way the F<install.exp> hash cannot see - for
-instance a change to how L<FuguVM::VM> or L<FuguVM::Expect> drives the
-installer. It is a data file rather than a constant in this module so a
-continuous-integration cache key can hash it too; keep it to the bare number,
-since its whole content is hashed and a comment edit would rotate the key.
+=over 4
 
-Memory and port settings do not shape the disk and are deliberately excluded,
-so changing them still hits the same entry.
+=item * the OpenBSD version
+
+=item * the architecture
+
+=item * the disk size
+
+=item * the contents of the F<install.exp> script that
+L<FuguVM::Expect> resolves
+
+=item * the contents of F<share/fuguvm/cache-generation>
+
+=back
+
+The last file is a generation counter. Increase the number in this
+file when the install driver changes in a way that the F<install.exp>
+hash cannot see. One example is a change in how L<FuguVM::VM> or
+L<FuguVM::Expect> drives the installer.
+
+The counter is a data file, not a constant in this module. Thus a
+continuous-integration cache key can hash the file too. Keep the file
+content to the bare number: the hash covers the whole content, and an
+edit to a comment rotates the key.
+
+The memory settings and the port settings do not shape the disk, and
+the key intentionally excludes them. Thus a change to these settings
+hits the same entry.
 
 =head2 Snapshots
 
-A snapshot is an immutable named layer over an entry's base image, for
-caching states fuguvm itself knows nothing about - the motivating case is
-a provisioning script caching its "guest packages installed" state. The
-mechanism lives here; the policy of what is worth caching stays in the
-callers.
+A snapshot is an immutable, named layer over the base image of an
+entry. Its purpose is to cache states that fuguvm itself does not
+know. One example is a provisioning script that caches its "guest
+packages installed" state. The mechanism is in this module. The
+policy - which states are worth a cache - stays in the callers.
 
-Snapshots live inside C<< installed/<key>/ >>, so invalidating a base -
-a new key, or C<cache clear> - invalidates the snapshots that depend on that
-exact base file, for free.
+The snapshots are inside C<< installed/<key>/ >>. Thus, when a base
+becomes invalid - through a new key, or through C<cache clear> - the
+snapshots that depend on that exact base file also become invalid
+automatically.
 
-C<snapshot_store> B<flattens> the working disk onto C<base.qcow2> rather than
-copying it, so every snapshot is a direct child of the base:
+C<snapshot_store> B<flattens> the working disk onto C<base.qcow2>. It
+does not copy the disk. Thus each snapshot is a direct child of the
+base:
 
     base.qcow2  <-  <name>.qcow2  <-  disk.qcow2
 
-A copy would carry the working disk's backing-file header verbatim, which is
-only correct while that disk hangs directly off the base. After a restore it
-hangs off a snapshot, so a copy would either stack chains without bound or -
-when the same name is re-saved, which a normal second run does - publish a
-qcow2 naming itself as its own backing file. Flattening also means no
-snapshot is ever another's parent, so C<snapshot_remove> cannot orphan one.
+A copy keeps the backing-file header of the working disk verbatim.
+That header is correct only while the disk hangs directly off the
+base. After a restore, the disk hangs off a snapshot. Thus a copy
+stacks chains without a limit, or it publishes a qcow2 that names
+itself as its own backing file. The second result occurs when a caller
+saves the same name again, which a normal second run does.
 
-The working disk must be from a stopped VM: a live overlay is not consistent.
+Because C<snapshot_store> flattens the disk, no snapshot is the parent
+of a different snapshot. Thus C<snapshot_remove> cannot make a
+snapshot an orphan.
+
+The working disk must come from a stopped VM. A live overlay is not
+consistent.
 
 =head1 METHODS
 
@@ -93,7 +120,8 @@ The working disk must be from a stopped VM: a live overlay is not consistent.
 
 =item new($cache_dir)
 
-Construct a cache over C<$cache_dir>, expanding a leading C<~>.
+Construct a cache over C<$cache_dir>. The constructor expands a
+C<~> at the start of the path.
 
 =item cache_dir
 
@@ -103,96 +131,108 @@ Construct a cache over C<$cache_dir>, expanding a leading C<~>.
 
 =item base_path($key)
 
-Locations, whether or not they exist.
+These methods return locations. The paths do not have to exist.
 
 =item key($vm_config)
 
-Derive the cache key for a VM configuration hash, or C<undef> when an input
-cannot be read - which leaves the caller with no key, and therefore no
-caching.
+Derive the cache key for a VM configuration hash. The method returns
+C<undef> when it cannot read an input. The caller then has no key, and
+thus no cache.
 
 =item lookup($key)
 
-Return C<< { key, dir, base, meta } >> for a complete entry, C<undef>
-otherwise. A half-written entry is a miss, not an error.
+Return C<< { key, dir, base, meta } >> for a complete entry. In other
+cases, the method returns C<undef>. A half-written entry is a miss,
+not an error.
 
 =item store($key, $disk_path, $meta)
 
-Compact C<$disk_path> into the cache as the base image for C<$key> and write
-C<$meta> - which should carry the guest C<root_password> - alongside it.
-Returns the base image path, or C<undef> on any failure, including an attempt
-to overwrite a populated key. The caller degrades to a standalone disk.
+Compact C<$disk_path> into the cache as the base image for C<$key>,
+and write C<$meta> adjacent to it. Put the guest C<root_password> in
+C<$meta>. The method returns the path of the base image. It returns
+C<undef> on a failure, and a try to overwrite a populated key is one
+such failure. The caller then degrades to a standalone disk.
 
 =item list
 
-Every complete entry, newest first, as
+Return each complete entry, newest first, as
 C<< { key, dir, base, meta, size, created_at, snapshots } >>.
 
 =item remove($key)
 
-Delete an entry and everything under it. True when the entry is gone.
+Delete an entry and all data under it. The method returns true when
+the entry is gone.
 
 =item sweep_temp
 
-Remove C<.tmp.*> trees left behind by an interrupted C<store>, including
-those of earlier processes. Returns the count removed.
+Remove the C<.tmp.*> trees that an interrupted C<store> left. This
+includes the trees of earlier processes. The method returns the count
+of removed trees.
 
 =item key_for_path($path)
 
-The key of the entry containing C<$path> - a base image or a snapshot - or
-C<undef> when C<$path> lies outside the cache. Answers "which cached image is
-this working disk built on?".
+Return the key of the entry that holds C<$path>, which is a base image
+or a snapshot. The method returns C<undef> when C<$path> is outside
+the cache. The method answers this question: "Which cached image is
+the base of this working disk?"
 
 =item snapshot_dir($key)
 
 =item snapshot_path($key, $name)
 
-Locations, whether or not they exist.
+These methods return locations. The paths do not have to exist.
 
 =item valid_snapshot_name($name)
 
-Whether C<$name> is usable. Names become file names inside the cache, so they
-must start with an alphanumeric and hold to word characters, dots and dashes,
-within a bounded length.
+Return true when C<$name> is usable. A name becomes a file name inside
+the cache. Thus a name must start with an alphanumeric character, it
+must hold only word characters, dots, and dashes, and it must have a
+bounded length.
 
 =item snapshot_store($key, $name, $disk_path, $meta)
 
-Flatten the stopped working disk at C<$disk_path> onto C<$key>'s base image
-and publish it as the named layer. C<$meta> should carry the state fields the
-disk embodies - C<installed> and the installed SSH public key - so a restore
-can reseed L<FuguVM::State>; the root password is copied from the base's own
-metadata rather than trusted from the caller. Returns the snapshot path, or
-C<undef> on failure.
+Flatten the stopped working disk at C<$disk_path> onto the base image
+of C<$key>, and publish the result as the named layer. Put the state
+fields that the disk holds in C<$meta>: C<installed> and the installed
+SSH public key. With these fields, a restore can reseed
+L<FuguVM::State>. The method copies the root password from the
+metadata of the base itself, and it does not trust the caller for this
+value. The method returns the snapshot path, or C<undef> on a failure.
 
-Re-saving an existing name replaces it, which is the normal second run of a
-provisioning script.
+When a caller saves an existing name again, the method replaces the
+snapshot. This is the normal second run of a provisioning script.
 
 =item snapshot_lookup($key, $name)
 
-Return C<< { key, name, path, base, meta } >> for a snapshot whose image, its
-metadata, and its backing chain all resolve; C<undef> otherwise. A snapshot
-whose base has been removed is a miss, not an error, so a caller can fall
-back to provisioning from scratch instead of failing hard.
+Return C<< { key, name, path, base, meta } >> for a snapshot whose
+image, metadata, and backing chain all resolve. In other cases, the
+method returns C<undef>. A snapshot with a removed base is a miss, not
+an error. Thus a caller can provision from scratch, and it does not
+fail hard.
 
 =item snapshot_list($key)
 
-Sorted snapshots of an entry, as C<< { name, path, size, created_at, meta } >>.
+Return the sorted snapshots of an entry, as
+C<< { name, path, size, created_at, meta } >>.
 
 =item snapshot_remove($key, $name)
 
-Delete a snapshot and its metadata. Safe in any order: snapshots are always
-direct children of the base, never of each other.
+Delete a snapshot and its metadata. Deletion in any order is safe,
+because each snapshot is a direct child of the base, never of a
+different snapshot.
 
 =back
 
 =head1 SECURITY
 
-F<meta.json> is mode 0600 and holds the generated guest root password, the
-same secret the VM state directory already keeps. Caching lengthens its life:
-it survives C<fuguvm destroy> and rotates only when the base key does. The
-guest permits password root login and QEMU forwards its SSH and serial
-console ports on every host interface, so the password is not a
-localhost-only secret. See L<fuguvm(1)>.
+F<meta.json> is mode 0600, and it holds the generated guest root
+password, the same secret that the VM state directory keeps. The cache
+extends the life of this secret: the password stays after
+C<fuguvm destroy>, and it rotates only when the base key rotates.
+
+The guest permits root login with a password. QEMU forwards the SSH
+port and the serial console port of the guest on each host interface.
+Thus the password is not a localhost-only secret. See L<fuguvm(1)>.
 
 =head1 SEE ALSO
 

--- a/lib/FuguVM/ImageCache.pod
+++ b/lib/FuguVM/ImageCache.pod
@@ -87,7 +87,7 @@ A snapshot is an immutable, named layer over the base image of an
 entry. Its purpose is to cache states that fuguvm itself does not
 know. One example is a provisioning script that caches its "guest
 packages installed" state. The mechanism is in this module. The
-policy - which states are worth a cache - stays in the callers.
+policy stays in the callers: they select the states that get a cache.
 
 The snapshots are inside C<< installed/<key>/ >>. Thus, when a base
 becomes invalid - through a new key, or through C<cache clear> - the
@@ -105,7 +105,7 @@ That header is correct only while the disk hangs directly off the
 base. After a restore, the disk hangs off a snapshot. Thus a copy
 stacks chains without a limit, or it publishes a qcow2 that names
 itself as its own backing file. The second result occurs when a caller
-saves the same name again, which a normal second run does.
+saves the same name again. A normal second run does this.
 
 Because C<snapshot_store> flattens the disk, no snapshot is the parent
 of a different snapshot. Thus C<snapshot_remove> cannot make a
@@ -171,8 +171,8 @@ of removed trees.
 
 =item key_for_path($path)
 
-Return the key of the entry that holds C<$path>, which is a base image
-or a snapshot. The method returns C<undef> when C<$path> is outside
+Return the key of the entry that holds C<$path>. The path points to
+a base image or a snapshot. The method returns C<undef> when C<$path> is outside
 the cache. The method answers this question: "Which cached image is
 the base of this working disk?"
 

--- a/lib/FuguVM/ImageCache.pod
+++ b/lib/FuguVM/ImageCache.pod
@@ -27,7 +27,7 @@ FuguVM::ImageCache - cache of installed OpenBSD disk images
 An installation of OpenBSD under TCG emulation takes tens of minutes.
 This module keeps the result, thus later runs do not do the
 installation again. The result is a pristine, compacted copy of the
-disk. This copy is made at the moment when the installation completes.
+disk. The module makes this copy when the installation is complete.
 Later VMs use this copy as the backing image of a throwaway qcow2
 overlay.
 
@@ -91,8 +91,7 @@ policy stays in the callers: they select the states that get a cache.
 
 The snapshots are inside C<< installed/<key>/ >>. Thus, when a base
 becomes invalid - through a new key, or through C<cache clear> - the
-snapshots that depend on that exact base file also become invalid
-automatically.
+snapshots of that base also become invalid automatically.
 
 C<snapshot_store> B<flattens> the working disk onto C<base.qcow2>. It
 does not copy the disk. Thus each snapshot is a direct child of the
@@ -199,7 +198,7 @@ L<FuguVM::State>. The method copies the root password from the
 metadata of the base itself, and it does not trust the caller for this
 value. The method returns the snapshot path, or C<undef> on a failure.
 
-When a caller saves an existing name again, the method replaces the
+When a caller saves the same name again, the method replaces the
 snapshot. This is the normal second run of a provisioning script.
 
 =item snapshot_lookup($key, $name)

--- a/lib/OpenHAP/Accessory.pod
+++ b/lib/OpenHAP/Accessory.pod
@@ -17,8 +17,8 @@ OpenHAP::Accessory - Base class for HAP accessories
 
 =head1 DESCRIPTION
 
-This module provides the base class for HomeKit accessories with
-required Accessory Information service.
+This module supplies the base class for HomeKit accessories. Each
+accessory holds the necessary Accessory Information service.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Accessory.pod
+++ b/lib/OpenHAP/Accessory.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::Accessory - Base class for HAP accessories
+OpenHAP::Accessory - base class for HAP accessories
 
 =head1 SYNOPSIS
 

--- a/lib/OpenHAP/Bridge.pod
+++ b/lib/OpenHAP/Bridge.pod
@@ -14,15 +14,15 @@ OpenHAP::Bridge - HAP bridge accessory
 
 =head1 DESCRIPTION
 
-This module represents a HAP bridge that can contain multiple
-bridged accessories. The bridge accessory carries the mandatory
-AccessoryInformation and ProtocolInformation services; bridged
-accessories carry only AccessoryInformation.
+This module supplies the HAP bridge. The bridge can hold many bridged
+accessories. The bridge accessory holds the necessary
+AccessoryInformation and ProtocolInformation services. Bridged
+accessories hold only the AccessoryInformation service.
 
-Change notifications from bridged accessories are forwarded to the
-bridge's own event callbacks with the originating accessory's aid
-preserved, so the server can deliver EVENT/1.0 notifications for
-device-side changes.
+The bridge forwards change notifications from bridged accessories to
+its own event callbacks. Each notification keeps the aid of the
+source accessory. Thus the server can send EVENT/1.0 notifications
+for changes on the device side.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Characteristic.pod
+++ b/lib/OpenHAP/Characteristic.pod
@@ -20,8 +20,8 @@ OpenHAP::Characteristic - HAP characteristic definitions
 
 =head1 DESCRIPTION
 
-This module represents HAP characteristics with their properties,
-values, and permissions.
+This module supplies the HAP characteristic objects. Each
+characteristic holds its properties, its value, and its permissions.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Config.pod
+++ b/lib/OpenHAP/Config.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::Config - Configuration file parser
+OpenHAP::Config - configuration file parser
 
 =head1 SYNOPSIS
 

--- a/lib/OpenHAP/Crypto.pod
+++ b/lib/OpenHAP/Crypto.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::Crypto - crypto primitives for HAP, wrapping CPAN modules
+OpenHAP::Crypto - crypto primitives for HAP, wrappers over CPAN modules
 
 =head1 SYNOPSIS
 
@@ -23,9 +23,10 @@ OpenHAP::Crypto - crypto primitives for HAP, wrapping CPAN modules
 
 =head1 DESCRIPTION
 
-Thin wrappers over the CPAN modules that do the actual work, giving
-callers one argument order and one place to look for which module
-provides what:
+This module holds thin wrappers over the CPAN modules that do the
+work. The wrappers give the callers one argument order. They also
+give one place that shows which module supplies each function. These
+are the modules:
 
 =over 4
 
@@ -39,9 +40,10 @@ provides what:
 
 =back
 
-The module also holds the SRP-6a group parameters from
-F<spec/HAP-Pairing.md> (the RFC 5054 3072-bit group, C<g> = 5) for
-L<OpenHAP::SRP>, and reads random bytes from F</dev/urandom>.
+The module also holds the SRP-6a group parameters for L<OpenHAP::SRP>.
+These parameters come from F<spec/HAP-Pairing.md> (the RFC 5054
+3072-bit group, C<g> = 5). The module reads random bytes from
+F</dev/urandom>.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Daemon.pod
+++ b/lib/OpenHAP/Daemon.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::Daemon - Daemonization and process management
+OpenHAP::Daemon - daemonization and process management
 
 =head1 SYNOPSIS
 
@@ -60,7 +60,7 @@ hold a valid PID.
 
     my $pid = $class->check_running($pidfile)
 
-This method uses the PID file to find if a daemon runs. It returns
+This method uses the PID file to report if a daemon runs. It returns
 the PID if the process exists. If not, it returns undef. The method
 reads the PID file. Then it uses kill(0) to make sure that the
 process runs.

--- a/lib/OpenHAP/Daemon.pod
+++ b/lib/OpenHAP/Daemon.pod
@@ -20,11 +20,11 @@ OpenHAP::Daemon - Daemonization and process management
 
 =head1 DESCRIPTION
 
-C<daemonize>, C<write_pidfile>, C<read_pidfile> and C<check_running> are
-a compatibility shim over L<FuguLib::Daemon> and L<FuguLib::State>,
-which document the behaviour; new code should call those directly.
-C<unveil_paths> is the part that belongs here, since the path list it
-assembles is specific to openhapd.
+C<daemonize>, C<write_pidfile>, C<read_pidfile>, and C<check_running>
+are a compatibility shim over L<FuguLib::Daemon> and
+L<FuguLib::State>. Those two modules document the behaviour. New code
+must call those modules directly. C<unveil_paths> belongs here
+because the path list that it assembles applies only to openhapd.
 
 =head1 CLASS METHODS
 
@@ -32,35 +32,38 @@ assembles is specific to openhapd.
 
     $class->daemonize($logfile)
 
-Fork into background, detach from terminal, and redirect standard file
-descriptors. The parent process exits successfully, and only the child
-continues. Standard input is redirected to /dev/null, stdout and stderr
-are redirected to the specified log file.
+This method forks the process into the background, detaches it from
+the terminal, and redirects the standard file descriptors. The parent
+process exits successfully, and only the child continues. The method
+redirects standard input to /dev/null. It redirects stdout and stderr
+to the log file C<$logfile>.
 
-Dies if forking or session creation fails.
+The method dies if the fork fails or if the session creation fails.
 
 =head2 write_pidfile
 
     $class->write_pidfile($path)
 
-Write the current process ID to the specified file. Returns true on
-success, undef on failure. Errors are logged.
+This method writes the current process ID to the file C<$path>. It
+returns true on success and undef on failure. It logs errors.
 
 =head2 read_pidfile
 
     my $pid = $class->read_pidfile($path)
 
-Read a PID from the specified file. Returns the PID as an integer, or
-undef if the file doesn't exist, cannot be read, or doesn't contain a
-valid PID.
+This method reads a PID from the file C<$path>. It returns the PID as
+an integer. If the file does not exist, the method returns undef. It
+also returns undef if it cannot read the file or if the file does not
+hold a valid PID.
 
 =head2 check_running
 
     my $pid = $class->check_running($pidfile)
 
-Check if a daemon is running based on its PID file. Returns the PID if
-the process exists, undef otherwise. This method reads the PID file and
-verifies the process is still running using kill(0).
+This method uses the PID file to find if a daemon runs. It returns
+the PID if the process exists. If not, it returns undef. The method
+reads the PID file. Then it uses kill(0) to make sure that the
+process runs.
 
 =head2 unveil_paths
 
@@ -70,20 +73,51 @@ verifies the process is still running using kill(0).
         script_lib  => "$RealBin/../lib",
     );
 
-Assemble the daemon's unveil(2) inventory: an ordered list of
-C<[$path, $perms]> pairs for L<FuguLib::Sandbox>, each required or
-marked C<< { optional => 1 } >>. Required paths (the state directory,
-F</dev/urandom>, the perl library directories) are a broken install
-when absent; optional paths (the configuration file, the daemon log,
-the mdnsd control socket, the resolver files) are legitimately absent
-on a working system and must never prevent startup.
+This method assembles the unveil(2) inventory of the daemon. The
+inventory is an ordered list of C<[$path, $perms]> pairs for
+L<FuguLib::Sandbox>. Each pair is necessary, or it has the mark
+C<< { optional => 1 } >>.
 
-The library directories are enumerated from C<%Config>, never derived
-from live C<@INC>; C<script_lib> is included read-only only when it
-contains an F<OpenHAP/> directory, so an installed layout never
-unveils F</usr/local/lib>. Pure assembly - nothing here changes the
-filesystem view - so it is unit-testable anywhere. C<perl_dirs>
-overrides the enumerated directories for tests.
+These are the necessary paths:
+
+=over 4
+
+=item * the state directory
+
+=item * F</dev/urandom>
+
+=item * the perl library directories
+
+=back
+
+If one of these paths is absent, the installation is broken.
+
+These are the optional paths:
+
+=over 4
+
+=item * the configuration file
+
+=item * the daemon log
+
+=item * the mdnsd control socket
+
+=item * the resolver files
+
+=back
+
+These paths can be absent on a correct system. Their absence must
+never prevent the startup.
+
+The method gets the library directories from C<%Config>. It does not
+get them from the live C<@INC>. The method includes C<script_lib>
+read-only, and only when that directory holds an F<OpenHAP/>
+directory. Thus an installed layout never unveils F</usr/local/lib>.
+
+The method only assembles data. It does not change the filesystem
+view. Thus unit tests for this method can run on all platforms. In
+tests, the C<perl_dirs> parameter replaces the directories from
+C<%Config>.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/DeviceLoader.pod
+++ b/lib/OpenHAP/DeviceLoader.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::DeviceLoader - Loads and instantiates devices from the configuration
+OpenHAP::DeviceLoader - loader for the devices in the configuration
 
 =head1 SYNOPSIS
 

--- a/lib/OpenHAP/DeviceLoader.pod
+++ b/lib/OpenHAP/DeviceLoader.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::DeviceLoader - Device configuration loading and instantiation
+OpenHAP::DeviceLoader - Loads and instantiates devices from the configuration
 
 =head1 SYNOPSIS
 
@@ -22,9 +22,9 @@ OpenHAP::DeviceLoader - Device configuration loading and instantiation
 
 =head1 DESCRIPTION
 
-Reads the device blocks from an L<OpenHAP::Config>, validates them,
-instantiates the matching device class, and registers each one with the
-HAP bridge.
+This module reads the device blocks from an L<OpenHAP::Config> and
+does a check of each block. It instantiates the device class that
+matches, and it registers each device with the HAP bridge.
 
 =head1 METHODS
 
@@ -32,66 +32,70 @@ HAP bridge.
 
     my $loader = OpenHAP::DeviceLoader->new()
 
-Create a new device loader instance. The loader maintains an internal
-counter for assigning Accessory IDs (AIDs), starting at 2 (AID 1 is
-reserved for the bridge itself).
+This method creates a new device loader instance. The loader keeps an
+internal counter that assigns the Accessory IDs (AIDs). The counter
+starts at 2, because AID 1 is reserved for the bridge itself.
 
 =head2 load_devices
 
     my $count = $loader->load_devices($config, $hap, $mqtt)
 
-Load all devices from the configuration and add them to the HAP bridge.
-Returns the number of successfully loaded devices.
+This method loads all devices from the configuration and adds them to
+the HAP bridge. It returns the number of devices that loaded
+correctly.
 
-The method:
+The method does these steps:
 
 =over 4
 
-=item * Retrieves device list from configuration
+=item * Gets the device list from the configuration
 
-=item * Validates each device configuration
+=item * Does a check of each device configuration
 
-=item * Instantiates appropriate device classes
+=item * Instantiates the applicable device classes
 
-=item * Subscribes devices to MQTT topics (if connected)
+=item * Subscribes the devices to MQTT topics (if MQTT is connected)
 
-=item * Registers devices with HAP bridge
+=item * Registers the devices with the HAP bridge
 
-=item * Logs progress and errors
+=item * Logs the progress and the errors
 
 =back
 
-Errors are logged but don't stop processing of remaining devices.
+The method logs errors, but an error does not stop the load of the
+other devices.
 
 =head2 get_devices
 
     my @devices = $loader->get_devices()
 
-Return a list of all successfully loaded device accessory objects.
+This method returns a list of all device accessory objects that
+loaded correctly.
 
-=head1 DEVICE VALIDATION
+=head1 DEVICE CHECKS
 
-Each device configuration must include:
+Each device configuration must have these fields:
 
 =over 4
 
-=item * B<name> - Human-readable device name
+=item * B<name> - The human-readable name of the device
 
-=item * B<type> - Device type (e.g., 'tasmota')
+=item * B<type> - The device type (for example, 'tasmota')
 
-=item * B<subtype> - Device subtype (e.g., 'thermostat')
+=item * B<subtype> - The device subtype (for example, 'thermostat')
 
-=item * B<topic> - MQTT topic for communication
+=item * B<topic> - The MQTT topic for communication
 
-=item * B<id> - Unique identifier (defaults to topic if not specified)
+=item * B<id> - The unique identifier. The default value is the topic.
 
 =back
 
-Devices missing required fields are skipped with appropriate error logging.
+The loader skips a device that does not have all the necessary
+fields. It logs an error for that device.
 
 =head1 SUPPORTED DEVICES
 
-The only device type is C<tasmota>, with these subtypes:
+The only device type is C<tasmota>. These are its subtypes:
 
 =over 4
 
@@ -108,9 +112,9 @@ L<OpenHAP::Tasmota::Lightbulb>
 
 =head1 ERROR HANDLING
 
-Device instantiation and MQTT subscription run inside C<eval>, so one
-misconfigured device is logged and skipped rather than stopping the
-daemon from starting.
+The device instantiation and the MQTT subscription run inside
+C<eval>. Thus one misconfigured device does not stop the start of the
+daemon. The loader logs that device and skips it.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/HAP.pod
+++ b/lib/OpenHAP/HAP.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::HAP - Main HAP server
+OpenHAP::HAP - main HAP server
 
 =head1 SYNOPSIS
 

--- a/lib/OpenHAP/HAP.pod
+++ b/lib/OpenHAP/HAP.pod
@@ -17,16 +17,17 @@ OpenHAP::HAP - Main HAP server
 
 =head1 DESCRIPTION
 
-This module implements the main HAP server with HTTP endpoints,
-pairing, and accessory management.
+This module is the main HAP server. The server has the HTTP
+endpoints, the pairing operations, and the accessory management.
 
-Characteristic changes - whether written over HTTP or reported by a
-device - are delivered to subscribed connections as EVENT/1.0
-notifications, coalesced over a 250 ms window except for the
-immediate-delivery characteristic types (see F<spec/HAP-HTTP.md>
-section 14). The connection whose request caused a change never
-receives an event for its own write, and a connection's subscriptions
-end when it closes.
+The server sends characteristic changes to subscribed connections as
+EVENT/1.0 notifications. A change can come from a write over HTTP or
+from a device report. The server coalesces the events over a 250 ms
+window. The characteristic types for immediate delivery are the
+exception (see F<spec/HAP-HTTP.md> section 14). The connection that
+caused a change with its request never gets an event for its own
+write. The subscriptions of a connection end when the connection
+closes.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/HTTP.pod
+++ b/lib/OpenHAP/HTTP.pod
@@ -19,27 +19,46 @@ OpenHAP::HTTP - HTTP/1.1 parser for HAP protocol
 
 =head1 DESCRIPTION
 
-This module implements a simple HTTP/1.1 parser and response builder
+This module supplies a simple HTTP/1.1 parser and a response builder
 for the HomeKit Accessory Protocol.
 
 =head1 FUNCTIONS
 
 =head2 parse($data)
 
-Parses HTTP request data and returns a hashref with:
-- method: HTTP method (GET, POST, PUT)
-- path: Request path
-- version: HTTP version
-- headers: Hash of headers (lowercase keys)
-- body: Request body
+This function parses the HTTP request data. It returns a hashref with
+these keys:
+
+=over 4
+
+=item * C<method> - The HTTP method (GET, POST, PUT)
+
+=item * C<path> - The request path
+
+=item * C<version> - The HTTP version
+
+=item * C<headers> - A hash of the headers (lowercase keys)
+
+=item * C<body> - The request body
+
+=back
 
 =head2 build_response(%args)
 
-Builds an HTTP response. Arguments:
-- status: HTTP status code (default: 200)
-- status_text: Status text (auto-generated if not provided)
-- headers: Hashref of headers
-- body: Response body
+This function builds an HTTP response. These are the arguments:
+
+=over 4
+
+=item * C<status> - The HTTP status code (default: 200)
+
+=item * C<status_text> - The status text. If it is not given, the
+function generates it.
+
+=item * C<headers> - A hashref of the headers
+
+=item * C<body> - The response body
+
+=back
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/HTTP.pod
+++ b/lib/OpenHAP/HTTP.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::HTTP - HTTP/1.1 parser for HAP protocol
+OpenHAP::HTTP - HTTP/1.1 parser for the HAP protocol
 
 =head1 SYNOPSIS
 

--- a/lib/OpenHAP/MQTT.pod
+++ b/lib/OpenHAP/MQTT.pod
@@ -17,9 +17,11 @@ OpenHAP::MQTT - MQTT client wrapper for OpenHAP
 
 =head1 DESCRIPTION
 
-A wrapper around L<Net::MQTT::Simple>, which is loaded with C<require>
-so it stays optional: without it, the daemon starts and serves HomeKit
-but no device state moves. Connections are plaintext; there is no TLS.
+This module is a wrapper around L<Net::MQTT::Simple>. It loads
+L<Net::MQTT::Simple> with C<require>, thus the dependency stays
+optional. Without the dependency, the daemon starts and serves HomeKit,
+but no device state moves. The connections are plaintext. There is no
+TLS.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/PIN.pod
+++ b/lib/OpenHAP/PIN.pod
@@ -22,38 +22,41 @@ OpenHAP::PIN - HomeKit Accessory Protocol PIN validation and normalization
 
 =head1 DESCRIPTION
 
-Handles HAP setup codes: 8-digit numeric codes used during pairing.
+This module handles HAP setup codes: the 8-digit numeric codes that
+pairing uses.
 
-Per the HAP specification, dashes and spaces are formatting characters only
-and are stripped before use, so C<9876-5432> and C<98765432> are the same
-setup code.
+The HAP specification says that dashes and spaces are format characters
+only. The module removes them before use. Thus C<9876-5432> and
+C<98765432> are the same setup code.
 
 =head1 FUNCTIONS
 
 =head2 normalize_pin($pin)
 
-Normalizes a PIN by stripping dashes and spaces, returning the 8-digit
-numeric string.
+This function removes the dashes and the spaces from a PIN. It returns
+the 8-digit numeric string.
 
     my $normalized = normalize_pin('9876-5432');
     # Returns: '98765432'
 
-Returns C<undef> if the input is not a valid format (not exactly 8 digits
-after normalization).
+The function returns C<undef> if the input format is not valid. A valid
+input has exactly 8 digits after normalization.
 
 =head2 validate_pin($pin)
 
-Validates a PIN meets HAP requirements:
+This function does a check of a PIN against these HAP requirements:
 
 =over 4
 
-=item * Must be exactly 8 digits (after stripping dashes/spaces)
+=item * The PIN must have exactly 8 digits after the removal of the
+dashes and the spaces.
 
-=item * Must not be a trivial or sequential pattern
+=item * The PIN must not be a trivial or sequential pattern.
 
 =back
 
-Returns C<1> if valid, C<undef> if invalid.
+The function returns C<1> if the PIN is valid. It returns C<undef> if
+the PIN is not valid.
 
     if (validate_pin('9876-5432')) {
         # PIN is valid

--- a/lib/OpenHAP/PIN.pod
+++ b/lib/OpenHAP/PIN.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::PIN - HomeKit Accessory Protocol PIN validation and normalization
+OpenHAP::PIN - HomeKit Accessory Protocol PIN checks and normalization
 
 =head1 SYNOPSIS
 

--- a/lib/OpenHAP/Pairing.pod
+++ b/lib/OpenHAP/Pairing.pod
@@ -18,8 +18,8 @@ OpenHAP::Pairing - HAP pairing protocol implementation
 
 =head1 DESCRIPTION
 
-This module implements the HAP pairing protocol including pair-setup
-(SRP) and pair-verify (X25519) flows.
+This module implements the HAP pairing protocol. The protocol has the
+pair-setup (SRP) flow and the pair-verify (X25519) flow.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/SRP.pod
+++ b/lib/OpenHAP/SRP.pod
@@ -19,13 +19,14 @@ OpenHAP::SRP - SRP-6a implementation for HAP pairing
 
 =head1 DESCRIPTION
 
-The server (accessory) role of the SRP-6a exchange used by HAP
-pair-setup. The group parameters come from L<OpenHAP::Crypto>, the
-modular arithmetic from L<Math::BigInt> (with the GMP backend when it is
-installed, which matters: the pure-Perl backend takes seconds per
-exponentiation at 3072 bits).
+This module implements the server (accessory) role of the SRP-6a
+exchange that HAP pair-setup uses. The group parameters come from
+L<OpenHAP::Crypto>. The modular arithmetic comes from L<Math::BigInt>.
+L<Math::BigInt> uses the GMP backend when that backend is installed.
+This is important: the pure-Perl backend takes seconds for each
+exponentiation at 3072 bits.
 
-L<OpenHAP::Test::Controller::SRP> is the client side, for tests.
+For tests, L<OpenHAP::Test::Controller::SRP> supplies the client side.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Service.pod
+++ b/lib/OpenHAP/Service.pod
@@ -15,7 +15,8 @@ OpenHAP::Service - HAP service definitions
 
 =head1 DESCRIPTION
 
-This module represents HAP services that contain related characteristics.
+This module represents HAP services. A service holds related
+characteristics.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Session.pod
+++ b/lib/OpenHAP/Session.pod
@@ -18,11 +18,12 @@ OpenHAP::Session - Encrypted session state for HAP connections
 
 =head1 DESCRIPTION
 
-This module manages the encrypted session state for HAP connections,
-including ChaCha20-Poly1305 encryption/decryption with proper nonce
-management and frame handling. C<decrypt> returns undef on a failed
-authentication tag, a truncated frame, or a frame claiming more than
-1024 bytes of plaintext; the caller must close the connection.
+This module manages the encrypted session state for HAP connections.
+It does the ChaCha20-Poly1305 encryption and decryption, with correct
+nonce management, and it manages the frames. C<decrypt> returns undef
+on a failed authentication tag, on a truncated frame, or on a frame
+that declares more than 1024 bytes of plaintext. The caller must then
+close the connection.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Session.pod
+++ b/lib/OpenHAP/Session.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::Session - Encrypted session state for HAP connections
+OpenHAP::Session - encrypted session state for HAP connections
 
 =head1 SYNOPSIS
 

--- a/lib/OpenHAP/Storage.pod
+++ b/lib/OpenHAP/Storage.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::Storage - Persistent storage for pairing data
+OpenHAP::Storage - persistent storage for pairing data
 
 =head1 SYNOPSIS
 

--- a/lib/OpenHAP/Storage.pod
+++ b/lib/OpenHAP/Storage.pod
@@ -19,9 +19,10 @@ OpenHAP::Storage - Persistent storage for pairing data
 
 =head1 DESCRIPTION
 
-This module handles persistent storage of pairing data, accessory keys,
-and configuration state, including the failed pairing attempt counter
-(C<get_auth_attempts>/C<set_auth_attempts>) that must survive restarts
-per F<spec/HAP-Pairing.md> section 8.
+This module handles the persistent storage of pairing data, accessory
+keys, and configuration state. This state includes the counter of
+pairing failures (C<get_auth_attempts>/C<set_auth_attempts>).
+F<spec/HAP-Pairing.md>, section 8, says that the daemon must keep this
+counter through restarts.
 
 =cut

--- a/lib/OpenHAP/TLV.pod
+++ b/lib/OpenHAP/TLV.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::TLV - TLV8 encoding/decoding for HAP protocol
+OpenHAP::TLV - TLV8 encoder and decoder for the HAP protocol
 
 =head1 SYNOPSIS
 
@@ -17,23 +17,25 @@ OpenHAP::TLV - TLV8 encoding/decoding for HAP protocol
 
 =head1 DESCRIPTION
 
-This module implements TLV8 (Type-Length-Value with 8-bit fields) encoding
-and decoding as specified in the HomeKit Accessory Protocol.
+This module encodes and decodes TLV8 (Type-Length-Value with 8-bit
+fields). The HomeKit Accessory Protocol specifies this format.
 
 =head1 FUNCTIONS
 
 =head2 encode(%items)
 
-Encodes a hash of type => value pairs into TLV8 format.
-Values longer than 255 bytes are automatically split into chunks.
+This function encodes a hash of type => value pairs into the TLV8
+format. It automatically splits values that are longer than 255 bytes
+into chunks.
 
 =head2 decode($data)
 
-Decodes TLV8 data into a hash of type => value pairs.
-Automatically concatenates chunks with the same type.
+This function decodes TLV8 data into a hash of type => value pairs. It
+automatically concatenates the chunks that have the same type.
 
-Returns the empty list if the buffer is malformed: a truncated record
-header, or a length field pointing past the end of the buffer.
+The function returns the empty list if the buffer is malformed. A
+malformed buffer has a truncated record header, or it has a length
+field that points past the end of the buffer.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Tasmota/Heater.pod
+++ b/lib/OpenHAP/Tasmota/Heater.pod
@@ -15,8 +15,8 @@ OpenHAP::Tasmota::Heater - Tasmota heater/switch HAP accessory
 
 =head1 DESCRIPTION
 
-This module implements a HAP switch accessory for Tasmota devices
-with relay control (heaters, switches, outlets).
+This module implements a HAP switch accessory for Tasmota devices that
+have relay control (for example, heaters, switches, and outlets).
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Tasmota/Sensor.pod
+++ b/lib/OpenHAP/Tasmota/Sensor.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-OpenHAP::Tasmota::Sensor - Tasmota temperature sensor HAP accessory
+OpenHAP::Tasmota::Sensor - Tasmota temperature-sensor HAP accessory
 
 =head1 SYNOPSIS
 
@@ -16,8 +16,8 @@ OpenHAP::Tasmota::Sensor - Tasmota temperature sensor HAP accessory
 
 =head1 DESCRIPTION
 
-This module implements a HAP temperature sensor accessory for Tasmota
-devices with temperature sensors (DS18B20, DHT22, etc).
+This module implements a HAP temperature-sensor accessory for Tasmota
+devices that have temperature sensors (for example, DS18B20 and DHT22).
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Tasmota/Thermostat.pod
+++ b/lib/OpenHAP/Tasmota/Thermostat.pod
@@ -16,7 +16,7 @@ OpenHAP::Tasmota::Thermostat - Tasmota thermostat HAP accessory
 =head1 DESCRIPTION
 
 This module implements a HAP thermostat accessory for Tasmota devices
-with temperature sensor and relay control.
+that have a temperature sensor and relay control.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Test/Controller.pod
+++ b/lib/OpenHAP/Test/Controller.pod
@@ -26,59 +26,80 @@ OpenHAP::Test::Controller - minimal HomeKit controller for tests
 
 =head1 DESCRIPTION
 
-A minimal HomeKit controller used by conformance and integration
-tests. It completes SRP-6a pair-setup (M1-M6), X25519 pair-verify, and
-speaks the ChaCha20-Poly1305 session framing, either over TCP against
-a live accessory or in-process through an injected transport.
+This module is a minimal HomeKit controller for the conformance tests
+and the integration tests. It completes the SRP-6a pair-setup (M1-M6)
+and the X25519 pair-verify, and it uses the ChaCha20-Poly1305 session
+framing. It can operate over TCP against a live accessory, or
+in-process through an injected transport.
 
-The controller follows the repository error convention: methods return
-undef (bare return) on protocol or transport errors, recording the TLV
-error code (or a message string) in C<last_error>; they die only on
-programming errors.
+The controller uses the error convention of the repository. A method
+returns undef (bare return) on a protocol error or a transport error,
+and it records the TLV error code, or a message string, in
+C<last_error>. A method dies only on a programming error.
 
 =head1 METHODS
 
 =head2 new(%args)
 
-Create a controller. Arguments: C<host> (default 127.0.0.1), C<port>
-(default 51827), C<pin> (setup code, default 031-45-154),
-C<controller_id> (pairing identifier, default openhap-test-ctrl),
-C<timeout> (socket timeout in seconds, default 5), and C<transport>.
+Create a controller. These are the arguments:
 
-C<transport>, when given, is a code ref C<($request_bytes) ->
-$response_bytes> replacing the TCP socket; this enables in-process use
-against an OpenHAP::HAP instance without sockets. Request and response
-bytes are pre-encryption/post-encryption wire bytes.
+=over 4
 
-An Ed25519 controller identity is generated once per controller.
+=item * C<host> - default 127.0.0.1
+
+=item * C<port> - default 51827
+
+=item * C<pin> - the setup code, default 031-45-154
+
+=item * C<controller_id> - the pairing identifier, default
+openhap-test-ctrl
+
+=item * C<timeout> - the socket timeout in seconds, default 5
+
+=item * C<transport> - optional, see below
+
+=back
+
+C<transport> is a code ref C<($request_bytes) -> $response_bytes>
+that replaces the TCP socket. This permits in-process use against an
+OpenHAP::HAP instance, without sockets. The request bytes and the
+response bytes are the wire bytes before encryption and after
+encryption.
+
+Each controller generates its Ed25519 identity one time.
 
 =head2 pair_setup()
 
-Complete pair-setup M1-M6 with the configured PIN. On success the
-accessory LTPK and pairing identifier are stored on the controller and
-true is returned.
+Complete the pair-setup M1-M6 with the configured PIN. On success, the
+method stores the accessory LTPK and the pairing identifier on the
+controller, and it returns true.
 
 =head2 pair_verify()
 
-Complete pair-verify M1-M4 and switch the connection to encrypted
-session framing. When the accessory LTPK is known from a prior
-C<pair_setup>, the accessory signature in M2 is verified against it.
+Complete the pair-verify M1-M4. Then switch the connection to
+encrypted session framing. When the controller knows the accessory
+LTPK from an earlier C<pair_setup>, the method does a check of the
+accessory signature in M2 against that LTPK.
 
 =head2 request($method, $path, $body?, $headers?)
 
-Perform one HTTP request over the session, encrypted once pair-verify
-has completed. Returns a hash ref with C<status>, C<headers> (lower
-cased names) and C<body>.
+Do one HTTP request over the session. The controller encrypts the
+request after the pair-verify is complete. The method returns a hash
+ref with C<status>, C<headers> (names in lower case), and C<body>.
 
 =head2 next_event($timeout?)
 
-Wait for an EVENT/1.0 message, decrypt and parse it. Returns a hash
-ref with C<status>, C<headers> and C<body>, or undef on timeout.
-Without an explicit $timeout the wait is bounded by the session
-timeout, which honors OPENHAP_TEST_TIMEOUT - pass a literal only for
-short negative probes ("no event arrives"). Event frames split across
-socket reads are reassembled without desynchronizing the session nonce
-counter. Requires a socket connection.
+Wait for one EVENT/1.0 message. Decrypt the message and parse it. The
+method returns a hash ref with C<status>, C<headers>, and C<body>, or
+undef on a timeout.
+
+Without an explicit $timeout, the session timeout limits the wait, and
+the session timeout obeys OPENHAP_TEST_TIMEOUT. Pass a literal value
+only for a short negative probe ("no event arrives").
+
+The method reassembles the event frames that split across socket
+reads. The reassembly does not desynchronize the session nonce
+counter. The method must have a socket connection.
 
 =head2 add_pairing($identifier, $ltpk, $permissions)
 
@@ -86,30 +107,32 @@ Add a pairing over POST /pairings (method AddPairing).
 
 =head2 remove_pairing($identifier?)
 
-Remove a pairing (default: this controller's own).
+Remove a pairing. The default is the controller's own pairing.
 
 =head2 list_pairings()
 
-Return an array ref of hashes with C<identifier>, C<ltpk> and
+Return an array ref of hashes with C<identifier>, C<ltpk>, and
 C<permissions>.
 
 =head2 last_error()
 
-The TLV error code (numeric) or message string of the last failure.
+Return the TLV error code (numeric), or the message string, of the
+last failure.
 
 =head2 is_encrypted()
 
-True once pair-verify has switched the session to encrypted framing.
+Return true after the pair-verify switches the session to encrypted
+framing.
 
 =head2 close()
 
-Close the socket connection and reset session state.
+Close the socket connection. Reset the session state.
 
 =head1 ENVIRONMENT
 
-Test-only namespace: not part of the production daemon and never a
-dependency of production modules. Ships to the integration VM together
-with the integration tests.
+This namespace is for tests only. It is not a part of the production
+daemon, and it is never a dependency of a production module. It ships
+to the integration VM together with the integration tests.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Test/Controller.pod
+++ b/lib/OpenHAP/Test/Controller.pod
@@ -76,7 +76,7 @@ controller, and it returns true.
 
 =head2 pair_verify()
 
-Complete the pair-verify M1-M4. Then switch the connection to
+Do the pair-verify M1-M4. Then switch the connection to
 encrypted session framing. When the controller knows the accessory
 LTPK from an earlier C<pair_setup>, the method does a check of the
 accessory signature in M2 against that LTPK.

--- a/lib/OpenHAP/Test/Controller.pod
+++ b/lib/OpenHAP/Test/Controller.pod
@@ -27,7 +27,7 @@ OpenHAP::Test::Controller - minimal HomeKit controller for tests
 =head1 DESCRIPTION
 
 This module is a minimal HomeKit controller for the conformance tests
-and the integration tests. It completes the SRP-6a pair-setup (M1-M6)
+and the integration tests. It does the SRP-6a pair-setup (M1-M6)
 and the X25519 pair-verify, and it uses the ChaCha20-Poly1305 session
 framing. It can operate over TCP against a live accessory, or
 in-process through an injected transport.
@@ -41,7 +41,7 @@ A method dies only on a programming error.
 
 =head2 new(%args)
 
-Create a controller. These are the arguments:
+The constructor creates a controller. These are the arguments:
 
 =over 4
 
@@ -70,28 +70,29 @@ Each controller generates its Ed25519 identity one time.
 
 =head2 pair_setup()
 
-Complete the pair-setup M1-M6 with the configured PIN. On success, the
-method stores the accessory LTPK and the pairing identifier on the
-controller, and it returns true.
+The method does the pair-setup M1-M6 with the configured PIN. On
+success, it stores the accessory LTPK and the pairing identifier on
+the controller, and it returns true.
 
 =head2 pair_verify()
 
-Do the pair-verify M1-M4. Then switch the connection to
-encrypted session framing. When the controller knows the accessory
-LTPK from an earlier C<pair_setup>, the method does a check of the
-accessory signature in M2 against that LTPK.
+The method does the pair-verify M1-M4. Then it switches the
+connection to encrypted session framing. When the controller knows
+the accessory LTPK from an earlier C<pair_setup>, the method does a
+check of the accessory signature in M2 against that LTPK.
 
 =head2 request($method, $path, $body?, $headers?)
 
-Do one HTTP request over the session. The controller encrypts the
-request after the pair-verify is complete. The method returns a hash
-ref with C<status>, C<headers> (names in lower case), and C<body>.
+The method does one HTTP request over the session. The controller
+encrypts the request after the pair-verify is complete. The method
+returns a hash ref with C<status>, C<headers> (names in lower case),
+and C<body>.
 
 =head2 next_event($timeout?)
 
-Wait for one EVENT/1.0 message. Decrypt the message and parse it. The
-method returns a hash ref with C<status>, C<headers>, and C<body>, or
-undef on a timeout.
+The method waits for one EVENT/1.0 message. It decrypts the message
+and parses it. The method returns a hash ref with C<status>,
+C<headers>, and C<body>, or undef on a timeout.
 
 Without an explicit $timeout, the session timeout limits the wait, and
 the session timeout obeys OPENHAP_TEST_TIMEOUT. Pass a literal value
@@ -103,30 +104,31 @@ counter. The method must have a socket connection.
 
 =head2 add_pairing($identifier, $ltpk, $permissions)
 
-Add a pairing over POST /pairings (method AddPairing).
+The method adds a pairing over POST /pairings (method AddPairing).
 
 =head2 remove_pairing($identifier?)
 
-Remove a pairing. The default is the controller's own pairing.
+The method removes a pairing. The default is the controller's own
+pairing.
 
 =head2 list_pairings()
 
-Return an array ref of hashes with C<identifier>, C<ltpk>, and
-C<permissions>.
+The method returns an array ref of hashes with C<identifier>,
+C<ltpk>, and C<permissions>.
 
 =head2 last_error()
 
-Return the TLV error code (numeric), or the message string, of the
-last failure.
+The method returns the TLV error code (numeric), or the message
+string, of the last failure.
 
 =head2 is_encrypted()
 
-Return true after the pair-verify switches the session to encrypted
-framing.
+The method returns true after the pair-verify switches the session to
+encrypted framing.
 
 =head2 close()
 
-Close the socket connection. Reset the session state.
+The method closes the socket connection. It resets the session state.
 
 =head1 ENVIRONMENT
 

--- a/lib/OpenHAP/Test/Controller.pod
+++ b/lib/OpenHAP/Test/Controller.pod
@@ -33,9 +33,9 @@ framing. It can operate over TCP against a live accessory, or
 in-process through an injected transport.
 
 The controller uses the error convention of the repository. A method
-returns undef (bare return) on a protocol error or a transport error,
-and it records the TLV error code, or a message string, in
-C<last_error>. A method dies only on a programming error.
+returns undef (bare return) on a protocol error or a transport error.
+It records the TLV error code, or a message string, in C<last_error>.
+A method dies only on a programming error.
 
 =head1 METHODS
 

--- a/lib/OpenHAP/Test/Controller/SRP.pod
+++ b/lib/OpenHAP/Test/Controller/SRP.pod
@@ -17,36 +17,53 @@ OpenHAP::Test::Controller::SRP - SRP-6a client role for tests
 
 =head1 DESCRIPTION
 
-The client (controller) role of the SRP-6a exchange served by
-L<OpenHAP::SRP>: the same RFC 5054 3072-bit group, g = 5, SHA-512
-hash, fixed username C<Pair-Setup>, and 384-byte padding rules
-(F<spec/HAP-Pairing.md> section 2). The setup code is normalized like
-the server side (dashes and spaces stripped).
+This module is the client (controller) role of the SRP-6a exchange
+that L<OpenHAP::SRP> serves. It uses the same parameters as the
+server:
+
+=over 4
+
+=item * the RFC 5054 3072-bit group
+
+=item * g = 5
+
+=item * the SHA-512 hash
+
+=item * the fixed username C<Pair-Setup>
+
+=item * the 384-byte padding rules (F<spec/HAP-Pairing.md> section 2)
+
+=back
+
+The module normalizes the setup code in the same way as the server
+side: it removes dashes and spaces.
 
 =head1 METHODS
 
 =head2 new(%args)
 
-C<password> is the 8-digit setup code; C<username> defaults to
+C<password> is the 8-digit setup code. The default for C<username> is
 C<Pair-Setup>.
 
 =head2 compute_public()
 
-Generate the ephemeral secret and return the padded 384-byte public
+Generate the ephemeral secret. Return the padded 384-byte public
 value A.
 
 =head2 compute_proof($salt, $B_bytes)
 
-Derive the session key from the server's salt and public key B, and
-return the client proof M1. Returns undef if B mod N == 0.
+Derive the session key from the server salt and the server public
+key B. Return the client proof M1. The method returns undef if
+B mod N == 0.
 
 =head2 verify_server_proof($M2)
 
-True iff $M2 equals H(PAD(A) | M1 | K).
+Return true if, and only if, $M2 equals H(PAD(A) | M1 | K).
 
 =head2 session_key()
 
-The 64-byte shared session key K, available after C<compute_proof>.
+Return the 64-byte shared session key K. The key is available after
+C<compute_proof>.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Test/Controller/SRP.pod
+++ b/lib/OpenHAP/Test/Controller/SRP.pod
@@ -47,23 +47,24 @@ C<Pair-Setup>.
 
 =head2 compute_public()
 
-Generate the ephemeral secret. Return the padded 384-byte public
-value A.
+The method generates the ephemeral secret. It returns the padded
+384-byte public value A.
 
 =head2 compute_proof($salt, $B_bytes)
 
-Derive the session key from the server salt and the server public
-key B. Return the client proof M1. The method returns undef if
-B mod N == 0.
+The method derives the session key from the server salt and the
+server public key B. It returns the client proof M1. The method
+returns undef if B mod N == 0.
 
 =head2 verify_server_proof($M2)
 
-Return true if, and only if, $M2 equals H(PAD(A) | M1 | K).
+The method returns true if, and only if, $M2 equals
+H(PAD(A) | M1 | K).
 
 =head2 session_key()
 
-Return the 64-byte shared session key K. The key is available after
-C<compute_proof>.
+The method returns the 64-byte shared session key K. The key is
+available after C<compute_proof>.
 
 =head1 SEE ALSO
 

--- a/lib/OpenHAP/Test/Integration.pod
+++ b/lib/OpenHAP/Test/Integration.pod
@@ -1,57 +1,58 @@
 =head1 NAME
 
-OpenHAP::Test::Integration - Base module for OpenHAP integration tests
+OpenHAP::Test::Integration - base module for OpenHAP integration tests
 
 =head1 SYNOPSIS
 
     use v5.36;
     use Test::More;
     use OpenHAP::Test::Integration;
-    
+
     my $env = OpenHAP::Test::Integration->new;
     $env->setup;
-    
+
     # Run tests...
     my $response = $env->http_request('GET', '/accessories');
     ok(defined $response, 'received response');
-    
+
     $env->teardown;
     done_testing();
 
 =head1 DESCRIPTION
 
-Setup, teardown, and helpers for the integration tests, which run against
-an installed openhapd on OpenBSD rather than against modules in the
-checkout.
+This module supplies the setup, the teardown, and the helpers for the
+integration tests. These tests run against an installed openhapd on
+OpenBSD, not against the modules in the checkout.
 
-Unlike the unit tests, these fail rather than skip when a requirement is
-missing, since a silent skip in the VM would report a green run that
-tested nothing.
+When a requirement is not available, these tests fail. They do not skip as
+the unit tests do, because a silent skip in the VM reports a green run
+that tests nothing.
 
 =head1 ENVIRONMENT
 
-Integration tests require:
+The integration tests must have these conditions:
 
 =over 4
 
-=item * OPENHAP_INTEGRATION_TEST environment variable set
+=item * The OPENHAP_INTEGRATION_TEST environment variable is set.
 
-=item * OpenBSD system with rcctl(8)
+=item * The system is OpenBSD with rcctl(8).
 
-=item * openhapd and hapctl installed in /usr/local/bin
+=item * openhapd and hapctl are installed in /usr/local/bin.
 
-=item * Configuration file at /etc/openhapd.conf
+=item * The configuration file is at /etc/openhapd.conf.
 
-=item * System user _openhap
+=item * The system has the user _openhap.
 
-=item * Data directory /var/db/openhapd
+=item * The system has the data directory /var/db/openhapd.
 
-=item * mosquitto(8) installed and startable via rcctl (MQTT tests)
+=item * mosquitto(8) is installed, and rcctl can start it (for the
+MQTT tests).
 
-=item * mdnsd(8) installed, with its flags set to a usable network
-interface and startable via rcctl; mdnsctl(8) installed as the browsing
-tool the mDNS tests observe advertisements with (the daemon itself no
-longer invokes it)
+=item * mdnsd(8) is installed, its flags are set to a usable network
+interface, and rcctl can start it. mdnsctl(8) is installed; the mDNS
+tests use it to see the advertisements (the daemon itself no longer
+invokes mdnsctl).
 
 =back
 
@@ -61,17 +62,20 @@ longer invokes it)
 
     my $env = OpenHAP::Test::Integration->new(%options);
 
-Create a new integration test environment. Options:
+Create a new environment for the integration tests. These are the
+options:
 
 =over 4
 
-=item config_file - Path to openhapd.conf (default: /etc/openhapd.conf)
+=item config_file - the path to openhapd.conf (default:
+/etc/openhapd.conf)
 
-=item hap_port - HAP server port (default: from config or 51827)
+=item hap_port - the HAP server port (default: from the
+configuration, or 51827)
 
-=item mqtt_host - MQTT broker host (default: 127.0.0.1)
+=item mqtt_host - the MQTT broker host (default: 127.0.0.1)
 
-=item mqtt_port - MQTT broker port (default: 1883)
+=item mqtt_port - the MQTT broker port (default: 1883)
 
 =back
 
@@ -79,14 +83,15 @@ Create a new integration test environment. Options:
 
     $env->setup;
 
-Validate environment and prepare for testing. Dies if environment is not ready.
+Do a check of the environment, and prepare for the tests. The method
+dies if the environment is not ready.
 
 =head2 teardown
 
     $env->teardown;
 
-Clean up resources after testing, including any controller connections
-handed out by C<get_controller>.
+Release the resources after the tests. These resources include each
+controller connection that C<get_controller> supplied.
 
 =head2 get_controller
 
@@ -94,22 +99,26 @@ handed out by C<get_controller>.
     $c->pair_setup or die 'pair-setup: ' . $c->last_error;
 
 Construct an L<OpenHAP::Test::Controller> for the configured host,
-port, and setup code (read from the C<hap_pin> configuration key). The
-connection is tracked and closed in C<teardown>. Extra arguments are
-passed through to the controller constructor.
+port, and setup code. The method reads the setup code from the
+C<hap_pin> configuration key. The environment keeps a record of the
+connection and closes it in C<teardown>. The method passes extra
+arguments through to the controller constructor.
 
 =head2 ensure_unpaired
 
     $env->ensure_unpaired or die 'cannot unpair';
 
-Guarantee the daemon is verifiably unpaired. When the pairings database
-(/var/db/openhapd/pairings.db) holds any entry, the daemon is stopped,
-the pairing state is wiped - pairings.db and auth_attempts, keeping the
-accessory identity - and the daemon is started again. The post-condition
-is then probed with POST /identify, which returns 204 only while
-unpaired; a paired answer fails the call. Returns true on a verified
-unpaired daemon, false otherwise. Every integration test file starts
-unpaired unless it pairs itself.
+Make sure that the daemon is unpaired. When the pairings database
+(/var/db/openhapd/pairings.db) holds an entry, the method stops the
+daemon, removes the pairing state, and starts the daemon again. The
+removed state is pairings.db and auth_attempts. The accessory identity
+stays.
+
+The method then does a check of the result with POST /identify, which
+returns 204 only while the daemon is unpaired. A paired answer fails
+the call. The method returns true when the check shows an unpaired
+daemon, and false in other cases. Each integration test file starts
+unpaired, unless the file pairs itself.
 
 =head2 http_request
 
@@ -122,12 +131,13 @@ registered until C<teardown> (or C<close_sockets>).
 
     $env->close_sockets;
 
-Close and forget every raw socket opened by C<http_request>, so a probe
-connection is not left registered with the daemon until teardown.
+Close and forget each raw socket that C<http_request> opened. Thus a
+probe connection does not stay registered with the daemon until the
+teardown.
 
 =head2 parse_http_response
 
-    my ($status, $headers, $body) = 
+    my ($status, $headers, $body) =
         OpenHAP::Test::Integration::parse_http_response($response);
 
 Parse an HTTP response.
@@ -142,65 +152,68 @@ Get a configuration value.
 
     my @topics = $env->get_device_topics;
 
-Get all device MQTT topics.
+Get all the MQTT topics of the devices.
 
 =head2 get_devices
 
     my ($light) = grep { $_->{subtype} eq 'lightbulb' } $env->get_devices;
 
-Get the configured device records: hashes with C<type>, C<subtype>,
-C<id>, C<name>, and C<topic>.
+Get the configured device records. Each record is a hash with
+C<type>, C<subtype>, C<id>, C<name>, and C<topic>.
 
 =head2 ensure_daemon_running
 
     $env->ensure_daemon_running or die "Cannot start daemon";
 
-Ensure openhapd is running and serving: starts it if needed, then
-waits for the HAP port, since the daemon publishes its mDNS
-advertisement before opening the listener.
+Make sure that openhapd runs and serves. If it is necessary, the
+method starts the daemon. The method then waits for the HAP port,
+because the daemon publishes its mDNS advertisement before it opens
+the listener.
 
 =head2 wait_for_hap_port
 
     $env->wait_for_hap_port or die "daemon not serving";
     $env->wait_for_hap_port(60);
 
-Wait until the HAP port accepts connections, polling up to the given
-number of seconds (default 30). Use this instead of a fixed sleep
-after restarting the daemon.
+Wait until the HAP port accepts connections. The method polls for a
+maximum of the given number of seconds (default 30). Use this method,
+not a fixed sleep, after you restart the daemon.
 
 =head2 ensure_daemon_stopped
 
     $env->ensure_daemon_stopped;
 
-Ensure openhapd is stopped.
+Make sure that openhapd is stopped.
 
 =head2 ensure_mqtt_running
 
     $env->ensure_mqtt_running or die "MQTT required";
 
-Ensure MQTT broker is running.
+Make sure that the MQTT broker runs.
 
 =head2 ensure_mdnsd_running
 
     $env->ensure_mdnsd_running or die "mdnsd required";
 
-Ensure mdnsd is running and stays running: start it if needed, then
-re-check across a settle window, because a point-in-time probe races
-green when mdnsd starts and then exits shortly after. On failure,
-captured diagnostics (rcctl state, process list, recent syslog lines)
-are emitted as warnings.
+Make sure that mdnsd runs and continues to run. If it is necessary,
+the method starts mdnsd. The method then does the check again across a
+settle window, because a probe at one point in time can show green
+when mdnsd starts and then exits a short time after that. On a
+failure, the method sends the captured diagnostics as warnings: the
+rcctl state, the process list, and recent syslog lines.
 
 =head2 get_log_lines
 
     my @lines = $env->get_log_lines($pattern);
 
-Get log lines matching pattern since baseline.
+Get the log lines that match the pattern and that come after the
+baseline.
 
 =head2 get_mqtt
 
     my $mqtt = $env->get_mqtt;
 
-Get MQTT client connection.
+Get the MQTT client connection.
 
 =head1 AUTHOR
 

--- a/lib/OpenHAP/Test/Integration.pod
+++ b/lib/OpenHAP/Test/Integration.pod
@@ -197,8 +197,8 @@ Make sure that the MQTT broker runs.
 
 Make sure that mdnsd runs and continues to run. If it is necessary,
 the method starts mdnsd. The method then does the check again across a
-settle window, because a probe at one point in time can show green
-when mdnsd starts and then exits a short time after that. On a
+settle window. A probe at one point in time can show green when mdnsd
+starts and then exits a short time after that. On a
 failure, the method sends the captured diagnostics as warnings: the
 rcctl state, the process list, and recent syslog lines.
 

--- a/lib/OpenHAP/Test/Integration.pod
+++ b/lib/OpenHAP/Test/Integration.pod
@@ -62,8 +62,8 @@ invokes mdnsctl).
 
     my $env = OpenHAP::Test::Integration->new(%options);
 
-Create a new environment for the integration tests. These are the
-options:
+The constructor creates a new environment for the integration tests.
+These are the options:
 
 =over 4
 
@@ -83,36 +83,36 @@ configuration, or 51827)
 
     $env->setup;
 
-Do a check of the environment, and prepare for the tests. The method
-dies if the environment is not ready.
+The method does a check of the environment, and it prepares for the
+tests. It dies if the environment is not ready.
 
 =head2 teardown
 
     $env->teardown;
 
-Release the resources after the tests. These resources include each
-controller connection that C<get_controller> supplied.
+The method releases the resources after the tests. These resources
+include each controller connection that C<get_controller> supplied.
 
 =head2 get_controller
 
     my $c = $env->get_controller;
     $c->pair_setup or die 'pair-setup: ' . $c->last_error;
 
-Construct an L<OpenHAP::Test::Controller> for the configured host,
-port, and setup code. The method reads the setup code from the
-C<hap_pin> configuration key. The environment keeps a record of the
-connection and closes it in C<teardown>. The method passes extra
+The method constructs an L<OpenHAP::Test::Controller> for the
+configured host, port, and setup code. It reads the setup code from
+the C<hap_pin> configuration key. The environment keeps a record of
+the connection and closes it in C<teardown>. The method passes extra
 arguments through to the controller constructor.
 
 =head2 ensure_unpaired
 
     $env->ensure_unpaired or die 'cannot unpair';
 
-Make sure that the daemon is unpaired. When the pairings database
-(/var/db/openhapd/pairings.db) holds an entry, the method stops the
-daemon, removes the pairing state, and starts the daemon again. The
-removed state is pairings.db and auth_attempts. The accessory identity
-stays.
+The method makes sure that the daemon is unpaired. When the pairings
+database (/var/db/openhapd/pairings.db) holds an entry, the method
+stops the daemon, removes the pairing state, and starts the daemon
+again. The removed state is pairings.db and auth_attempts. The
+accessory identity stays.
 
 The method then does a check of the result with POST /identify.
 That request returns 204 only while the daemon is unpaired. A paired answer fails
@@ -124,81 +124,81 @@ unpaired, unless the file pairs itself.
 
     my $response = $env->http_request($method, $path, $body, $headers);
 
-Make an HTTP request to the HAP server. The connection stays open and
-registered until C<teardown> (or C<close_sockets>).
+The method makes an HTTP request to the HAP server. The connection
+stays open and registered until C<teardown> (or C<close_sockets>).
 
 =head2 close_sockets
 
     $env->close_sockets;
 
-Close and forget each raw socket that C<http_request> opened. Thus a
-probe connection does not stay registered with the daemon until the
-teardown.
+The method closes and forgets each raw socket that C<http_request>
+opened. Thus a probe connection does not stay registered with the
+daemon until the teardown.
 
 =head2 parse_http_response
 
     my ($status, $headers, $body) =
         OpenHAP::Test::Integration::parse_http_response($response);
 
-Parse an HTTP response.
+The method parses an HTTP response.
 
 =head2 get_config_value
 
     my $value = $env->get_config_value($key);
 
-Get a configuration value.
+The method gets a configuration value.
 
 =head2 get_device_topics
 
     my @topics = $env->get_device_topics;
 
-Get all the MQTT topics of the devices.
+The method gets all the MQTT topics of the devices.
 
 =head2 get_devices
 
     my ($light) = grep { $_->{subtype} eq 'lightbulb' } $env->get_devices;
 
-Get the configured device records. Each record is a hash with
-C<type>, C<subtype>, C<id>, C<name>, and C<topic>.
+The method gets the configured device records. Each record is a hash
+with C<type>, C<subtype>, C<id>, C<name>, and C<topic>.
 
 =head2 ensure_daemon_running
 
     $env->ensure_daemon_running or die "Cannot start daemon";
 
-Make sure that openhapd runs and serves. If it is necessary, the
-method starts the daemon. The method then waits for the HAP port,
-because the daemon publishes its mDNS advertisement before it opens
-the listener.
+The method makes sure that openhapd runs and serves. If it is
+necessary, the method starts the daemon. The method then waits for
+the HAP port, because the daemon publishes its mDNS advertisement
+before it opens the listener.
 
 =head2 wait_for_hap_port
 
     $env->wait_for_hap_port or die "daemon not serving";
     $env->wait_for_hap_port(60);
 
-Wait until the HAP port accepts connections. The method polls for a
-maximum of the given number of seconds (default 30). Use this method,
-not a fixed sleep, after you restart the daemon.
+The method waits until the HAP port accepts connections. It polls for
+a maximum of the given number of seconds (default 30). Use this
+method, not a fixed sleep, after you restart the daemon.
 
 =head2 ensure_daemon_stopped
 
     $env->ensure_daemon_stopped;
 
-Make sure that openhapd is stopped.
+The method makes sure that openhapd is stopped.
 
 =head2 ensure_mqtt_running
 
     $env->ensure_mqtt_running or die "MQTT required";
 
-Make sure that the MQTT broker runs.
+The method makes sure that the MQTT broker runs.
 
 =head2 ensure_mdnsd_running
 
     $env->ensure_mdnsd_running or die "mdnsd required";
 
-Make sure that mdnsd runs and continues to run. If it is necessary,
-the method starts mdnsd. The method then does the check again across a
-settle window. A probe at one point in time can show green when mdnsd
-starts and then exits a short time after that. On a
+The method makes sure that mdnsd runs and continues to run. If it is
+necessary, the method starts mdnsd. The method then does the check
+again across a settle window. A probe at one point in time can show
+green when mdnsd starts and then exits a short time after that. On a
 failure, the method sends the captured diagnostics as warnings: the
 rcctl state, the process list, and recent syslog lines.
 
@@ -206,14 +206,14 @@ rcctl state, the process list, and recent syslog lines.
 
     my @lines = $env->get_log_lines($pattern);
 
-Get the log lines that match the pattern and that come after the
-baseline.
+The method gets the log lines that match the pattern and that come
+after the baseline.
 
 =head2 get_mqtt
 
     my $mqtt = $env->get_mqtt;
 
-Get the MQTT client connection.
+The method gets the MQTT client connection.
 
 =head1 AUTHOR
 

--- a/lib/OpenHAP/Test/Integration.pod
+++ b/lib/OpenHAP/Test/Integration.pod
@@ -114,8 +114,8 @@ daemon, removes the pairing state, and starts the daemon again. The
 removed state is pairings.db and auth_attempts. The accessory identity
 stays.
 
-The method then does a check of the result with POST /identify, which
-returns 204 only while the daemon is unpaired. A paired answer fails
+The method then does a check of the result with POST /identify.
+That request returns 204 only while the daemon is unpaired. A paired answer fails
 the call. The method returns true when the check shows an unpaired
 daemon, and false in other cases. Each integration test file starts
 unpaired, unless the file pairs itself.

--- a/man/fugulib/Daemon.3p
+++ b/man/fugulib/Daemon.3p
@@ -19,7 +19,7 @@
 .Os
 .Sh NAME
 .Nm FuguLib::Daemon
-.Nd detach a Perl program from its controlling terminal
+.Nd daemonization for Perl programs
 .Sh SYNOPSIS
 .Bd -literal
 use FuguLib::Daemon;
@@ -55,7 +55,7 @@ The child then appends standard output to
 .Fa logfile
 and duplicates standard output onto standard error.
 .Pp
-The arguments are:
+These are the arguments:
 .Bl -tag -width "logfileXX"
 .It Fa logfile
 The path for standard output and standard error.
@@ -93,7 +93,7 @@ dies and does not return if the fork fails, if
 .Xr setsid 2
 fails, or if the module cannot redirect one of the three standard
 descriptors.
-A daemon cannot recover from these start-up conditions.
+A daemon cannot recover from these startup conditions.
 .Sh SEE ALSO
 .Xr setsid 2 ,
 .Xr daemon 3 ,

--- a/man/fugulib/Daemon.3p
+++ b/man/fugulib/Daemon.3p
@@ -31,52 +31,52 @@ FuguLib::Daemon->daemonize(
 .Ed
 .Sh DESCRIPTION
 .Nm
-turns the running program into a daemon:
-it forks,
-the parent exits,
-and the child becomes a session leader with its standard descriptors
-redirected away from the terminal.
+turns the program into a daemon.
+The program forks, and the parent exits.
+The child becomes a session leader and redirects its standard
+descriptors away from the terminal.
 .Pp
-The module keeps no state and has a single class method.
+The module keeps no state and has one class method.
 .Ss daemonize
 .Fn daemonize "%args"
 forks into the background and detaches from the controlling terminal.
 .Pp
 The parent calls
 .Fa on_fork
-if one was given,
-then exits with status 0;
+if the caller gave one, and then exits with status 0.
+Thus
 .Fn daemonize
-therefore returns only in the child.
+returns only in the child.
 The child calls
-.Xr setsid 2 ,
-reopens standard input from
-.Pa /dev/null ,
-appends standard output to
-.Fa logfile ,
+.Xr setsid 2
+and reopens standard input from
+.Pa /dev/null .
+The child then appends standard output to
+.Fa logfile
 and duplicates standard output onto standard error.
 .Pp
-The arguments are as follows:
+The arguments are:
 .Bl -tag -width "logfileXX"
 .It Fa logfile
-Path for standard output and standard error.
+The path for standard output and standard error.
 The default is
-.Pa /dev/null ,
-which is what a daemon logging through
+.Pa /dev/null .
+This default is correct for a daemon that logs through
 .Xr FuguLib::Log 3p
-in syslog mode wants.
-The file is opened for appending.
+in syslog mode.
+The module opens the file in append mode.
 .It Fa on_fork
-Code reference called in the parent with the child's process ID before
-the parent exits.
-This is where a PID file is written,
-because only the parent knows the child's process ID at that point.
+A code reference that the parent calls with the child's process ID
+before the parent exits.
+Write the PID file in this code reference.
+Only the parent knows the child's process ID at that point.
 .El
 .Sh RETURN VALUES
 .Fn daemonize
 returns nothing in the child and never returns in the parent.
 .Sh EXAMPLES
-Daemonize, writing a PID file from the parent and logging through syslog:
+This example daemonizes the program, writes a PID file from the
+parent, and logs through syslog:
 .Bd -literal -offset indent
 my $log = FuguLib::Log->new(mode => 'syslog', ident => 'mydaemon');
 my $state = FuguLib::State->new('/var/run/mydaemon.pid');
@@ -89,12 +89,11 @@ $log->info('started, pid %d', $$);
 .Ed
 .Sh ERRORS
 .Fn daemonize
-dies rather than returning if the fork fails,
-if
+dies and does not return if the fork fails, if
 .Xr setsid 2
-fails,
-or if any of the three standard descriptors cannot be redirected.
-These are start-up conditions a daemon cannot recover from.
+fails, or if the module cannot redirect one of the three standard
+descriptors.
+A daemon cannot recover from these start-up conditions.
 .Sh SEE ALSO
 .Xr setsid 2 ,
 .Xr daemon 3 ,
@@ -107,12 +106,12 @@ These are start-up conditions a daemon cannot recover from.
 .Sh CAVEATS
 Call
 .Fn daemonize
-before opening files or sockets that the daemon expects to keep:
-the standard descriptors are redirected in the child,
-but anything already open is inherited as it is.
+before you open files or sockets that the daemon must keep.
+The child redirects the standard descriptors, but it inherits
+everything that is already open with no change.
 .Pp
 The parent exits with status 0 even if
 .Fa on_fork
 fails.
-A caller that must know whether the PID file was written has to check
-for it separately.
+To make sure that the PID file exists, the caller must do a separate
+check.

--- a/man/fugulib/Imsg.3p
+++ b/man/fugulib/Imsg.3p
@@ -35,47 +35,54 @@ say $msg->{type};
 .Ed
 .Sh DESCRIPTION
 .Nm
-frames messages the way the base-system
+frames messages in the same format as the base-system
 .Xr imsg_init 3
-facility does:
-a fixed native-endian header carrying type, length, peer id and sender
-pid, followed by a payload.
-It is pure serialisation over an already-connected stream socket \(em
-the module never opens, names, or closes a socket itself, and it never
-logs.
+facility.
+Each message has a fixed native-endian header and then a payload.
+The header holds the type, the length, the peer id, and the sender
+pid.
+The module does only serialisation over a stream socket that is
+already connected.
+The module never opens, names, or closes a socket, and it never logs.
 Callers decide what a failure means.
 .Pp
-The wire format \(em field layout, length semantics, size bounds, and
-message boundary rules \(em is not restated here;
-it is specified in the protocol reference
+This page does not repeat the wire format:
+the field layout, the length semantics, the size bounds, and the
+message boundary rules.
+The protocol reference
 .Pa spec/MDNS-Imsg.md
-in the OpenHAP source tree, which this implementation follows.
+in the OpenHAP source tree gives the full specification, and this
+implementation follows it.
 .Ss new
 .Fn new "fh => $fh"
 creates a framing object over the connected socket
 .Fa $fh .
-The handle is required;
-omitting it is a programming error and dies.
+The handle is necessary.
+A call without the handle is a programming error, and
+.Fn new
+dies.
 .Ss send
 .Fn send "type => $type" "data => $bytes"
 frames and writes one message.
 .Fa data
 defaults to the empty string.
-Returns 1 on success.
-Returns
+The method returns 1 on success.
+On failure, the method returns
 .Dv undef
-with
-.Va $!
-set when the payload exceeds the protocol bound
+and sets
+.Va $! .
+This occurs when the payload is larger than the protocol bound
 .Pq Er EMSGSIZE ,
-when the connection has already failed
+when the connection failed earlier
 .Pq Er EPIPE ,
-or on a write error.
-A peer that closed the socket surfaces as
-.Er EPIPE ;
+or when a write error occurs.
+If the peer closed the socket, the method reports
+.Er EPIPE .
+The module suppresses
 .Dv SIGPIPE
-is suppressed for the duration of the write.
-Oversized payloads are refused, never truncated.
+during the write.
+The method refuses a payload that is too large, and it never
+truncates the payload.
 .Ss recv
 .Fn recv "timeout => $seconds"
 returns one whole message as a hash reference with
@@ -83,17 +90,20 @@ returns one whole message as a hash reference with
 and
 .Va data
 keys.
-Short reads accumulate across calls, and several messages arriving in
-one read are returned one per call.
-Returns
+Short reads accumulate across calls.
+If several messages arrive in one read, the method returns them one
+for each call.
+The method returns
 .Dv undef
-on timeout, on clean end-of-file, or on an unrecoverable framing error
-.Pq Er EBADMSG ,
-after which the connection is dead and every later call returns
+on a timeout, on a clean end-of-file, or on an unrecoverable framing
+error
+.Pq Er EBADMSG .
+After a framing error, the connection is dead, and every later call
+returns
 .Dv undef .
 Without a
 .Fa timeout
-the call blocks until a message or end-of-file arrives.
+the call blocks until a message or an end-of-file arrives.
 .Sh SEE ALSO
 .Xr imsg_init 3 ,
 .Xr FuguLib::MDNS 3p

--- a/man/fugulib/Log.3p
+++ b/man/fugulib/Log.3p
@@ -36,13 +36,13 @@ $log->err('cannot open %s: %s', $path, $!);
 .Ed
 .Sh DESCRIPTION
 .Nm
-gives a program one logging interface whether it is running as a daemon
-or in the foreground.
-The destination is chosen once,
-when the logger is created,
-and every call site is written the same way regardless.
+gives a program one logging interface whether the program runs as a
+daemon or in the foreground.
+The caller selects the destination one time, when it creates the
+logger.
+Every call site then has the same form for all destinations.
 .Pp
-Messages below the configured level are discarded.
+The logger discards messages below the configured level.
 The levels, from lowest to highest, are
 .Cm debug ,
 .Cm info ,
@@ -54,51 +54,51 @@ and
 .Ss new
 .Fn new "%args"
 creates a logger.
-The arguments are as follows:
+The arguments are:
 .Bl -tag -width "facilityXX"
 .It Fa mode
-Where messages go.
-One of:
+The destination for messages.
+The value is one of:
 .Pp
 .Bl -tag -width "syslogXX" -compact
 .It Cm syslog
-Through
+Messages go through
 .Xr syslog 3 .
+The logger calls
 .Xr openlog 3
-is called immediately with the
+immediately with the
 .Cm ndelay
 and
 .Cm pid
 options.
 .It Cm stderr
-To standard error,
-one line per message,
-prefixed with a local-time stamp and the upper-cased level.
+Messages go to standard error, with one line for each message.
+Each line starts with a local-time stamp and the level in upper case.
 .It Cm quiet
-Nowhere.
-Messages are discarded before the level is even considered.
+Messages go nowhere.
+The logger discards them before it does a check of the level.
 .El
 .Pp
 The default is
 .Cm stderr .
 .It Fa level
-Lowest level to emit.
+The lowest level to emit.
 The default is
 .Cm info .
 .It Fa ident
-Program name passed to
+The program name that the logger passes to
 .Xr openlog 3 .
 The default is
 .Ql fugulib .
-Ignored unless
+The logger uses this argument only when
 .Fa mode
 is
 .Cm syslog .
 .It Fa facility
-Syslog facility,
-either a
+The syslog facility.
+The value is a
 .Xr Sys::Syslog 3p
-constant or one of the names
+constant, or one of the names
 .Cm daemon ,
 .Cm user
 or
@@ -113,30 +113,32 @@ The default is
 $log->info($fmt, @args);
 .Ed
 .Pp
-Log one message at the level named by the method.
+Each method logs one message at the level that its name gives.
 When
 .Fa @args
-is non-empty the message is
+is not empty, the method formats
 .Fa $fmt
-formatted through
-.Xr sprintf 3 ;
-otherwise
+through
+.Xr sprintf 3 .
+When
+.Fa @args
+is empty, the method uses
 .Fa $fmt
-is used literally.
+as a literal string.
 .Pp
 .Fn warn
 is a synonym for
-.Fn warning
+.Fn warning ,
 and
 .Fn err
-for
-.Fn error ,
-so that either the syslog or the English spelling reads naturally at the
-call site.
+is a synonym for
+.Fn error .
+Thus the call site can use the syslog spelling or the English
+spelling.
 .Ss set_level
 .Fn set_level "$level"
-changes the lowest level to emit on an existing logger.
-Anything not recognised as a level name is treated as
+changes the lowest level to emit on a logger after its creation.
+If the value is not a known level name, the logger uses
 .Cm info .
 .Sh RETURN VALUES
 .Fn new
@@ -145,8 +147,8 @@ The logging methods and
 .Fn set_level
 have no useful return value.
 .Sh EXAMPLES
-Log to standard error in the foreground and to syslog otherwise,
-without changing any call site:
+This example logs to standard error in the foreground, and to syslog
+in the background, with no change to the call sites:
 .Bd -literal -offset indent
 my $log = FuguLib::Log->new(
     mode  => $foreground ? 'stderr' : 'syslog',
@@ -159,14 +161,14 @@ my $log = FuguLib::Log->new(
 dies if
 .Fa mode
 is not one of the three names above.
-An unrecognised
+An unknown
 .Fa level
 or
 .Fa facility
-is not an error:
-the level falls back to
-.Cm info
-and the facility to
+is not an error.
+The level becomes
+.Cm info ,
+and the facility becomes
 .Dv LOG_DAEMON .
 .Sh SEE ALSO
 .Xr syslog 3 ,
@@ -176,19 +178,19 @@ and the facility to
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh CAVEATS
-The format string is passed to
+The logging methods pass the format string to
 .Xr sprintf 3
 only when arguments follow it.
-A message that happens to contain a percent sign is therefore safe on its
-own but not once an argument is added,
-so log variable text as
-.Ql %s
-rather than interpolating it into the format.
+Thus a message that has a percent sign is safe alone, but not when an
+argument follows.
+Log variable text with
+.Ql %s .
+Do not interpolate the text into the format string.
 .Pp
-A single process should create one syslog-mode logger.
+A process must create no more than one syslog-mode logger.
 .Xr openlog 3
 and
 .Xr closelog 3
-act on process-wide state,
-so a second logger going out of scope closes the connection the first one
-is still using.
+act on process-wide state.
+Thus, when a second logger goes out of scope, it closes the connection
+that the first logger still uses.

--- a/man/fugulib/Log.3p
+++ b/man/fugulib/Log.3p
@@ -36,8 +36,9 @@ $log->err('cannot open %s: %s', $path, $!);
 .Ed
 .Sh DESCRIPTION
 .Nm
-gives a program one logging interface whether the program runs as a
-daemon or in the foreground.
+gives a program one logging interface.
+The interface is the same when the program runs as a daemon and when
+it runs in the foreground.
 The caller selects the destination one time, when it creates the
 logger.
 Every call site then has the same form for all destinations.

--- a/man/fugulib/Log.3p
+++ b/man/fugulib/Log.3p
@@ -55,7 +55,7 @@ and
 .Ss new
 .Fn new "%args"
 creates a logger.
-The arguments are:
+These are the arguments:
 .Bl -tag -width "facilityXX"
 .It Fa mode
 The destination for messages.

--- a/man/fugulib/MDNS.3p
+++ b/man/fugulib/MDNS.3p
@@ -82,7 +82,7 @@ connects to the control socket.
 The method returns 1 on success.
 It returns
 .Dv undef
-when the socket is missing or unreachable.
+when the socket is absent or unreachable.
 When mdnsd does not run, this is a normal condition.
 The caller decides if this condition is important.
 .Ss publish_service
@@ -123,7 +123,7 @@ on input that is too long.
 This is an error, never a silent truncation.
 The method also returns
 .Dv undef
-on a missing connection, on an error reply (for example a name
+on an absent connection, on an error reply (for example a name
 collision),
 on an end-of-file, or on a timeout.
 .Ss update_txt

--- a/man/fugulib/MDNS.3p
+++ b/man/fugulib/MDNS.3p
@@ -123,7 +123,8 @@ on input that is too long.
 This is an error, never a silent truncation.
 The method also returns
 .Dv undef
-on a missing connection, on an error reply such as a name collision,
+on a missing connection, on an error reply (for example a name
+collision),
 on an end-of-file, or on a timeout.
 .Ss update_txt
 .Fn update_txt "txt => $string" "timeout => $seconds"

--- a/man/fugulib/MDNS.3p
+++ b/man/fugulib/MDNS.3p
@@ -44,23 +44,26 @@ $mdns->withdraw;
 .Sh DESCRIPTION
 .Nm
 publishes services with
-.Xr mdnsd 8
-by speaking its control protocol natively over
+.Xr mdnsd 8 .
+The module uses the mdnsd control protocol directly over
 .Pa /var/run/mdnsd.sock ,
-with no
+and it starts no
 .Xr mdnsctl 8
 child process.
-The connection is the advertisement's lifetime:
-mdnsd withdraws the service when the socket closes, so a daemon keeps
-the object alive for as long as it wants to be discoverable, and
-withdrawing is nothing more than closing.
+The connection is the lifetime of the advertisement.
+mdnsd withdraws the service when the socket closes.
+Thus a daemon keeps the object alive for as long as the daemon must
+be discoverable.
+To withdraw the advertisement, the daemon only closes the socket.
 .Pp
-The wire protocol \(em message types, payload layouts, the group state
-machine and its timing \(em is specified in
+The document
 .Pa spec/MDNS-Control.md
-in the OpenHAP source tree.
-The module never logs;
-every method returns an outcome and records the most recent failure for
+in the OpenHAP source tree specifies the wire protocol.
+This specification has the message types, the payload layouts, the
+group state machine, and its timing.
+The module never logs.
+Every method returns an outcome and records the most recent failure
+for
 .Fn error .
 .Ss new
 .Fn new "socket_path => $path" "timeout => $seconds"
@@ -69,16 +72,19 @@ creates a handle.
 defaults to
 .Pa /var/run/mdnsd.sock .
 .Fa timeout
-bounds how long the publish methods wait for mdnsd's replies and
-defaults to 10 seconds;
-a healthy mdnsd confirms publication after roughly four.
+sets the maximum time that the publish methods wait for the replies
+from mdnsd.
+The default is 10 seconds.
+A healthy mdnsd confirms publication after approximately four seconds.
 .Ss connect
 .Fn connect
 connects to the control socket.
-Returns 1, or
+The method returns 1 on success.
+It returns
 .Dv undef
-when the socket is missing or unreachable \(em mdnsd not running is a
-normal condition, and the caller decides whether it matters.
+when the socket is missing or unreachable.
+When mdnsd does not run, this is a normal condition.
+The caller decides if this condition is important.
 .Ss publish_service
 .Fo publish_service
 .Fa "name => $instance"
@@ -90,51 +96,58 @@ normal condition, and the caller decides whether it matters.
 .Fc
 advertises one service and waits for mdnsd to confirm publication.
 .Fa name
-is the service instance name;
-mdnsd also uses it as the publish group name, so the two cannot
-disagree.
+is the service instance name.
+mdnsd also uses this name as the publish group name.
+Thus the two names cannot be different.
 .Fa app
-is the application protocol without a leading underscore
-.Pq Dq hap , not Dq _hap ;
+is the application protocol with no underscore at the start
+.Pq Dq hap , not Dq _hap .
 .Fa proto
 must be
 .Dq tcp
 or
 .Dq udp .
 .Fa txt
-is the already-formatted TXT string:
-key=value pairs joined with
-.Ql \&. ,
-which is the delimiter
+is the TXT string in its final format:
+key=value pairs with the
+.Ql \&.
+character between them.
 .Xr mdnsd 8
-splits on with no escaping.
-The module does not know or care what the keys mean.
+splits the string on this delimiter, with no escape mechanism.
+The meaning of the keys is not important to the module.
 .Pp
-Returns 1 once the service is published.
-Returns
+The method returns 1 after mdnsd publishes the service.
+The method returns
 .Dv undef
-on over-length input (an error, never a silent truncation), on a
-missing connection, on an error reply such as a name collision, on
-end-of-file, or on timeout.
+on input that is too long.
+This is an error, never a silent truncation.
+The method also returns
+.Dv undef
+on a missing connection, on an error reply such as a name collision,
+on an end-of-file, or on a timeout.
 .Ss update_txt
 .Fn update_txt "txt => $string" "timeout => $seconds"
 replaces the TXT record.
-mdnsd cannot replace records on a held connection, so this withdraws
-the advertisement and republishes over a fresh connection, reusing the
-parameters given to
+mdnsd cannot replace records on a held connection.
+Thus the method withdraws the advertisement and publishes it again
+over a fresh connection.
+The method uses the same parameters that the caller gave to
 .Fn publish_service .
-While unpublished it is a successful no-op.
+When the service is not published, the method does nothing and
+returns success.
 .Ss withdraw
 .Fn withdraw
-closes the control socket, which withdraws the advertisement.
-Always returns 1.
+closes the control socket.
+This closure withdraws the advertisement.
+The method always returns 1.
 .Ss is_published
 .Fn is_published
-returns true while the service is advertised on a held connection.
+returns true while the module advertises the service on a held
+connection.
 .Ss error
 .Fn error
-returns the most recent failure as a short string, for the caller to
-log.
+returns the most recent failure as a short string.
+The caller can log this string.
 .Sh SEE ALSO
 .Xr FuguLib::Imsg 3p ,
 .Xr mdnsd 8

--- a/man/fugulib/MDNS.3p
+++ b/man/fugulib/MDNS.3p
@@ -19,7 +19,7 @@
 .Os
 .Sh NAME
 .Nm FuguLib::MDNS
-.Nd publish mDNS services through mdnsd
+.Nd mDNS service publication through mdnsd
 .Sh SYNOPSIS
 .Bd -literal
 use FuguLib::MDNS;
@@ -123,7 +123,7 @@ on input that is too long.
 This is an error, never a silent truncation.
 The method also returns
 .Dv undef
-on an absent connection, on an error reply (for example a name
+on an absent connection, on an error reply (for example, a name
 collision),
 on an end-of-file, or on a timeout.
 .Ss update_txt

--- a/man/fugulib/Privdrop.3p
+++ b/man/fugulib/Privdrop.3p
@@ -95,7 +95,7 @@ It dies in these conditions:
 .It
 The
 .Fa user
-argument is missing.
+argument is absent.
 .It
 The method cannot resolve the user or the group.
 .It

--- a/man/fugulib/Privdrop.3p
+++ b/man/fugulib/Privdrop.3p
@@ -28,48 +28,51 @@ FuguLib::Privdrop->drop_privileges(user => '_openhap');
 .Ed
 .Sh DESCRIPTION
 .Nm
-implements the privilege drop an
+does the privilege drop that an
 .Ox
-daemon performs once its privileged work is done:
-bind the reserved port,
-fork the helper that needs root,
-then give up root for good and run the event loop as an unprivileged user.
+daemon does when its privileged work is complete.
+The daemon binds the reserved port and forks the helper that must have
+root.
+Then the daemon gives up root permanently and runs the event loop as an
+unprivileged user.
 .Pp
-The module keeps no state and has a single class method.
+The module keeps no state and has one class method.
 .Ss drop_privileges
 .Fn drop_privileges "%args"
-switches the process to the given user and group and verifies that root
-cannot be regained.
+switches the process to the given user and group.
+It then makes sure that the process cannot get root again.
 .Pp
-The arguments are as follows:
+These are the arguments:
 .Bl -tag -width "groupXX"
 .It Fa user
-Name of the user to become.
-Required.
+The name of the user to become.
+This argument is necessary.
 .It Fa group
-Name of the group to become.
-Optional;
-the user's primary group is used if it is omitted.
+The name of the group to become.
+This argument is optional.
+If you omit it, the method uses the user's primary group.
 .El
 .Pp
-The method returns immediately if the effective user ID is not 0,
-so a program that is already unprivileged may call it unconditionally.
-Otherwise it resolves the user and group,
-calls
+If the effective user ID is not 0,
+the method returns immediately.
+Thus a program that is already unprivileged can call it in all cases.
+In the other case, the method resolves the user and the group.
+It calls
 .Xr setgid 2
 before
-.Xr setuid 2 ,
-assigns the real and effective IDs,
-and then confirms both that neither ID is 0 any more and that calling
+.Xr setuid 2
+and sets the real and effective IDs.
+Then it makes sure that the two IDs are not 0.
+It also makes sure that a call to
 .Xr setuid 2
 with 0 does not bring root back.
 .Sh RETURN VALUES
 .Fn drop_privileges
-returns 1 on success,
-including the case where the process was already unprivileged.
-It never returns on failure.
+returns 1 on success.
+A call from a process that is already unprivileged is a success.
+The method never returns on failure.
 .Sh EXAMPLES
-Bind a reserved port as root, then run as
+This example binds a reserved port as root and then runs as
 .Ar _myapp :
 .Bd -literal -offset indent
 my $socket = IO::Socket::INET->new(
@@ -86,20 +89,26 @@ while (my $client = $socket->accept) {
 .Ed
 .Sh ERRORS
 .Fn drop_privileges
-dies,
-rather than returning a failure indication,
-when
+does not return a failure code.
+It dies in these conditions:
+.Bl -bullet -offset indent
+.It
+The
 .Fa user
-is missing,
-when the user or group cannot be resolved,
-when
+argument is missing.
+.It
+The method cannot resolve the user or the group.
+.It
 .Xr setgid 2
 or
 .Xr setuid 2
-fails,
-or when the process still holds root afterwards.
-A privilege drop that half succeeded is not something a caller can be
-allowed to continue past.
+fails.
+.It
+The process holds root after the calls.
+.El
+.Pp
+The caller must not continue after a privilege drop that is not
+complete.
 .Sh SEE ALSO
 .Xr setgid 2 ,
 .Xr setuid 2 ,
@@ -108,14 +117,14 @@ allowed to continue past.
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh CAVEATS
-Supplementary groups are not changed.
-A process that was started as root keeps whatever supplementary groups
-it inherited,
-which on
-.Ox
-is how a daemon retains access to the
+The method does not change the supplementary groups.
+A process that starts as root keeps the supplementary groups that it
+inherits.
+On
+.Ox ,
+this is how a daemon keeps access to the
 .Xr mdnsd 8
-socket after dropping to its own user.
-Callers that need the groups cleared must call
+socket after it drops to its own user.
+To remove the groups, call
 .Xr setgroups 2
-themselves before dropping.
+before the privilege drop.

--- a/man/fugulib/Privdrop.3p
+++ b/man/fugulib/Privdrop.3p
@@ -19,7 +19,7 @@
 .Os
 .Sh NAME
 .Nm FuguLib::Privdrop
-.Nd drop root privileges permanently
+.Nd permanent drop of root privileges
 .Sh SYNOPSIS
 .Bd -literal
 use FuguLib::Privdrop;

--- a/man/fugulib/Process.3p
+++ b/man/fugulib/Process.3p
@@ -19,7 +19,7 @@
 .Os
 .Sh NAME
 .Nm FuguLib::Process
-.Nd spawn, supervise and reap child processes
+.Nd spawn, monitor and reap child processes
 .Sh SYNOPSIS
 .Bd -literal
 use FuguLib::Process;
@@ -35,65 +35,70 @@ FuguLib::Process->terminate($result->{pid}) if $result->{success};
 .Ed
 .Sh DESCRIPTION
 .Nm
-covers the parts of running a child process that are easy to get wrong:
-telling a child that started from one that exited immediately,
-escalating from
+does the parts of child-process control that are easy to get wrong.
+It shows the difference between a child that runs and a child that
+exits immediately.
+It sends
 .Dv SIGTERM
-to
+first and sends
 .Dv SIGKILL
-on a schedule,
-and reaping zombies without blocking.
+after a delay.
+It reaps zombies and does not block.
 .Pp
-The module keeps no state;
-every method is a class method.
+The module keeps no state.
+Every method is a class method.
 .Ss spawn_command
 .Fn spawn_command "%args"
 forks,
 redirects the standard descriptors,
-and executes a command.
+and runs a command.
 .Pp
-The arguments are as follows:
+These are the arguments:
 .Bl -tag -width "check_aliveXX"
 .It Fa cmd
-Array reference holding the command and its arguments.
-Required, and must not be empty.
+An array reference that holds the command and its arguments.
+This argument is necessary and must not be empty.
 .It Fa daemonize
-If true, the child calls
+If this argument is true, the child calls
 .Xr setsid 2
 before exec.
 The default is false.
 .It Fa stdin , Fa stdout , Fa stderr
-Paths for the child's standard descriptors.
-Each defaults to
+The paths for the child's standard descriptors.
+The default for each path is
 .Pa /dev/null .
 .It Fa check_alive
-Seconds to wait before confirming the child survived.
-The default is 1;
-0 skips the check and returns as soon as the fork succeeds.
+The number of seconds to wait before the check that the child continues
+to run.
+The default is 1.
+If the value is 0, the method does not do the check and returns when
+the fork succeeds.
 .It Fa on_success
-Code reference called with the child's process ID once the spawn is
-judged successful.
+A code reference that the method calls with the child's process ID when
+the spawn is successful.
 .It Fa on_error
-Code reference called with a message when the spawn fails.
+A code reference that the method calls with a message when the spawn
+fails.
 .El
 .Pp
 When
 .Fa check_alive
-is non-zero the parent sleeps for that many seconds and then makes two
-tests: a non-blocking
-.Xr waitpid 2 ,
-which reaps the child and proves it exited,
-and
+is not zero,
+the parent sleeps for that number of seconds and then does two tests.
+A
+.Xr waitpid 2
+call that does not block reaps the child and shows that it exited.
+A
 .Xr kill 2
-with signal 0,
-which proves it is still there.
-This is what catches an exec that failed for a reason the fork could not
-report, such as a command that does not exist.
+call with signal 0 shows that the child is still there.
+These tests catch an exec that fails for a reason that the fork cannot
+report,
+for example a command that does not exist.
 .Ss is_alive
 .Fn is_alive "$pid"
-reports whether a process exists and is not a zombie.
-A zombie child is reaped as a side effect of the check and then reported
-as not alive.
+reports if a process exists and is not a zombie.
+The check reaps a zombie child as a side effect and then reports it as
+not alive.
 .Ss terminate
 .Fn terminate "$pid" "%args"
 sends
@@ -101,85 +106,87 @@ sends
 waits,
 and sends
 .Dv SIGKILL
-if that was not enough.
+if the process continues to run.
 .Pp
-The arguments are as follows:
+These are the arguments:
 .Bl -tag -width "grace_periodXX"
 .It Fa grace_period
-Seconds to wait between the two signals.
+The number of seconds to wait between the two signals.
 The default is 5.
 .It Fa on_kill
-Code reference called once the process is gone.
+A code reference that the method calls when the process is gone.
 .El
 .Ss reap
 .Fn reap "$pid"
-reaps one zombie child without blocking.
+reaps one zombie child and does not block.
 .Ss reap_all
 .Fn reap_all
-reaps every zombie child that is ready,
-without blocking,
-and returns how many there were.
+reaps each zombie child that is ready and does not block.
+It returns the number of children that it reaped.
 .Ss wait_exit
 .Fn wait_exit "$pid" "$timeout"
-polls until the process exits or the timeout expires.
+polls until the process exits or until the timeout ends.
+The default for
 .Fa $timeout
-defaults to 30 seconds.
+is 30 seconds.
 .Ss spawn_perl
 .Fn spawn_perl "%args"
-runs Perl code in a child process,
-passing through the
+runs Perl code in a child process.
+It gives the child the parent's
 .Ic -I
-paths the parent picked up from
+paths.
+The parent gets these paths from
 .Ic -I ,
 .Ic use lib
 or
-.Ev PERL5LIB ,
-so the child sees the same modules.
+.Ev PERL5LIB .
+Thus the child sees the same modules.
 .Pp
 .Fa code
-is the program text and
+is the program text.
 .Fa args
-an array reference of arguments for it;
-every other argument is handed to
+is an array reference of arguments for the program.
+The method gives all other arguments to
 .Fn spawn_command .
 .Sh RETURN VALUES
 .Fn spawn_command
 and
 .Fn spawn_perl
 return a hash reference.
-On success it holds
+On success, the hash holds
 .Fa success
 set to 1 and
 .Fa pid .
-On failure
+On failure,
 .Fa success
 is 0 and
 .Fa error
-describes what went wrong;
+gives the cause.
+When the spawn makes a child and the child dies,
+the hash also holds
 .Fa pid
 and
-.Fa exit_code
-are also present when the child was reached and died.
+.Fa exit_code .
 .Pp
 .Fn is_alive
 returns 1 or 0.
 .Pp
 .Fn terminate
-returns 1 if the process is gone,
-0 if it survived
+returns 1 if the process is gone.
+It returns 0 if the process continues after
 .Dv SIGKILL .
 .Pp
 .Fn reap
-returns 1 if the child was reaped or was never there,
-0 if it is still running.
+returns 1 when it reaps the child or when the child does not exist.
+It returns 0 when the child continues to run.
 .Fn reap_all
 returns a count.
 .Pp
 .Fn wait_exit
-returns 1 if the process exited within the timeout,
-0 otherwise.
+returns 1 if the process exits in the timeout period.
+If not, it returns 0.
 .Sh EXAMPLES
-Run a helper and stop it again:
+This example runs a helper and then stops it:
 .Bd -literal -offset indent
 my $r = FuguLib::Process->spawn_command(
     cmd      => [ 'mdnsctl', 'publish', $name, '_hap', 'tcp', $port ],
@@ -191,11 +198,11 @@ FuguLib::Process->terminate($r->{pid}, grace_period => 10)
 .Ed
 .Sh ERRORS
 No method dies.
-Failures are reported through the returned hash reference or the boolean
-return value,
-and through
+The methods report failures through the hash reference or the boolean
+value that they return.
+When you give an
 .Fa on_error
-when one was supplied.
+callback, the methods also report the failure through it.
 .Sh SEE ALSO
 .Xr kill 2 ,
 .Xr setsid 2 ,
@@ -210,32 +217,34 @@ blocks the caller for
 .Fa check_alive
 seconds.
 The check is a plain
-.Xr sleep 3 ,
-so a program that spawns several children pays for each one in turn.
+.Xr sleep 3 .
+Thus a program that spawns several children waits the full time for
+each child in sequence.
 .Pp
-A child that legitimately finishes inside the
+The method reports a child that correctly stops in the
 .Fa check_alive
-window is reported as a failure,
-with an
+window as a failure.
+The
 .Fa error
-saying it completed immediately and an
+says that the child stopped immediately, and the
 .Fa exit_code
-of 0.
-Use
+is 0.
+Set
 .Fa check_alive
-set to 0 for commands that are expected to be short.
+to 0 for commands that stop quickly.
 .Pp
 .Fn is_alive
 and
 .Fn reap
 call
 .Xr waitpid 2 ,
-which only ever reaps children of the calling process.
-For any other process they fall back to
+which reaps only the children of the caller.
+For all other processes, they use
 .Xr kill 2
-with signal 0,
-which cannot distinguish a live process from a zombie.
+with signal 0.
+This signal cannot show the difference between a live process and a
+zombie.
 .Pp
-Process IDs are recycled.
-Nothing here can tell the process that was asked about from a later one
-that inherited its number.
+The operating system uses process IDs again for new processes.
+The module cannot show the difference between the initial process and a
+later process with the same number.

--- a/man/fugulib/Process.3p
+++ b/man/fugulib/Process.3p
@@ -237,8 +237,8 @@ to 0 for commands that stop quickly.
 and
 .Fn reap
 call
-.Xr waitpid 2 ,
-which reaps only the children of the caller.
+.Xr waitpid 2 .
+That call reaps only the children of the caller.
 For all other processes, they use
 .Xr kill 2
 with signal 0.

--- a/man/fugulib/Process.3p
+++ b/man/fugulib/Process.3p
@@ -19,7 +19,7 @@
 .Os
 .Sh NAME
 .Nm FuguLib::Process
-.Nd spawn, monitor and reap child processes
+.Nd child process management
 .Sh SYNOPSIS
 .Bd -literal
 use FuguLib::Process;
@@ -93,7 +93,7 @@ A
 call with signal 0 shows that the child is still there.
 These tests catch an exec that fails for a reason that the fork cannot
 report,
-for example a command that does not exist.
+for example, a command that does not exist.
 .Ss is_alive
 .Fn is_alive "$pid"
 reports if a process exists and is not a zombie.

--- a/man/fugulib/Sandbox.3p
+++ b/man/fugulib/Sandbox.3p
@@ -102,14 +102,14 @@ Each entry can have
 .Li { optional => 1 }
 as a third element.
 If a
-.Em required
-path is missing,
+.Em necessary
+path is absent,
 the method dies and gives the path.
 If the method accepts a path with a typo and gives no report,
 unveil becomes useless.
 If an
 .Em optional
-path is missing,
+path is absent,
 the method skips it and reports it through the
 .Fa on_skip
 callback.

--- a/man/fugulib/Sandbox.3p
+++ b/man/fugulib/Sandbox.3p
@@ -40,85 +40,91 @@ wraps
 .Xr pledge 2
 and
 .Xr unveil 2
-so that callers never test the operating system themselves:
-on
-.Ox
-the restrictions are real,
-everywhere else every method is a no-op returning success,
-and
+so that callers do not test the operating system themselves.
+On
+.Ox ,
+the restrictions are real.
+On all other platforms, each method is a no-op that returns success.
 .Fn is_supported
-tells a caller or a test which of the two it got.
+tells a caller or a test which of the two it gets.
 .Pp
-All methods are class methods;
-there is no object,
-because the two syscalls being wrapped are process-global.
-Failures die with the offending promise string or path and the errno;
-there is no force flag and no warn-and-continue mode.
-The module never logs;
-callers decide what to report.
+All methods are class methods.
+There is no object because the two syscalls that the module wraps are
+process-global.
+A method that fails dies with the promise string or the path that
+caused the failure, and with the errno.
+There is no force flag and no warn-and-continue mode.
+The module never logs.
+The caller decides what to report.
 .Pp
 On
-.Ox
-the base-system
+.Ox ,
+.Nm
+loads the base-system modules
 .Xr OpenBSD::Pledge 3p
 and
 .Xr OpenBSD::Unveil 3p
-modules are loaded when
-.Nm
-is,
-and failing to load them is immediately fatal:
-there, their absence means a broken perl,
+when it loads.
+If these modules do not load, the process dies immediately.
+On that platform, the absence of these modules shows a broken perl and
 not an unsupported system.
 .Ss is_supported
 .Fn is_supported
-returns true only where the restrictions are enforced,
+returns true only where the restrictions are real,
 that is,
 on
 .Ox .
 .Ss pledge
 .Fn pledge "promises => $string"
-restricts the process to the space-separated promise set,
+limits the process to the space-separated set of promises,
 as
 .Xr pledge 2
 defines it.
-Returns 1, dies on failure naming the promises and the error.
-The first call defines the sandbox;
-later calls may only shrink it.
+The method returns 1.
+On failure, it dies and gives the promises and the error.
+The first call defines the sandbox.
+Later calls can only make it smaller.
 .Ss unveil
 .Fo unveil
 .Fa "paths => arrayref of pairs"
 .Fa "on_skip => sub"
 .Fc
-restricts the filesystem view to the listed paths with the listed
+limits the filesystem view to the listed paths with the listed
 .Xr unveil 2
 permission strings.
-The argument is an ordered list of pairs, not a hash:
+The argument is an ordered list of pairs, not a hash.
 .Xr unveil 2
-replaces rather than merges a path's permissions,
-so parent-then-child ordering is load-bearing,
-and hash key order would randomise it.
+replaces the permissions of a path and does not merge them.
+Thus the order of parent before child is necessary,
+and the key order of a hash makes that order random.
 .Pp
-Each entry may carry
+Each entry can have
 .Li { optional => 1 }
 as a third element.
-A missing
+If a
 .Em required
-path dies naming the path \(em a typo'd path silently accepted is the
-failure mode that makes unveil useless \(em while a missing
+path is missing,
+the method dies and gives the path.
+If the method accepts a path with a typo and gives no report,
+unveil becomes useless.
+If an
 .Em optional
-path is skipped and reported through the
+path is missing,
+the method skips it and reports it through the
 .Fa on_skip
-callback,
-for paths that are legitimately absent on a working system
-(a configuration file, a socket whose daemon is not running).
-Returns 1.
+callback.
+The optional flag is for paths that can be absent on a system that
+operates correctly.
+Examples are a configuration file and the socket of a daemon that does
+not run.
+The method returns 1.
 .Ss unveil_lock
 .Fn unveil_lock
-forbids further
+prevents more
 .Fn unveil
-calls,
-fixing the view for the life of the process.
-Returns 1, dies on failure.
+calls and locks the view for the life of the process.
+The method returns 1.
+It dies on failure.
 .Sh SEE ALSO
 .Xr pledge 2 ,
 .Xr unveil 2 ,

--- a/man/fugulib/Signal.3p
+++ b/man/fugulib/Signal.3p
@@ -36,53 +36,58 @@ until (FuguLib::Signal::check_interrupted()) {
 .Ed
 .Sh DESCRIPTION
 .Nm
-installs signal handlers so that a program can be interrupted without
-leaving temporary files, child processes or half-written state behind.
+installs signal handlers so that a signal can interrupt a program
+safely.
+The program does not leave temporary files, child processes or
+half-written state behind.
 .Pp
 There are two shapes.
 .Fn setup_graceful_exit
-runs the cleanup handlers and exits from inside the signal handler,
-which suits a program whose work can be abandoned at any point.
+runs the cleanup handlers and exits from inside the signal handler.
+This shape is correct for a program that can stop its work at all
+times.
 .Fn setup_interrupt_flag
-only raises a flag,
-leaving the program to notice it and stop where stopping is safe.
+only sets a flag.
+The program must do a check of the flag and stop where a stop is safe.
 .Pp
-Either way the previous handlers are remembered and put back by
-.Fn restore ,
-which the destructor calls,
-so a scoped object leaves the process as it found it.
+In each shape, the object keeps the previous handlers.
+.Fn restore
+puts them back,
+and the destructor calls
+.Fn restore .
+Thus a scoped object leaves the process in its initial state.
 .Ss new
 .Fn new
 creates a signal handler manager.
-It installs nothing on its own.
+It does not install handlers.
 .Ss setup_graceful_exit
 .Fn setup_graceful_exit "@signals"
-installs a handler for each named signal that sets the interrupt flag,
+installs a handler for each named signal.
+The handler sets the interrupt flag,
 runs the cleanup handlers,
 and exits with status 130.
 .Ss setup_interrupt_flag
 .Fn setup_interrupt_flag "@signals"
-installs a handler for each named signal that sets the interrupt flag and
-returns.
-Nothing else happens until the program looks at the flag.
+installs a handler for each named signal.
+The handler sets the interrupt flag and returns.
+No other action occurs until the program reads the flag.
 .Ss add_cleanup
 .Fn add_cleanup "$handler"
-adds a code reference to be called,
+adds a code reference that runs,
 with the signal name as its argument,
 before
 .Fn setup_graceful_exit
 exits.
-Handlers run in the order they were added,
-each inside an
-.Ic eval ,
-so one that dies does not stop the rest.
+The handlers run in the sequence in which you add them.
+Each handler runs inside an
+.Ic eval .
+Thus a handler that dies does not stop the others.
 .Ss restore
 .Fn restore
-puts back the handlers that were in place before this object installed
-its own.
+puts back the handlers that this object replaced.
 .Ss check_interrupted
 .Fn check_interrupted
-reports whether a handled signal has arrived.
+reports if a handled signal came.
 It is a plain function, not a method.
 .Ss reset_interrupted
 .Fn reset_interrupted
@@ -96,13 +101,13 @@ returns a signal handler manager.
 .Fn add_cleanup
 and
 .Fn restore
-return the object,
-so they chain.
+return the object.
+Thus the calls can chain.
 .Pp
 .Fn check_interrupted
-returns true if a handled signal has arrived.
+returns true if a handled signal came.
 .Sh EXAMPLES
-Stop between items rather than in the middle of one:
+This example stops between items and not in the middle of one:
 .Bd -literal -offset indent
 my $sig = FuguLib::Signal->new;
 $sig->setup_interrupt_flag('INT', 'TERM');
@@ -114,7 +119,7 @@ for my $item (@items) {
 .Ed
 .Sh ERRORS
 No method dies.
-A cleanup handler that dies is caught and ignored.
+If a cleanup handler dies, the module catches the error and ignores it.
 .Sh SEE ALSO
 .Xr perlipc 1 ,
 .Xr kill 2 ,
@@ -123,19 +128,20 @@ A cleanup handler that dies is caught and ignored.
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh CAVEATS
-The interrupt flag and the list of cleanup handlers are package globals,
+The interrupt flag and the list of cleanup handlers are package
+globals,
 not per-object.
-Two managers in one process share both:
-a cleanup handler added through one runs for a signal caught by the other,
-and
+Two managers in one process share the flag and the list.
+A cleanup handler that you add through one manager runs for a signal
+that the other manager catches.
 .Fn reset_interrupted
-clears the flag for both.
+clears the flag for each manager.
 .Pp
-The cleanup list is emptied once it has run,
-so a second signal after a graceful exit has begun finds nothing left to
-clean up.
+The module empties the cleanup list after the list runs.
+Thus a second signal that comes after the start of a graceful exit
+finds no handlers.
 .Pp
-Handlers are ordinary Perl signal handlers and run between opcodes,
+The handlers are standard Perl signal handlers and run between opcodes,
 not immediately.
-A program blocked in a system call notices the signal when the call
+A program that a system call blocks sees the signal when the call
 returns.

--- a/man/fugulib/State.3p
+++ b/man/fugulib/State.3p
@@ -19,7 +19,7 @@
 .Os
 .Sh NAME
 .Nm FuguLib::State
-.Nd PID file handling
+.Nd PID file management
 .Sh SYNOPSIS
 .Bd -literal
 use FuguLib::State;
@@ -34,9 +34,9 @@ $state->write_pid;
 .Ed
 .Sh DESCRIPTION
 .Nm
-reads and writes a PID file and answers whether the process it names is
-still there.
-It exists so that a daemon,
+reads and writes a PID file.
+It also tells if the process that the file names is still there.
+The module exists so that a daemon,
 its
 .Xr rc.d 8
 script,
@@ -46,37 +46,39 @@ and a control utility can all agree on the same question.
 creates a state object for the named file.
 The argument is positional,
 not a keyword pair.
-The file is neither created nor read at this point.
+The method does not create and does not read the file at this point.
 .Ss write_pid
 .Fn write_pid "$pid"
 writes
-.Fa $pid ,
-followed by a newline,
-to the PID file,
-truncating whatever was there.
 .Fa $pid
-defaults to the calling process.
-The file is locked with
+and a newline to the PID file.
+It truncates the previous contents.
+The default for
+.Fa $pid
+is the process ID of the caller.
+The method locks the file with
 .Xr flock 2
 between the open and the write.
 .Ss read_pid
 .Fn read_pid
-returns the process ID recorded in the file.
-The first line must be a run of decimal digits;
-anything else, including a missing file, reads as no PID at all.
+returns the process ID that the file holds.
+The first line must be a sequence of decimal digits.
+If the contents are different, or if the file is missing, the method
+returns no PID.
 .Ss remove
 .Fn remove
-deletes the PID file.
+removes the PID file.
 .Ss is_running
 .Fn is_running
-returns the recorded process ID if that process is alive,
-as judged by
-.Xr FuguLib::Process 3p .
+returns the process ID from the file if that process is alive.
+The method uses
+.Xr FuguLib::Process 3p
+for the liveness check.
 .Ss is_stale
 .Fn is_stale
-reports whether the PID file names a process that is no longer alive:
-the condition under which a daemon may take the file over rather than
-refusing to start.
+reports if the PID file names a process that is not alive now.
+In this condition, a daemon can take the file and does not refuse to
+start.
 .Sh RETURN VALUES
 .Fn new
 returns a state object,
@@ -88,7 +90,8 @@ is
 .Dv undef .
 .Pp
 .Fn write_pid
-returns 1 on success and 0 if the file could not be opened or locked.
+returns 1 on success.
+It returns 0 if it cannot open or lock the file.
 .Pp
 .Fn read_pid
 and
@@ -96,18 +99,19 @@ and
 return a process ID,
 or
 .Dv undef
-when there is none to report.
+when there is no process ID to report.
 .Pp
 .Fn remove
-returns 1 if the file was already absent,
-otherwise the result of
+returns 1 if the file is already absent.
+If not, it returns the result of
 .Xr unlink 2 .
 .Pp
 .Fn is_stale
-returns 0 when the file holds no readable PID,
-so a missing PID file is not stale.
+returns 0 when the file holds no readable PID.
+Thus a missing PID file is not stale.
 .Sh EXAMPLES
-Refuse to start twice, and clean up after a crash:
+This example prevents a second start and removes the file after a
+crash:
 .Bd -literal -offset indent
 my $state = FuguLib::State->new('/var/run/mydaemon.pid');
 
@@ -122,8 +126,9 @@ FuguLib::Daemon->daemonize(
 .Ed
 .Sh ERRORS
 No method dies.
-Failures to open, lock or unlink the file are reported through the return
-value, and the reason is left in
+The methods report a failure to open, lock or unlink the file through
+the return value.
+The reason stays in
 .Va $! .
 .Sh SEE ALSO
 .Xr flock 2 ,
@@ -133,25 +138,22 @@ value, and the reason is left in
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh CAVEATS
-The lock taken by
 .Fn write_pid
-is released when the file is closed,
-at the end of that call.
-It serialises two concurrent writes;
-it does not hold the PID file for the lifetime of the daemon,
-and
+releases its lock when it closes the file,
+at the end of the call.
+The lock puts two concurrent writes in sequence.
+It does not hold the PID file for the life of the daemon.
 .Fn read_pid
-does not take a lock at all.
+does not take a lock.
 .Pp
-Checking
+A check with
 .Fn is_running
-and then acting on the answer is inherently racy:
-the process may exit,
-or another may claim the file,
-in between.
+and then an action on the answer is a race condition.
+In between, the process can exit,
+or a different process can claim the file.
 .Pp
 .Fn is_running
-inherits the limits of
-.Xr FuguLib::Process 3p Ns 's
-liveness check,
-which cannot tell a recycled process ID from the original.
+has the same limits as the liveness check of
+.Xr FuguLib::Process 3p .
+That check cannot show the difference between the initial process and a
+later process with the same ID.

--- a/man/fugulib/State.3p
+++ b/man/fugulib/State.3p
@@ -35,7 +35,7 @@ $state->write_pid;
 .Sh DESCRIPTION
 .Nm
 reads and writes a PID file.
-It also tells if the process that the file names is still there.
+It also reports if the process that the file names still runs.
 The module exists so that a daemon,
 its
 .Xr rc.d 8

--- a/man/fugulib/State.3p
+++ b/man/fugulib/State.3p
@@ -63,7 +63,7 @@ between the open and the write.
 .Fn read_pid
 returns the process ID that the file holds.
 The first line must be a sequence of decimal digits.
-If the contents are different, or if the file is missing, the method
+If the contents are different, or if the file is absent, the method
 returns no PID.
 .Ss remove
 .Fn remove
@@ -108,7 +108,7 @@ If not, it returns the result of
 .Pp
 .Fn is_stale
 returns 0 when the file holds no readable PID.
-Thus a missing PID file is not stale.
+Thus an absent PID file is not stale.
 .Sh EXAMPLES
 This example prevents a second start and removes the file after a
 crash:

--- a/man/fuguvm/fuguvm.1
+++ b/man/fuguvm/fuguvm.1
@@ -108,7 +108,7 @@ KVM on aarch64 Linux hosts with
 .Pa /dev/kvm ,
 and TCG on all other hosts.
 .It Fl h , Fl Fl help
-Show usage information.
+Show the usage message.
 .El
 .Pp
 These commands are available:
@@ -213,11 +213,11 @@ the installed-image cache that
 describes,
 and the downloads that the built-in proxy keeps for the installer.
 .Cm list
-prints one line for each cached image
+shows one line for each cached image
 .Pq key, size, creation time, snapshot count .
 It puts a mark on the entry that the invoked VM's configuration
 derives at this time.
-Then it prints the proxy's downloads by
+Then it shows the proxy's downloads by
 .Ox
 version.
 .Cm clear
@@ -327,7 +327,7 @@ Stop the VM before you run
 .Cm info
 shows the image details.
 .It Cm help
-Show usage information.
+Show the usage message.
 .El
 .Sh IMAGE CACHE
 An installation of
@@ -348,7 +348,7 @@ are a cheap factory reset.
 .Pp
 Entries are under
 .Ar cache_dir ,
-beside the proxy cache that holds the miniroot and the install sets:
+adjacent to the proxy cache that holds the miniroot and the install sets:
 .Bd -literal -offset indent
 <cache_dir>/proxy/...                            miniroot, install sets
 <cache_dir>/installed/<key>/base.qcow2           mode 0400, compacted
@@ -392,7 +392,7 @@ Entries are immutable and write-once.
 .Nm
 builds each entry whole in a temporary directory,
 and then publishes the entry with a rename of that directory.
-Thus a reader never sees the base image of one installation beside the
+Thus a reader never sees the base image of one installation adjacent to the
 metadata of a different installation.
 .Pp
 A snapshot is an immutable, named layer over the base image of an
@@ -514,7 +514,7 @@ $ fuguvm --vm minimal up
 .Sh HISTORY
 The
 .Nm
-utility first appeared in 2025.
+utility was first available in 2025.
 Its initial purpose was to run the
 .Xr openhapd 8
 test suite against a real
@@ -534,7 +534,7 @@ also stores the password in the
 of that entry
 .Pq mode 0600 .
 The cache makes the life of this secret longer:
-the password survives
+the password stays after
 .Cm destroy ,
 and it changes only when the base key changes.
 .Pp

--- a/man/fuguvm/fuguvm.1
+++ b/man/fuguvm/fuguvm.1
@@ -216,7 +216,7 @@ and the downloads that the built-in proxy keeps for the installer.
 prints one line for each cached image
 .Pq key, size, creation time, snapshot count .
 It puts a mark on the entry that the invoked VM's configuration
-currently derives.
+derives at this time.
 Then it prints the proxy's downloads by
 .Ox
 version.
@@ -281,7 +281,7 @@ See
 .Pp
 .Cm save
 flattens the working disk into the cache,
-under the base image on which the disk is built.
+under the base image that the disk uses.
 .Cm restore
 replaces the working disk with a new overlay on
 .Ar name ,
@@ -465,9 +465,9 @@ project.
 .It 4
 VM not found.
 .It 5
-VM is running.
+The VM runs.
 .It 6
-VM is not running.
+The VM does not run.
 .It 7
 Timeout in the wait for the VM.
 .It 8

--- a/man/fuguvm/fuguvm.1
+++ b/man/fuguvm/fuguvm.1
@@ -79,8 +79,8 @@ If you do not give
 .Nm
 searches up from the current directory for an
 .Pa .fuguvmrc
-file,
-and the directory that holds this file is the project root.
+file.
+The directory that holds this file is the project root.
 .Pp
 The options are:
 .Bl -tag -width Ds
@@ -256,8 +256,8 @@ Each VM has its own
 and
 .Ar disk_size
 key inputs.
-Thus a removal for one VM removes bases that a different VM can use,
-and the downloads for the
+Thus a removal for one VM removes bases that a different VM can use.
+It also removes the downloads for the
 .Ox
 version that a different VM installs.
 .Pp
@@ -297,7 +297,7 @@ needs no disk and no state,
 and it can run on a fresh checkout before the first
 .Cm up .
 .Pp
-A snapshot that is missing or unresolvable causes an exit with code 11,
+A snapshot that is absent or unresolvable causes an exit with code 11,
 not 1.
 Thus a script can see the difference between this and a real failure:
 .Bd -literal -offset indent
@@ -317,11 +317,15 @@ Without the flag,
 the output goes to standard error,
 the same as all other informational output.
 .It Cm disk Cm check | repair | info
-Manage the VM disk image:
-do a check of its integrity,
-repair errors
-(stop the VM first),
-or show the image details.
+Manage the VM disk image.
+.Cm check
+does a check of its integrity.
+.Cm repair
+repairs errors.
+Stop the VM before you run
+.Cm repair .
+.Cm info
+shows the image details.
 .It Cm help
 Show usage information.
 .El
@@ -334,7 +338,7 @@ Thus
 keeps the result:
 a clean, compacted copy of the disk.
 .Nm
-makes the copy immediately after the installer completes.
+makes the copy immediately after the installation is complete.
 Later runs use the copy as the backing image of a throwaway overlay.
 With a warm cache,
 .Cm destroy
@@ -406,8 +410,8 @@ base.qcow2  <-  <name>.qcow2  <-  disk.qcow2
 .Pp
 Thus no snapshot is the parent of a different snapshot,
 and the removal of one snapshot cannot orphan a different snapshot.
-Because the snapshots are inside the entry,
-each operation that makes a base invalid
+The snapshots are inside the entry.
+Thus each operation that makes a base invalid
 .Pq a new key, or Cm cache clear
 also makes the snapshots of that base invalid.
 .Sh FILES

--- a/man/fuguvm/fuguvm.1
+++ b/man/fuguvm/fuguvm.1
@@ -35,118 +35,132 @@ installs and manages
 virtual machines under QEMU.
 It downloads the installation image,
 creates the disk image,
-answers the installer over the serial console,
-and from then on controls the machine's lifecycle,
+and answers the installer over the serial console.
+It then controls the machine's lifecycle,
 guest access,
 and console automation.
-Getting from nothing to a machine that accepts
-.Xr ssh 1
-is one command,
-and running it again does nothing.
+You need only one command to go from nothing to a machine that accepts
+.Xr ssh 1 .
+A second run of the command does nothing.
 .Pp
 The host does not have to run
 .Ox .
-Anything that runs QEMU will do,
-and the accelerator is chosen to suit it,
-so a Linux or Darwin workstation can build,
+A host that runs QEMU is sufficient,
+and
+.Nm
+selects the accelerator to match the host.
+Thus a Linux or Darwin workstation can build,
 test,
 or reproduce a bug on a real
 .Ox
-system without one on the desk.
+system without an
+.Ox
+machine on the desk.
 .Pp
-Within the OpenHAP source tree,
+In the OpenHAP source tree,
 .Nm
 is a development tool:
-it is not installed by
 .Ql make install
-and is not part of any release package.
+does not install it,
+and it is not part of a release package.
 .Pp
 .Nm
 operates on a project:
-a directory containing an
+a directory that has an
 .Pa .fuguvmrc
 configuration file and an
 .Pa .fuguvm/
-state directory,
-created by the
+state directory.
+The
 .Cm init
-command.
-Unless
-.Fl Fl project
-is given,
-the project root is auto-discovered by searching upward from the
-current directory for an
+command creates them.
+If you do not give
+.Fl Fl project ,
+.Nm
+searches up from the current directory for an
 .Pa .fuguvmrc
-file.
+file,
+and the directory that holds this file is the project root.
 .Pp
-The options are as follows:
+The options are:
 .Bl -tag -width Ds
 .It Fl Fl vm Ar name
 Operate on the named VM.
 The default is
 .Dq default .
-VM definitions live in
+VM definitions are in
 .Pa .fuguvm/vms/ Ns Ar name Ns Pa .conf .
 .It Fl Fl project Ar dir
 Use
 .Ar dir
-as the project root instead of auto-discovering it.
+as the project root,
+and do not search for it.
 .It Fl q , Fl Fl quiet
-Suppress informational output.
+Do not show informational output.
 .It Fl Fl emulate
-Force TCG software emulation instead of hardware acceleration.
-Without this flag the accelerator is chosen automatically:
-HVF on macOS, KVM on aarch64 Linux hosts with
+Use TCG software emulation,
+not hardware acceleration.
+Without this flag,
+.Nm
+selects the accelerator automatically:
+HVF on macOS,
+KVM on aarch64 Linux hosts with
 .Pa /dev/kvm ,
-and TCG everywhere else.
+and TCG on all other hosts.
 .It Fl h , Fl Fl help
-Display usage information.
+Show usage information.
 .El
 .Pp
-The following commands are available:
+These commands are available:
 .Bl -tag -width "expect script"
 .It Cm init Op Ar dir
 Initialize a project in
 .Ar dir
 (default: the current directory).
-Creates the
+The command creates the
 .Pa .fuguvmrc
 project configuration,
 the
 .Pa .fuguvm/
-directory with
+directory with the
 .Pa vms/
 and
 .Pa state/
 subdirectories,
 and a default VM configuration.
-Idempotent:
-does nothing if the project is already initialized.
+The command is idempotent:
+it does nothing if the project is already initialized.
 .It Cm up Op Fl Fl no-cache
-Ensure the VM is running.
-Downloads the installation image,
+Make sure that the VM runs.
+The command downloads the installation image,
 creates the disk image,
-and starts the VM as needed.
-Idempotent.
+and starts the VM,
+as necessary.
+The command is idempotent.
 .Pp
-Unless the installed-image cache is disabled,
+If the installed-image cache is on,
 .Cm up
-takes both sides of that cache:
-with no disk image present it creates one as an overlay on a matching
-cached base and boots the installed system directly,
-skipping the miniroot download and the installer entirely;
-after an installation it publishes the freshly installed disk as a new
-cached base.
-Caching is best effort:
-a failure warns and the VM comes up anyway,
-installing from scratch or keeping a standalone disk.
+uses both sides of that cache.
+If there is no disk image,
+.Cm up
+creates one as an overlay on a cached base that matches,
+and boots the installed system directly.
+This skips the miniroot download and the installer.
+After an installation,
+.Cm up
+publishes the newly installed disk as a new cached base.
+The cache operation is best effort:
+a failure causes a warning,
+and the VM starts,
+with an installation from scratch or with a standalone disk.
 .Pp
 .Fl Fl no-cache
-skips both the restore and the save for this invocation,
-forcing a fresh installation and leaving the cache untouched.
-It overrides the
+skips the restore and the save for this run.
+This causes a fresh installation and does not change the cache.
+The flag overrides the
 .Ar image_cache
-directive and is meant for debugging the installer itself.
+directive.
+Use it to debug the installer itself.
 .It Cm down
 Stop the VM gracefully.
 .It Cm destroy
@@ -157,12 +171,12 @@ Start the VM in the background.
 Stop the VM.
 With
 .Fl f ,
-terminate it forcefully.
+stop it with force.
 .It Cm status
-Show VM status as
+Show the VM status as
 .Ar key : value
-lines,
-including
+lines.
+The lines include
 .Ar ssh_port
 and
 .Ar console_port .
@@ -174,7 +188,7 @@ and exit with its exit code.
 Authentication uses the SSH agent.
 .It Cm console
 Show how to connect to the VM serial console
-.Pq via Xr telnet 1 .
+.Pq with Xr telnet 1 .
 .It Cm expect Ar script Op Ar argument ...
 Run an
 .Xr expect 1
@@ -185,139 +199,152 @@ Block until the VM accepts SSH connections
 .It Cm image Cm download | list
 Manage cached installation images.
 .Cm list
-shows cached images;
+shows the cached images.
 .Cm download Op Ar version
-shows the cache path or download URL for
+shows the cache path or the download URL for
 .Ar version
 (default: 7.8).
-Images are downloaded via the built-in proxy when the VM boots.
+The built-in proxy downloads the images when the VM boots.
 .It Cm cache Cm list | clear Op Fl Fl stale
-Manage everything under
+Manage all data under
 .Ar cache_dir :
-the installed-image cache described in
-.Sx IMAGE CACHE ,
-and the downloads the built-in proxy keeps for the installer.
+the installed-image cache that
+.Sx IMAGE CACHE
+describes,
+and the downloads that the built-in proxy keeps for the installer.
 .Cm list
-prints one line per cached image
-.Pq key, size, creation time, snapshot count ,
-marking the entry the invoked VM's configuration currently derives,
-then the proxy's downloads by
+prints one line for each cached image
+.Pq key, size, creation time, snapshot count .
+It puts a mark on the entry that the invoked VM's configuration
+currently derives.
+Then it prints the proxy's downloads by
 .Ox
 version.
 .Cm clear
-removes every image and every download;
+removes each image and each download.
 .Fl Fl stale
-keeps only the image the invoked VM derives and only the downloads for
-the
+keeps only the image that the invoked VM derives,
+and only the downloads for the
 .Ox
 .Ar version
-it installs.
-Both forms also sweep temporary trees left by an interrupted save.
+that it installs.
+Both forms also remove temporary trees that an interrupted save leaves
+behind.
 .Pp
-Pruning the downloads is the only thing that bounds them.
-They are keyed by
+This removal is the only limit on the downloads.
+Their key is the
 .Ox
 version alone,
-share no key input with the images,
-and every pattern the proxy caches is version-scoped,
-so a
+and it has no input in common with the image keys.
+Each pattern that the proxy caches has a version scope.
+Thus,
+after a
 .Ar version
-bump otherwise leaves the whole previous version's file sets behind
-unreadable.
+change,
+the file sets of the previous version stay in the cache until you
+remove them,
+and nothing reads them again.
 .Pp
 The scope of
 .Fl Fl stale
-is one VM,
-the one named by
-.Fl Fl vm .
-The key inputs
+is one VM:
+the VM that
+.Fl Fl vm
+names.
+Each VM has its own
 .Ar version
 and
 .Ar disk_size
-are per-VM,
-so pruning for one VM removes bases another VM would have hit,
-and downloads for the
+key inputs.
+Thus a removal for one VM removes bases that a different VM can use,
+and the downloads for the
 .Ox
-version another VM installs.
+version that a different VM installs.
 .Pp
 .Cm clear
-refuses to remove an entry while a VM in this project is running on it,
-and warns when removal orphans the disk of a stopped one
+does not remove an entry while a VM in this project runs on it.
+It gives a warning when a removal orphans the disk of a stopped VM
 .Pq rebuild it with Cm destroy No and Cm up .
-VMs in other projects sharing the same
-.Ar cache_dir
-cannot be surveyed and are not covered by either check.
+.Cm clear
+cannot examine the VMs of other projects that share the same
+.Ar cache_dir ,
+and the two checks do not apply to them.
 .It Cm snapshot Cm save | restore | rm Ar name
 .It Cm snapshot Cm list Op Fl Fl names
-Manage named snapshot layers over the cached base image,
-for caching guest states
+Manage named snapshot layers over the cached base image.
+Use them to cache guest states that
 .Nm
-knows nothing about
-.Pq typically the result of a provisioning script .
+does not know about
+.Pq usually the result of a provisioning script .
 See
 .Sx IMAGE CACHE .
 .Pp
 .Cm save
-flattens the working disk into the cache under the base image it is built
-on;
+flattens the working disk into the cache,
+under the base image on which the disk is built.
 .Cm restore
-replaces the working disk with a fresh overlay on
-.Ar name
-and reseeds the VM state the snapshot records.
-The VM must be stopped for both:
+replaces the working disk with a new overlay on
+.Ar name ,
+and reseeds the VM state that the snapshot records.
+Stop the VM before both operations:
 a live overlay is not consistent.
 .Cm save
-additionally needs an installed VM whose disk is built on a cached image;
-a standalone disk
-.Pq from Fl Fl no-cache No or Ar image_cache no
-cannot be snapshotted.
+also needs an installed VM with a disk that is built on a cached image.
+You cannot snapshot a standalone disk
+.Pq from Fl Fl no-cache No or Ar image_cache no .
 .Cm restore
-needs neither disk nor state and can run on a fresh checkout before the
-first
+needs no disk and no state,
+and it can run on a fresh checkout before the first
 .Cm up .
 .Pp
-A missing or unresolvable snapshot exits 11 rather than 1, so a script can
-distinguish it from a real failure:
+A snapshot that is missing or unresolvable causes an exit with code 11,
+not 1.
+Thus a script can see the difference between this and a real failure:
 .Bd -literal -offset indent
 fuguvm snapshot restore deps-$hash || provision_from_scratch
 .Ed
 .Pp
+The scope of
 .Cm list
 and
 .Cm rm
-are scoped to the cache entry the current configuration derives.
+is the cache entry that the current configuration derives.
 .Cm list Fl Fl names
-writes bare snapshot names to standard output, one per line, for
-scripts;
-without it the listing goes to standard error like all other
-informational output.
+writes bare snapshot names to standard output,
+one name on each line,
+for scripts.
+Without the flag,
+the output goes to standard error,
+the same as all other informational output.
 .It Cm disk Cm check | repair | info
 Manage the VM disk image:
-verify integrity,
+do a check of its integrity,
 repair errors
-(the VM must be stopped),
-or show image details.
+(stop the VM first),
+or show the image details.
 .It Cm help
-Display usage information.
+Show usage information.
 .El
 .Sh IMAGE CACHE
-Installing
+An installation of
 .Ox
-under software emulation costs tens of minutes.
+under software emulation takes tens of minutes.
+Thus
 .Nm
-therefore keeps the result:
-a pristine, compacted copy of the disk taken the moment the installer
-finished, which later runs use as the backing image of a throwaway
-overlay.
-A warm cache turns
+keeps the result:
+a clean, compacted copy of the disk.
+.Nm
+makes the copy immediately after the installer completes.
+Later runs use the copy as the backing image of a throwaway overlay.
+With a warm cache,
 .Cm destroy
-followed by
+and then
 .Cm up
-into a cheap factory reset.
+are a cheap factory reset.
 .Pp
-Entries live under
+Entries are under
 .Ar cache_dir ,
-beside the proxy cache holding the miniroot and install sets:
+beside the proxy cache that holds the miniroot and the install sets:
 .Bd -literal -offset indent
 <cache_dir>/proxy/...                            miniroot, install sets
 <cache_dir>/installed/<key>/base.qcow2           mode 0400, compacted
@@ -328,10 +355,12 @@ beside the proxy cache holding the miniroot and install sets:
 .Pp
 .Ar key
 is
-.Ar version Ns - Ns Ar arch Ns - Ns Ar hash ,
-where
+.Ar version Ns - Ns Ar arch Ns - Ns Ar hash .
+The
 .Ar hash
-is a truncated SHA-256 over everything that shapes an installed disk:
+part is a truncated SHA-256 over all inputs that shape an installed
+disk.
+These inputs are:
 the
 .Ox
 version,
@@ -342,41 +371,45 @@ the contents of the
 installer script,
 and the contents of
 .Pa share/fuguvm/cache-generation .
-Memory and port settings do not shape the disk and are excluded,
-so changing them still hits the same entry.
+The memory and port settings do not shape the disk,
+and the hash excludes them.
+Thus a change to them hits the same entry.
 .Pp
 .Pa share/fuguvm/cache-generation
 is a generation counter.
-Bump the number in it when the way the installer is driven changes
-outside
-.Pa install.exp ,
-so existing cached images are invalidated.
-Keep it to the bare number:
-the whole file is hashed.
+Increase the number in the file when the procedure that drives the
+installer changes outside
+.Pa install.exp .
+This makes the cached images invalid.
+Keep only the bare number in the file:
+the hash includes the whole file.
 .Pp
 Entries are immutable and write-once.
-Each is built whole in a temporary directory and published by renaming
-that directory, so a reader never sees one installation's base image
-beside another installation's metadata.
+.Nm
+builds each entry whole in a temporary directory,
+and then publishes the entry with a rename of that directory.
+Thus a reader never sees the base image of one installation beside the
+metadata of a different installation.
 .Pp
-A snapshot is an immutable named layer over an entry's base image,
-created by
+A snapshot is an immutable, named layer over the base image of an
+entry.
 .Cm snapshot save
-from a stopped VM.
-Snapshots are flattened onto
-.Pa base.qcow2 ,
-so each is a direct child of the base whatever the working disk was built
-on:
+creates the snapshot from a stopped VM.
+.Nm
+flattens each snapshot onto
+.Pa base.qcow2 .
+Thus each snapshot is a direct child of the base,
+and the initial backing of the working disk has no effect:
 .Bd -literal -offset indent
 base.qcow2  <-  <name>.qcow2  <-  disk.qcow2
 .Ed
 .Pp
-No snapshot is therefore ever another's parent,
-and removing one cannot orphan another.
-Because snapshots live inside the entry,
-anything that invalidates a base
+Thus no snapshot is the parent of a different snapshot,
+and the removal of one snapshot cannot orphan a different snapshot.
+Because the snapshots are inside the entry,
+each operation that makes a base invalid
 .Pq a new key, or Cm cache clear
-invalidates its snapshots with it.
+also makes the snapshots of that base invalid.
 .Sh FILES
 .Bl -tag -width ".fuguvm/vms/name.conf" -compact
 .It Pa .fuguvmrc
@@ -393,19 +426,21 @@ Runtime state
 .Pq PID files, sockets, disk images .
 .It Pa ~/.cache/fuguvm/
 Default cache directory:
-downloaded installation images and installed-image cache.
+downloaded installation images and the installed-image cache.
 .It Pa share/fuguvm/cache-generation
-Installed-image cache generation counter.
+Generation counter for the installed-image cache.
 .El
 .Pp
 .Ar image_cache Cm yes | no
 .Pq default Cm yes
 switches the installed-image cache on or off.
-It is read from the project
+.Nm
+reads the directive from the project
 .Pa .fuguvmrc
 or the global
 .Pa ~/.fuguvmrc ,
-project first, and may also appear inside a
+with the project first.
+The directive can also be in a
 .Ar vm
 block.
 .Fl Fl no-cache
@@ -414,7 +449,7 @@ on
 overrides all of them.
 .Sh EXIT STATUS
 .Nm
-exits with one of the following values:
+exits with one of these values:
 .Pp
 .Bl -tag -width Ds -offset indent -compact
 .It 0
@@ -434,7 +469,7 @@ VM is running.
 .It 6
 VM is not running.
 .It 7
-Timeout waiting for the VM.
+Timeout in the wait for the VM.
 .It 8
 SSH connection failed.
 .It 9
@@ -449,7 +484,7 @@ The
 .Cm ssh
 command with a
 .Ar command
-argument exits with the remote command's exit code.
+argument exits with the exit code of the remote command.
 .Sh EXAMPLES
 Initialize a project and boot the default VM:
 .Bd -literal -offset indent
@@ -475,36 +510,41 @@ $ fuguvm --vm minimal up
 .Sh HISTORY
 The
 .Nm
-utility first appeared in 2025,
-written to run the
+utility first appeared in 2025.
+Its initial purpose was to run the
 .Xr openhapd 8
 test suite against a real
 .Ox
-guest,
-and generalised from there.
+guest.
+It became more general from there.
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh SECURITY CONSIDERATIONS
 .Nm
-generates a random root password for each installation and stores it in
-the VM state directory,
-and, when the installed image is cached, in that entry's
+generates a random root password for each installation and stores it
+in the VM state directory.
+When the installed image goes into the cache,
+.Nm
+also stores the password in the
 .Pa meta.json
+of that entry
 .Pq mode 0600 .
-Caching lengthens the secret's life:
-it survives
-.Cm destroy
-and rotates only when the base key does.
+The cache makes the life of this secret longer:
+the password survives
+.Cm destroy ,
+and it changes only when the base key changes.
 .Pp
 This is not a localhost-only secret.
-The guest permits password root login,
-and QEMU is given
+The guest permits password root login.
+.Nm
+gives QEMU the
 .Ar ssh_port
 and
 .Ar console_port
-with no bind address,
-so the forwarded SSH port and the telnet serial console listen on every
-host interface.
-Treat a running VM, and a populated
-.Ar cache_dir ,
-as reachable by anyone who can reach the host.
+values with no bind address.
+Thus the forwarded SSH port and the telnet serial console listen on
+each host interface.
+Treat a VM that runs as open to all persons who can reach the host.
+Apply the same rule to a
+.Ar cache_dir
+that has content.

--- a/man/openhap/hapctl.8
+++ b/man/openhap/hapctl.8
@@ -26,95 +26,98 @@
 .Ar command
 .Sh DESCRIPTION
 .Nm
-is a command-line utility for managing and querying the
+is a command-line utility for the
 .Xr openhapd 8
 daemon.
-It validates the configuration file,
-reports whether the daemon is running and paired,
-and lists the configured devices.
+It does a check of the configuration file.
+It shows if the daemon operates and if it is paired.
+It shows a list of the configured devices.
 .Pp
-The options are as follows:
+The options are:
 .Bl -tag -width Ds
 .It Fl c Ar file
-Specify the configuration file.
+Read the configuration from
+.Ar file .
 The default is
 .Pa /etc/openhapd.conf .
 .El
 .Pp
-The following commands are available:
+These commands are available:
 .Bl -tag -width "devicesXX"
 .It Cm check
-Validate the configuration file syntax.
-Parses
+Do a check of the configuration file syntax.
+The command parses
 .Xr openhapd.conf 5
-and reports any syntax errors or invalid values.
-Exits with status 0 if the configuration is valid,
-non-zero otherwise.
-Also displays the number of configured devices.
+and shows syntax errors and values that are not valid.
+If the configuration is correct, the command exits with status 0.
+If it is not, the exit status is not 0.
+The command also shows the number of configured devices.
 .It Cm status
-Display the status of the
+Show the status of the
 .Xr openhapd 8
-daemon and pairing information.
-Shows whether the daemon is running,
-its process ID,
-and the current pairing state (paired, unpaired, or unknown).
-For paired accessories,
-displays the number of paired HomeKit controllers.
+daemon and the pairing data.
+The command shows if the daemon operates, and it shows the process
+ID and the pairing state (paired, unpaired, or unknown).
+For a paired accessory, the command shows the number of paired
+HomeKit controllers.
 .It Cm devices
-List all devices configured in
-.Xr openhapd.conf 5 .
-For each device, displays:
+Show all devices that
+.Xr openhapd.conf 5
+configures.
+For each device, the command shows:
 .Bl -bullet -compact
 .It
-Device name as it appears in HomeKit
+The device name, as HomeKit shows it
 .It
-Device type and subtype
+The device type and subtype
 .It
-MQTT topic prefix
+The MQTT topic prefix
 .It
-Internal device identifier
+The internal device identifier
 .El
 .It Cm help
-Display usage information.
+Show the usage message.
 .El
 .Sh FILES
 .Bl -tag -width "/var/db/openhapd/pairingsXX" -compact
 .It Pa /etc/openhapd.conf
-Default configuration file.
+The default configuration file.
 .It Pa /var/run/openhapd.pid
-Process ID of the running daemon.
+The process ID of the daemon when it runs.
 .It Pa /var/db/openhapd/pairings
-Pairing database used for status checks.
+The pairing database for status checks.
 .El
 .Sh EXIT STATUS
 .Ex -std
-Commands exit with status 0 on success.
+The commands exit with status 0 on success.
 .Pp
 The
 .Cm check
-command exits with non-zero status if configuration errors are found.
+command exits with a status that is not 0 if it finds configuration
+errors.
 .Pp
 The
 .Cm status
 and
 .Cm devices
-commands exit with status 0 regardless of daemon state.
+commands always exit with status 0.
+The daemon state has no effect on their exit status.
 .Sh EXAMPLES
-Validate the configuration file:
+Do a check of the configuration file:
 .Bd -literal -offset indent
 $ hapctl check
 Configuration file /etc/openhapd.conf is valid
   Configured devices: 3
 .Ed
 .Pp
-Check daemon status:
+Show the daemon status:
 .Bd -literal -offset indent
 $ hapctl status
 openhapd is running (PID 12345)
 Pairing status: paired (2 controllers)
 .Ed
 .Pp
-List configured devices:
+Show the configured devices:
 .Bd -literal -offset indent
 $ hapctl devices
 Configured devices: 2
@@ -130,27 +133,30 @@ Configured devices: 2
     ID:    living_room
 .Ed
 .Pp
-Use an alternate configuration file:
+Use a different configuration file:
 .Bd -literal -offset indent
 $ hapctl -c /etc/openhapd.test.conf check
 .Ed
 .Sh DIAGNOSTICS
-Configuration errors are reported to
-.Em stderr
-with descriptive messages.
+.Nm
+writes configuration errors to
+.Em stderr ,
+with a message that describes each error.
 .Pp
 If
 .Xr openhapd 8
-is not running,
+is not in operation,
 .Cm status
-will report:
+shows:
 .Bd -literal -offset indent
 openhapd is not running
 .Ed
 .Pp
-If the pairing database cannot be read,
+If
+.Nm
+cannot read the pairing database,
 .Cm status
-will report:
+shows:
 .Bd -literal -offset indent
 Pairing status: unknown (cannot read storage)
 .Ed
@@ -161,16 +167,17 @@ Pairing status: unknown (cannot read storage)
 .Sh HISTORY
 The
 .Nm
-utility first appeared with
+utility was first available with
 .Xr openhapd 8
 in 2025.
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh CAVEATS
 .Nm
-reads the pairing database directly to determine pairing status.
-This requires read access to
+reads the pairing database directly to get the pairing status.
+Thus, it must have read access to
 .Pa /var/db/openhapd/ .
-When run as a non-root user,
-pairing status may be reported as
+When a user who is not root runs
+.Nm ,
+the command can show the pairing status as
 .Dq unknown .

--- a/man/openhap/hapctl.8
+++ b/man/openhap/hapctl.8
@@ -30,7 +30,7 @@ is a command-line utility for the
 .Xr openhapd 8
 daemon.
 It does a check of the configuration file.
-It shows if the daemon operates and if it is paired.
+It shows if the daemon runs and if it is paired.
 It shows a list of the configured devices.
 .Pp
 The options are:
@@ -56,7 +56,7 @@ The command also shows the number of configured devices.
 Show the status of the
 .Xr openhapd 8
 daemon and the pairing data.
-The command shows if the daemon operates, and it shows the process
+The command shows if the daemon runs, and it shows the process
 ID and the pairing state (paired, unpaired, or unknown).
 For a paired accessory, the command shows the number of paired
 HomeKit controllers.
@@ -145,7 +145,7 @@ with a message that describes each error.
 .Pp
 If
 .Xr openhapd 8
-is not in operation,
+does not run,
 .Cm status
 shows:
 .Bd -literal -offset indent

--- a/man/openhap/openhapd.8
+++ b/man/openhap/openhapd.8
@@ -33,7 +33,7 @@ on
 .Ox .
 .Pp
 .Nm
-is a bridge between HomeKit controllers, for example the iOS Home app,
+is a bridge between HomeKit controllers, for example, the iOS Home app,
 and devices that MQTT controls.
 It changes HAP requests into MQTT commands.
 It sends changes of the device state back to HomeKit.
@@ -75,9 +75,9 @@ In that condition, the daemon starts, writes a warning to the log,
 and serves the paired controllers.
 Discovery is not available until you restart
 .Nm
-with
+while
 .Xr mdnsd 8
-active.
+runs.
 .Pp
 On
 .Ox ,
@@ -163,7 +163,7 @@ If a necessary path is absent, this is a fatal configuration error.
 .It perl library directories
 (necessary, read) the library tree of the interpreter, for the one
 module that the daemon loads late, on the MQTT reconnect path.
-.It Pa config file
+.It Pa configuration file
 (optional, read) the file that the
 .Fl c
 option names.
@@ -267,7 +267,7 @@ daemon was first available in 2025.
 .Sh CAVEATS
 For correct operation,
 .Nm
-needs an MQTT broker, for example
+needs an MQTT broker, for example,
 .Xr mosquitto 8 ,
 and
 .Xr mdnsd 8 .

--- a/man/openhap/openhapd.8
+++ b/man/openhap/openhapd.8
@@ -122,7 +122,7 @@ Increase the log verbosity.
 You can give this option more than one time.
 Each use increases the log level:
 .Fl v
-enables debug logging, and
+gives the debug messages, and
 .Fl vv
 adds trace messages.
 .El

--- a/man/openhap/openhapd.8
+++ b/man/openhap/openhapd.8
@@ -67,7 +67,7 @@ When
 stops, it closes the socket, and this removes the advertisement.
 .Pp
 .Xr mdnsd 8
-must be in operation when
+must run when
 .Nm
 starts.
 If it is not, HomeKit controllers cannot find the accessory.
@@ -77,7 +77,7 @@ Discovery is not available until you restart
 .Nm
 with
 .Xr mdnsd 8
-in operation.
+active.
 .Pp
 On
 .Ox ,
@@ -271,7 +271,7 @@ needs an MQTT broker, for example
 .Xr mosquitto 8 ,
 and
 .Xr mdnsd 8 .
-Both must be in operation.
+Both must run.
 If one of them is not available, the daemon starts and does what it
 can.
 The daemon tries the MQTT connection again in the background.

--- a/man/openhap/openhapd.8
+++ b/man/openhap/openhapd.8
@@ -27,18 +27,18 @@
 .Sh DESCRIPTION
 The
 .Nm
-daemon speaks the HomeKit Accessory Protocol (HAP)
+daemon uses the HomeKit Accessory Protocol (HAP)
 so that Apple HomeKit can control MQTT-connected Tasmota devices
 on
 .Ox .
 .Pp
 .Nm
-acts as a bridge between HomeKit controllers (such as the iOS Home app)
-and devices controlled via MQTT,
-translating HAP requests into MQTT commands and publishing device state
-changes back to HomeKit.
+is a bridge between HomeKit controllers, for example the iOS Home app,
+and devices that MQTT controls.
+It changes HAP requests into MQTT commands.
+It sends changes of the device state back to HomeKit.
 .Pp
-Pairing and transport security follow the HAP specification:
+Pairing and transport security obey the HAP specification:
 .Bl -bullet -compact
 .It
 Pair-setup with SRP-6a (Secure Remote Password)
@@ -54,126 +54,138 @@ Session encryption with ChaCha20-Poly1305 AEAD
 Service advertisement over mDNS
 .El
 .Pp
-The service is advertised over mDNS by talking to
-.Xr mdnsd 8
-directly on its control socket,
+.Nm
+advertises the service over mDNS.
+To do this, it connects directly to the control socket of
+.Xr mdnsd 8 ,
 .Pa /var/run/mdnsd.sock .
 .Nm
-holds that socket open for its lifetime and spawns no helper process;
-closing it on shutdown is what withdraws the advertisement.
-.Xr mdnsd 8
-must be running when
+keeps the socket open for its full lifetime and spawns no helper
+process.
+When
 .Nm
-starts for the accessory to be discoverable.
-Without it the daemon still starts and serves paired controllers,
-logging a warning;
-discovery remains unavailable until
-.Nm
-is restarted with
+stops, it closes the socket, and this removes the advertisement.
+.Pp
 .Xr mdnsd 8
-running.
+must be in operation when
+.Nm
+starts.
+If it is not, HomeKit controllers cannot find the accessory.
+In that condition, the daemon starts, writes a warning to the log,
+and serves the paired controllers.
+Discovery is not available until you restart
+.Nm
+with
+.Xr mdnsd 8
+in operation.
 .Pp
 On
 .Ox ,
-once the daemon has dropped privileges and advertised itself,
-it restricts its own syscall surface with
+the daemon drops privileges and advertises itself.
+Then it restricts its own syscall surface with
 .Xr pledge 2
 to
 .Dq stdio rpath wpath cpath fattr flock inet dns unix
-before handling any network input;
-the
+before it receives any network input.
+The
 .Dq proc ,
 .Dq exec
 and
 .Dq prot_exec
-promises are deliberately absent.
-.Ox
-is the only platform where this is enforced;
-on other systems the daemon runs unrestricted.
+promises are absent by design.
+These restrictions are in effect only on
+.Ox .
+On other systems, the daemon runs without restrictions.
 .Pp
-The options are as follows:
+The options are:
 .Bl -tag -width Ds
 .It Fl c Ar file
-Specify the configuration file.
+Read the configuration from
+.Ar file .
 The default is
 .Pa /etc/openhapd.conf .
 .It Fl f
 Run in the foreground.
 By default,
 .Nm
-will daemonize and log to
+daemonizes and logs to
 .Xr syslog 3 .
 With this option,
 .Nm
 stays in the foreground and logs to
 .Em stderr .
 .It Fl n
-Check the configuration file for syntax errors and exit.
-No daemon is started.
+Do a check of the configuration file for syntax errors and exit.
+No daemon starts.
 .It Fl v
-Increase verbosity.
-Can be specified multiple times for more detailed logging.
+Increase the log verbosity.
+You can give this option more than one time.
 Each use increases the log level:
 .Fl v
-enables debug logging,
+enables debug logging, and
 .Fl vv
-adds trace information.
+adds trace messages.
 .El
 .Sh FILES
 .Bl -tag -width "/var/db/openhapd/pairingsXX" -compact
 .It Pa /etc/openhapd.conf
-Default configuration file.
+The default configuration file.
 .It Pa /var/db/openhapd/
-State directory containing pairing database and cryptographic keys.
+The state directory that holds the pairing database and the
+cryptographic keys.
 .It Pa /var/db/openhapd/pairings
-Database of paired HomeKit controllers.
+The database of paired HomeKit controllers.
 .It Pa /var/db/openhapd/ltsk
-Long-term secret key (Ed25519 private key).
+The long-term secret key (Ed25519 private key).
 .It Pa /var/db/openhapd/ltpk
-Long-term public key (Ed25519 public key).
+The long-term public key (Ed25519 public key).
 .It Pa /var/run/openhapd.pid
-Process ID file.
+The process ID file.
 .El
 .Pp
 On
-.Ox
-the running daemon locks its filesystem view down with
-.Xr unveil 2
-and can read
+.Ox ,
+the daemon restricts its filesystem view with
+.Xr unveil 2 .
+It can read
 .Em nothing
-outside the list below \(em an operator wondering why
+outside of the list that follows.
+If
 .Nm
-cannot see a file should look here first.
-Paths marked optional may be absent without preventing startup;
-a missing required path is a fatal configuration error.
+cannot see a file, examine this list first.
+If an optional path is absent, the daemon starts.
+If a necessary path is absent, this is a fatal configuration error.
 .Bl -tag -width "/var/run/mdnsd.sockXX" -compact
 .It Pa db_path
-(required, read-write-create) the state directory above.
+(necessary, read-write-create) the state directory above.
 .It Pa /dev/urandom
-(required, read) randomness for all key material.
+(necessary, read) randomness for all key material.
 .It perl library directories
-(required, read) the interpreter's library tree, for the one lazily
-loaded module on the MQTT reconnect path.
+(necessary, read) the library tree of the interpreter, for the one
+module that the daemon loads late, on the MQTT reconnect path.
 .It Pa config file
-(optional, read) the file named with
-.Fl c .
+(optional, read) the file that the
+.Fl c
+option names.
 .It Pa /var/log/openhapd.log
-(optional, write) the daemon-mode log; never created in
+(optional, write) the daemon-mode log; the daemon never creates this
+file in
 .Fl f
 mode.
 .It Pa /var/run/mdnsd.sock
-(optional, read-write) re-advertising after a pairing change
-reconnects to
-.Xr mdnsd 8 .
+(optional, read-write) after a pairing change, the daemon makes a new
+connection to
+.Xr mdnsd 8
+to advertise again.
 .It Pa /etc/resolv.conf , Pa /etc/hosts , Pa /etc/services , Pa /etc/protocols
-(optional, read) the resolver files, used when
+(optional, read) the resolver files; the daemon uses them when
 .Cm mqtt_host
-is a name rather than an address.
+is a name and not an address.
 .It Pa /etc/localtime
 (optional, read) timestamps.
 .El
 .Sh EXAMPLES
-Check the configuration file:
+Do a check of the configuration file:
 .Bd -literal -offset indent
 # openhapd -n
 .Ed
@@ -183,7 +195,7 @@ Run in the foreground with verbose logging:
 # openhapd -f -v
 .Ed
 .Pp
-Typical daemon startup via
+Start the daemon the usual way, through
 .Xr rc 8 :
 .Bd -literal -offset indent
 # rcctl enable openhapd
@@ -193,31 +205,31 @@ Typical daemon startup via
 .Nm
 logs to
 .Xr syslog 3
-using the
+with the
 .Dq daemon
 facility.
-When run in the foreground with
+When the daemon runs in the foreground with
 .Fl f ,
-messages are written to
+it writes the messages to
 .Em stderr .
 .Pp
-Log messages include:
+These are some of the log messages:
 .Bl -tag -width "Not pairedXX"
 .It Dq Starting OpenHAP server
-Daemon started successfully and listening for connections.
+The daemon started correctly and now listens for connections.
 .It Dq Not paired - use Home app with PIN: XXX-XX-XXX
-The accessory is not paired with any HomeKit controller.
-Use the displayed PIN to pair via the iOS Home app.
+The accessory is not paired with a HomeKit controller.
+Use the PIN from the message to pair through the iOS Home app.
 .It Dq Connected to MQTT broker at host:port
-Successfully connected to the MQTT broker.
+The daemon connected to the MQTT broker.
 .It Dq MQTT broker not available, will retry in background
-Could not connect to MQTT broker on startup.
+The daemon did not connect to the MQTT broker at startup.
 .Nm
-will continue attempting to connect.
+continues to try to connect in the background.
 .It Dq Paired with controller: identifier
-A new HomeKit controller successfully completed pairing.
+The pairing with a new HomeKit controller was successful.
 .It Dq Secure session established
-An encrypted session was successfully negotiated with a paired controller.
+The daemon started an encrypted session with a paired controller.
 .El
 .Sh SEE ALSO
 .Xr syslog 3 ,
@@ -231,8 +243,9 @@ HomeKit Accessory Protocol Specification (Non-Commercial Version):
 .Lk https://developer.apple.com/homekit/
 .Sh STANDARDS
 .Nm
-follows the HomeKit Accessory Protocol Specification R2 for IP accessories.
-The cryptography it uses is specified in:
+obeys the HomeKit Accessory Protocol Specification R2 for IP
+accessories.
+These documents specify the cryptography that it uses:
 .Bl -bullet -compact
 .It
 RFC 5054: Using the Secure Remote Password (SRP) Protocol for TLS Authentication
@@ -248,74 +261,79 @@ RFC 7748: Elliptic Curves for Security (Curve25519)
 .Sh HISTORY
 The
 .Nm
-daemon first appeared in 2025.
+daemon was first available in 2025.
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh CAVEATS
+For correct operation,
 .Nm
-requires a working MQTT broker (such as
-.Xr mosquitto 8 )
-and a running
-.Xr mdnsd 8
-to function properly.
-Without either, the daemon starts and serves what it can:
-MQTT reconnects in the background,
-while mDNS discovery stays unavailable until the daemon is restarted.
+needs an MQTT broker, for example
+.Xr mosquitto 8 ,
+and
+.Xr mdnsd 8 .
+Both must be in operation.
+If one of them is not available, the daemon starts and does what it
+can.
+The daemon tries the MQTT connection again in the background.
+The mDNS discovery is not available until you restart the daemon.
 .Pp
-The HAP PIN code is logged on first startup when the accessory is unpaired.
-Protect access to system logs accordingly.
+At the first startup, if the accessory is not paired, the daemon
+writes the HAP PIN code to the log.
+Thus, limit the access to the system logs.
 .Pp
-Pairing data stored in
+The pairing data in
 .Pa /var/db/openhapd/
-contains cryptographic keys.
-The directory should be owned by
-.Dq _openhap
-with mode 0700.
+holds cryptographic keys.
+The owner of the directory must be
+.Dq _openhap ,
+and the mode must be 0700.
 .Sh BUGS
 .Nm
-only supports Tasmota devices over MQTT.
-HAP over Bluetooth Low Energy is not implemented.
+operates only with Tasmota devices over MQTT.
+It does not implement HAP over Bluetooth Low Energy.
 .Sh SECURITY CONSIDERATIONS
 .Nm
-starts as root to fix the ownership of
-.Pa /var/db/openhapd ,
-drops to the
+starts as root to set the correct ownership of
+.Pa /var/db/openhapd .
+Then it drops to the
 .Dq _openhap
-user,
-publishes its mDNS advertisement,
-and only then restricts itself \(em first the filesystem view with
+user and publishes its mDNS advertisement.
+Then it restricts itself:
+first the filesystem view with
 .Xr unveil 2 ,
-then the syscall surface with
-.Xr pledge 2
-\(em before accepting any network connection.
-Applying the restrictions after the privilege drop means they confine
-everything that ever handles untrusted input;
-they do not, and cannot, confine the brief root phase, which handles
-none.
+and then the syscall surface with
+.Xr pledge 2 .
+The daemon accepts network connections only after these steps.
+.Pp
+Because the restrictions come after the privilege drop, they apply to
+all code that receives untrusted input.
+They do not, and cannot, apply to the short root phase.
+But that phase receives no untrusted input.
 .Pp
 The promise set is
 .Dq stdio rpath wpath cpath fattr flock inet dns unix :
 .Bl -tag -width "wpath cpathXX" -compact
 .It Cm stdio
-always required.
+always necessary.
 .It Cm rpath
 .Pa /dev/urandom ,
-state reads, and the lazily loaded MQTT module.
+state reads, and the MQTT module that the daemon loads late.
 .It Cm wpath , cpath
-writing, creating and removing state files, and the daemon log.
+to write, create, and remove the state files and the daemon log.
 .It Cm fattr
-key material is chmodded to 0600.
+the daemon sets the mode of the key material to 0600.
 .It Cm flock
-state files are lock-protected.
+locks protect the state files.
 .It Cm inet
-the HAP listener and MQTT connections.
+the HAP listener and the MQTT connections.
 .It Cm dns
-resolving
+to resolve
 .Cm mqtt_host
 when it is a name.
 .It Cm unix
-re-advertising after a pairing change reconnects to
-.Xr mdnsd 8 .
+after a pairing change, the daemon makes a new connection to
+.Xr mdnsd 8
+to advertise again.
 .El
 .Pp
 The
@@ -323,39 +341,43 @@ The
 .Cm exec
 and
 .Cm prot_exec
-promises are deliberately absent:
+promises are absent by design:
 the daemon spawns no processes and loads no shared objects after
 startup.
-The unveiled paths and their dispositions are listed in
-.Sx FILES .
+The section
+.Sx FILES
+lists the unveiled paths and the access type of each path.
 .Pp
 The
 .Xr mdnsd 8
-control socket is created root:wheel with mode 0660,
-so the
+control socket has owner root:wheel and mode 0660.
+Thus, the
 .Dq _openhap
-user must be able to open it read-write;
-the standard setup arranges this through wheel group membership.
+user must have read-write access to the socket.
+In the standard setup, the
+.Dq _openhap
+user is a member of the wheel group, and this gives the access.
 .Pp
-Enforcement is
-.Ox No only .
-Linux and Darwin are development platforms where both mechanisms are
-no-ops;
-a deployment there runs unrestricted, whatever the rest of this page
-says.
+The restrictions are in effect only on
+.Ox .
+Linux and Darwin are development platforms, and there the two
+mechanisms do nothing.
+On these platforms, the daemon runs without restrictions.
 .Pp
-A pledge violation kills the daemon immediately with
-.Dv SIGABRT ,
-and the kernel logs a line to
+A pledge violation stops the daemon immediately with
+.Dv SIGABRT .
+The kernel then writes a line to
 .Xr dmesg 8
 and
-.Pa /var/log/messages
-naming the process and the forbidden syscall \(em if
+.Pa /var/log/messages .
+This line names the process and the syscall that is not permitted.
+If
 .Nm
-dies unexpectedly, look there before anywhere else.
-A path outside the unveiled view does not kill anything;
-the affected operation fails with
+stops and you do not know why, examine these logs first.
+.Pp
+A path outside of the unveiled view does not stop the daemon.
+The operation on that path fails with
 .Er ENOENT
 or
-.Er EACCES ,
-typically surfacing as a warning in the daemon log.
+.Er EACCES .
+Usually, the daemon log then shows a warning.

--- a/man/openhap/openhapd.conf.5
+++ b/man/openhap/openhapd.conf.5
@@ -25,71 +25,73 @@
 is the configuration file for the
 .Xr openhapd 8
 daemon.
-The file uses a simple key-value format with device blocks for
-defining HomeKit accessories.
+The file uses a simple key-value format with device blocks that
+define HomeKit accessories.
 .Pp
-Lines beginning with
+A line that starts with
 .Sq #
-are comments and are ignored.
+is a comment, and the daemon ignores it.
 .Sh GLOBAL OPTIONS
-The following global options are available:
+These global options are available:
 .Bl -tag -width Ds
 .It Ic hap_name Ar string
-The name of the HomeKit bridge as it appears in the iOS Home app.
+The name of the HomeKit bridge, as the iOS Home app shows it.
 Default:
 .Dq OpenHAP Bridge .
 .It Ic hap_port Ar number
-TCP port for the HAP server.
+The TCP port for the HAP server.
 Default: 51827.
 .It Ic hap_pin Ar XXXX-XXXX
-The 8-digit setup code used for pairing.
-Format: XXXX-XXXX where X is a digit 0-9.
-Dashes are for readability only and are stripped during processing.
-Certain values are invalid per the HAP specification
-(after stripping dashes):
+The 8-digit setup code for pairing.
+The format is XXXX-XXXX, in which each X is a digit 0-9.
+The dashes only make the code easy to read.
+The daemon removes them when it parses the value.
+The HAP specification does not permit these values (after removal of
+the dashes):
 00000000, 11111111, 22222222, 33333333, 44444444,
 55555555, 66666666, 77777777, 88888888, 99999999,
 12345678, 87654321.
 Default: 1995-1018.
 .It Ic hap_model Ar string
-Model name reported to HomeKit.
+The model name that the daemon sends to HomeKit.
 Default:
 .Dq OpenHAP .
 .It Ic hap_manufacturer Ar string
-Manufacturer name reported to HomeKit.
+The manufacturer name that the daemon sends to HomeKit.
 Default:
 .Dq OpenBSD .
 .It Ic db_path Ar path
-Directory for storing pairing database and cryptographic keys.
+The directory that holds the pairing database and the cryptographic
+keys.
 Default:
 .Pa /var/db/openhapd .
 .It Ic log_level Ar level
-Logging verbosity level.
-Valid values:
+The log verbosity level.
+The valid values are:
 .Cm debug , info , notice , warning , err , crit , alert , emerg .
 Default:
 .Cm info .
 .It Ic log_facility Ar facility
-Syslog facility for log messages.
-Valid values:
+The syslog facility for the log messages.
+The valid values are:
 .Cm daemon , local0 Ns \(en Ns Cm local7 , user .
 Default:
 .Cm daemon .
 .It Ic mqtt_host Ar hostname
-Hostname or IP address of the MQTT broker.
+The hostname or the IP address of the MQTT broker.
 Default: 127.0.0.1.
 .It Ic mqtt_port Ar number
-TCP port of the MQTT broker.
+The TCP port of the MQTT broker.
 Default: 1883.
 .It Ic mqtt_user Ar username
-Username for MQTT authentication.
-Optional.
+The username for MQTT authentication.
+This option is optional.
 .It Ic mqtt_pass Ar password
-Password for MQTT authentication.
-Optional.
+The password for MQTT authentication.
+This option is optional.
 .El
 .Sh DEVICE BLOCKS
-Devices are defined using the following syntax:
+Define each device with this syntax:
 .Bd -literal -offset indent
 device <type> <subtype> <id> {
     name = "<display name>"
@@ -101,67 +103,69 @@ device <type> <subtype> <id> {
 The parameters are:
 .Bl -tag -width "subtypeXX"
 .It Ar type
-Device driver type.
-Currently only
+The device driver type.
+At this time, only
 .Cm tasmota
-is supported.
+is available.
 .It Ar subtype
-Device subtype.
+The device subtype.
 For
 .Cm tasmota ,
-valid values are:
+the valid values are:
 .Cm thermostat , heater , sensor .
 .It Ar id
-Unique identifier for the device within the configuration.
-Used for internal reference.
+The unique identifier of the device in the configuration.
+The daemon uses it for internal reference.
 .It Ic name
-Display name shown in the iOS Home app.
-Required.
+The display name that the iOS Home app shows.
+This option is necessary.
 .It Ic topic
-MQTT topic prefix for the device.
-For Tasmota devices, this is the topic configured in the device's
-MQTT settings (default:
-.Dq tasmota_%06X
-where %06X is the last 6 hex digits of the MAC address).
-Required.
+The MQTT topic prefix for the device.
+For Tasmota devices, this is the topic from the MQTT settings of the
+device.
+The default of that setting is
+.Dq tasmota_%06X ,
+in which %06X is the last 6 hex digits of the MAC address.
+This option is necessary.
 .El
 .Pp
-Additional options depend on the device subtype:
+The other options are different for each device subtype:
 .Ss Thermostat Options
-Tasmota thermostat devices support the following options:
+Tasmota thermostat devices have these options:
 .Bl -tag -width "target_temp_topicXX"
 .It Ic current_temp_topic Ar topic
-MQTT topic for current temperature readings.
+The MQTT topic for the current temperature values.
 Default:
 .Ar topic Ns /SENSOR .
 .It Ic target_temp_topic Ar topic
-MQTT topic for target temperature.
+The MQTT topic for the target temperature.
 Default:
 .Ar topic Ns /TARGET .
 .It Ic state_topic Ar topic
-MQTT topic for heater state (on/off).
+The MQTT topic for the heater state (on or off).
 Default:
 .Ar topic Ns /STATE .
 .It Ic min_temp Ar celsius
-Minimum temperature in Celsius.
+The minimum temperature in Celsius.
 Default: 10.0.
 .It Ic max_temp Ar celsius
-Maximum temperature in Celsius.
+The maximum temperature in Celsius.
 Default: 30.0.
 .It Ic temp_step Ar celsius
-Temperature adjustment step size.
+The step size for temperature adjustment.
 Default: 0.5.
 .El
 .Sh FILES
 .Bl -tag -width "/var/db/openhapd/XX" -compact
 .It Pa /etc/openhapd.conf
-Default configuration file location.
+The default location of the configuration file.
 .It Pa /etc/examples/openhapd.conf
-Example configuration file installed by
-.Cm make install .
+The example configuration file that
+.Cm make install
+installs.
 .El
 .Sh EXAMPLES
-Minimal configuration with a single thermostat:
+A minimal configuration with one thermostat:
 .Bd -literal -offset indent
 hap_name = "Home Bridge"
 hap_pin = 9876-5432
@@ -174,7 +178,7 @@ device tasmota thermostat bedroom {
 }
 .Ed
 .Pp
-Multiple devices with custom MQTT settings:
+Three devices with custom MQTT settings:
 .Bd -literal -offset indent
 hap_name = "OpenHAP"
 hap_port = 51827
@@ -212,32 +216,35 @@ device tasmota thermostat kitchen {
 .Xr mosquitto 8 ,
 .Xr openhapd 8
 .Sh STANDARDS
-The MQTT topic structure follows the Tasmota firmware conventions.
+The MQTT topic structure obeys the Tasmota firmware conventions.
 See
 .Lk https://tasmota.github.io/docs/MQTT/
-for details on Tasmota MQTT topics.
+for more data on the Tasmota MQTT topics.
 .Sh HISTORY
 The
 .Nm
-file format first appeared with
+file format was first available with
 .Xr openhapd 8
 in 2025.
 .Sh AUTHORS
 .An Dick Olsson Aq Mt hi@senzilla.io
 .Sh CAVEATS
-The
+The configuration file holds the
 .Ic hap_pin
-is stored in plain text in the configuration file.
-Ensure appropriate file permissions (mode 0600, owned by root).
+in plain text.
+Make sure that the file permissions are correct:
+mode 0600, with root as the owner.
 .Pp
-Changing the
+If you change the
 .Ic hap_name
-or
+or the
 .Ic hap_pin
-after pairing may require re-pairing all controllers.
+after pairing, it can be necessary to pair all controllers again.
 .Pp
+The file holds
 .Ic mqtt_pass
-is stored in plain text and is sent to the broker in the clear;
+in plain text, and the daemon sends it to the broker without
+encryption.
 .Xr openhapd 8
-does not speak MQTT over TLS.
+does not use MQTT over TLS.
 Keep the broker on the local machine or on a trusted network.

--- a/man/openhap/openhapd.conf.5
+++ b/man/openhap/openhapd.conf.5
@@ -43,7 +43,8 @@ The TCP port for the HAP server.
 Default: 51827.
 .It Ic hap_pin Ar XXXX-XXXX
 The 8-digit setup code for pairing.
-The format is XXXX-XXXX, in which each X is a digit 0-9.
+The format is XXXX-XXXX.
+Each X is a digit 0-9.
 The dashes only make the code easy to read.
 The daemon removes them when it parses the value.
 The HAP specification does not permit these values (after removal of
@@ -96,7 +97,7 @@ Define each device with this syntax:
 device <type> <subtype> <id> {
     name = "<display name>"
     topic = "<mqtt topic>"
-    [additional options...]
+    [more options...]
 }
 .Ed
 .Pp
@@ -124,8 +125,8 @@ The MQTT topic prefix for the device.
 For Tasmota devices, this is the topic from the MQTT settings of the
 device.
 The default of that setting is
-.Dq tasmota_%06X ,
-in which %06X is the last 6 hex digits of the MAC address.
+.Dq tasmota_%06X .
+The %06X part is the last 6 hex digits of the MAC address.
 This option is necessary.
 .El
 .Pp

--- a/t/web/site.t
+++ b/t/web/site.t
@@ -157,7 +157,7 @@ for my $page (@PAGES) {
 # install.html is rendered from INSTALL.md, not retyped
 {
 	my $html = slurp("$OUT/install.html");
-	like( $html, qr/Create system user/,
+	like( $html, qr/Create the system user/,
 		'install.html carries content from INSTALL.md' );
 }
 

--- a/web/404.body.html
+++ b/web/404.body.html
@@ -1,7 +1,7 @@
 <h1>No such page</h1>
 
-<p>There is nothing at that address.  It may never have existed, or it may
-have moved when a manual was renamed.</p>
+<p>There is no page at this address.  Possibly the page never existed, or it
+moved when a manual got a new name.</p>
 
-<p>Start from <a href="index.html">the front page</a>, or go straight to the
+<p>Start from <a href="index.html">the front page</a>, or go directly to the
 <a href="manuals.html">manuals</a>.</p>

--- a/web/foot.html
+++ b/web/foot.html
@@ -1,8 +1,8 @@
 </main>
 <hr>
 <footer>
-<p>Docs are <a href="https://creativecommons.org/licenses/by/4.0/">CC BY
-4.0</a>, code is <a href="https://opensource.org/license/isc-license-txt">ISC</a>.</p>
+<p>The documentation is <a href="https://creativecommons.org/licenses/by/4.0/">CC BY
+4.0</a>; the code is <a href="https://opensource.org/license/isc-license-txt">ISC</a>.</p>
 </footer>
 </body>
 </html>

--- a/web/fugulib.body.html
+++ b/web/fugulib.body.html
@@ -24,7 +24,7 @@ makes sure that the process cannot get root again.</dd>
 
 <dt>FuguLib::Process</dt>
 <dd>The module spawns and execs children, and makes sure that a child is
-alive after start-up.  It stops a child with a grace period before
+alive after startup.  It stops a child with a grace period before
 <code>SIGKILL</code>, reaps zombies, and waits for exit.</dd>
 
 <dt>FuguLib::Signal</dt>
@@ -46,7 +46,7 @@ with <code>FuguLib::Process</code>.</dd>
 <a href="https://man.openbsd.org/pledge.2">pledge(2)</a> and
 <a href="https://man.openbsd.org/unveil.2">unveil(2)</a>: the calls are real
 on OpenBSD and do nothing on other platforms.  Thus the callers do not
-examine the operating system.  A failure stops the process; there is no
+examine the operating system.  A method that fails dies; there is no
 warn-and-continue mode.</dd>
 
 <dt>FuguLib::Imsg</dt>
@@ -64,7 +64,7 @@ socket.</dd>
 <h2>Reference</h2>
 
 <p>Each module has a section 3p manual page, and OpenHAP installs the pages
-&mdash; thus <code>man FuguLib::Daemon</code> operates on a machine that has
+&mdash; thus <code>man FuguLib::Daemon</code> finds the page on a machine that has
 OpenHAP.  The pages are also listed under
 <a href="manuals.html#fugulib">FuguLib in the manuals</a>.</p>
 

--- a/web/fugulib.body.html
+++ b/web/fugulib.body.html
@@ -1,68 +1,73 @@
 <h1>FuguLib</h1>
 
-<p>FuguLib covers the parts of writing an OpenBSD-style daemon in Perl that the
-base system leaves to you: going into the background, writing a PID file,
-dropping privileges, reaping children, handling signals, logging to syslog or
-stderr depending on how the program was started, restricting itself with pledge
-and unveil, and advertising over mDNS without shelling out.</p>
+<p>FuguLib does the tasks that the base system leaves to an OpenBSD-style
+daemon in Perl.  A daemon must go into the background, write a PID file,
+drop privileges, reap children, and answer signals.  It must log to syslog
+or to stderr, as applicable to how it started.  It must limit itself with
+pledge and unveil, and advertise over mDNS without a child process.
+FuguLib supplies these functions.</p>
 
-<p>Nine modules, using only core Perl.  OpenHAP is built on it; nothing in it
-knows about OpenHAP.</p>
+<p>FuguLib has nine modules and uses only core Perl.  OpenHAP uses FuguLib;
+FuguLib does not know about OpenHAP.</p>
 
 <h2>The modules</h2>
 
 <dl>
 <dt>FuguLib::Daemon</dt>
-<dd>Fork, <code>setsid</code>, redirect the standard descriptors.  A callback
-runs in the parent before it exits, which is where the PID file gets
-written.</dd>
+<dd>The module forks, calls <code>setsid</code>, and redirects the standard
+descriptors.  A callback runs in the parent before the parent exits; the
+callback writes the PID file.</dd>
 
 <dt>FuguLib::Privdrop</dt>
-<dd>Drop from root to a named user and group, then verify that root cannot be
-regained.</dd>
+<dd>The module drops from root to a specified user and group.  It then
+makes sure that the process cannot get root again.</dd>
 
 <dt>FuguLib::Process</dt>
-<dd>Spawn, exec, verify a child actually survived start-up, terminate with a
-grace period before <code>SIGKILL</code>, reap zombies, and wait for
-exit.</dd>
+<dd>The module spawns and execs children, and makes sure that a child is
+alive after start-up.  It stops a child with a grace period before
+<code>SIGKILL</code>, reaps zombies, and waits for exit.</dd>
 
 <dt>FuguLib::Signal</dt>
-<dd>Register handlers for graceful shutdown or for a flag a long-running loop
-can poll, with a stack of cleanup callbacks and restoration of the previous
-handlers.</dd>
+<dd>The module registers handlers for a controlled shutdown, or for a flag
+that a long loop can poll.  It keeps a stack of cleanup callbacks and puts
+the previous handlers back.</dd>
 
 <dt>FuguLib::Log</dt>
-<dd>One interface over syslog, stderr and silence, with level filtering and
-printf-style formatting, so a daemon and a CLI tool can share code.</dd>
+<dd>The module gives one interface for syslog, stderr, and silence, with
+level filters and printf-style formats.  Thus a daemon and a CLI tool can
+use the same code.</dd>
 
 <dt>FuguLib::State</dt>
-<dd>PID file reading and writing with locking, plus stale-PID detection built
-on <code>FuguLib::Process</code>.</dd>
+<dd>The module reads and writes PID files with locks, and finds stale PIDs
+with <code>FuguLib::Process</code>.</dd>
 
 <dt>FuguLib::Sandbox</dt>
-<dd><a href="https://man.openbsd.org/pledge.2">pledge(2)</a> and
-<a href="https://man.openbsd.org/unveil.2">unveil(2)</a> as a platform
-abstraction: real on OpenBSD, a no-op everywhere else, so callers never test
-the operating system themselves.  Failures die; there is no
+<dd>The module is a platform abstraction for
+<a href="https://man.openbsd.org/pledge.2">pledge(2)</a> and
+<a href="https://man.openbsd.org/unveil.2">unveil(2)</a>: the calls are real
+on OpenBSD and do nothing on other platforms.  Thus the callers do not
+examine the operating system.  A failure stops the process; there is no
 warn-and-continue mode.</dd>
 
 <dt>FuguLib::Imsg</dt>
-<dd>The base-system imsg framing &mdash; a fixed native-endian header and a
-payload &mdash; over any connected stream socket, with whole-message reads
-across short counts.</dd>
+<dd>The module supplies the base-system imsg framing &mdash; a fixed
+native-endian header and a payload &mdash; over a connected stream socket.
+It reads full messages when the socket returns short counts.</dd>
 
 <dt>FuguLib::MDNS</dt>
-<dd>Publish services through <code>mdnsd(8)</code> by speaking its control
-protocol directly, no <code>mdnsctl</code> child process; the held socket is
-the advertisement's lifetime.</dd>
+<dd>The module publishes services through <code>mdnsd(8)</code> with its
+control protocol directly, not through a <code>mdnsctl</code> child
+process.  The advertisement stays active while the module holds the
+socket.</dd>
 </dl>
 
 <h2>Reference</h2>
 
-<p>Each module has a section 3p manual page, installed with OpenHAP &mdash; so
-<code>man FuguLib::Daemon</code> works on a machine that has it &mdash; and
-listed under <a href="manuals.html#fugulib">FuguLib in the manuals</a>.</p>
+<p>Each module has a section 3p manual page, and OpenHAP installs the pages
+&mdash; thus <code>man FuguLib::Daemon</code> operates on a machine that has
+OpenHAP.  The pages are also listed under
+<a href="manuals.html#fugulib">FuguLib in the manuals</a>.</p>
 
 <h2>Name</h2>
 
-<p><em>Fugu</em> is the pufferfish, after OpenBSD&rsquo;s mascot.</p>
+<p><em>Fugu</em> is the pufferfish, the mascot of OpenBSD.</p>

--- a/web/fuguvm.body.html
+++ b/web/fuguvm.body.html
@@ -1,57 +1,59 @@
 <h1>FuguVM</h1>
 
 <p>FuguVM installs and manages <a href="https://www.openbsd.org/">OpenBSD</a>
-virtual machines under QEMU.  It fetches the install set, creates the disk,
-answers the installer over the serial console, and hands you back a machine
-that accepts SSH.  One command, unattended, on a host that need not be running
-OpenBSD itself.</p>
+virtual machines under QEMU.  It downloads the install set, creates the
+disk, and answers the installer through the serial console.  The result is
+a machine that accepts SSH.  One command does the unattended install, on a
+host that does not run OpenBSD.</p>
 
-<p>It exists so that an install can be driven from a <code>Makefile</code>
-rather than answered by hand.</p>
+<p>Thus a <code>Makefile</code> can control an install; you do not have to
+answer the installer manually.</p>
 
 <h2>What it does</h2>
 
 <dl>
 <dt>Unattended install</dt>
 <dd><code>fuguvm up</code> downloads the release, creates the disk image,
-drives <code>bsd.rd</code> through the installer, and starts the machine.  It
-is idempotent: run it again and nothing happens.</dd>
+controls <code>bsd.rd</code> through the installer, and starts the machine.
+The command is idempotent: if you run it again, nothing occurs.</dd>
 
 <dt>Per-project state</dt>
-<dd>State lives beside the code, in an <code>.fuguvmrc</code> file and an
-<code>.fuguvm/</code> directory found by searching upward from the current
-directory.  Several machines can be defined per project, each with its own
-release, memory, disk and forwarded ports.</dd>
+<dd>The state is adjacent to the code, in an <code>.fuguvmrc</code> file and
+an <code>.fuguvm/</code> directory.  FuguVM finds them with a search up from
+the current directory.  A project can define several machines, each with
+its own release, memory, disk, and forwarded ports.</dd>
 
 <dt>Cached install images</dt>
-<dd>Release sets are cached under <code>~/.cache/fuguvm/</code> and served to
-the guest through a built-in proxy, so the expensive download happens once
-rather than once per machine.</dd>
+<dd>FuguVM keeps the release sets in a cache under
+<code>~/.cache/fuguvm/</code>, and a built-in proxy serves them to the
+guest.  Thus the large download occurs one time, not one time for each
+machine.</dd>
 
 <dt>Scriptable</dt>
-<dd><code>fuguvm ssh</code> runs a command in the guest and exits with its
-status; <code>fuguvm expect</code> drives the serial console with an
-<a href="https://man.openbsd.org/expect.1">expect(1)</a> script; and there is a
-distinct exit code per failure mode &mdash; not running, timed out, download
-failed.</dd>
+<dd><code>fuguvm ssh</code> runs a command in the guest and exits with the
+status of that command.  <code>fuguvm expect</code> controls the serial
+console with an
+<a href="https://man.openbsd.org/expect.1">expect(1)</a> script.  Each
+failure mode has its own exit code &mdash; not started, timeout, download
+failure.</dd>
 
-<dt>Whatever accelerator is there</dt>
-<dd>HVF on macOS, KVM on aarch64 Linux, TCG everywhere else, chosen
-automatically and overridable with <code>--emulate</code>.</dd>
+<dt>Automatic accelerator choice</dt>
+<dd>FuguVM selects HVF on macOS, KVM on aarch64 Linux, and TCG on other
+platforms.  The <code>--emulate</code> option overrides the choice.</dd>
 </dl>
 
-<h2>Where it came from</h2>
+<h2>Origin</h2>
 
-<p>FuguVM was written to run OpenHAP's integration tests on the platform they
-are about: <a href="https://man.openbsd.org/pledge.2">pledge(2)</a>,
-<a href="https://man.openbsd.org/unveil.2">unveil(2)</a>, <code>rc.d</code> and
-<code>mdnsd</code> cannot be tested anywhere else.  Nothing in it knows about
-OpenHAP; this repository is its first user.</p>
+<p>FuguVM runs the integration tests of OpenHAP on their target platform:
+tests of <a href="https://man.openbsd.org/pledge.2">pledge(2)</a>,
+<a href="https://man.openbsd.org/unveil.2">unveil(2)</a>, <code>rc.d</code>
+and <code>mdnsd</code> are possible only on OpenBSD.  FuguVM does not know
+about OpenHAP; this repository is its first user.</p>
 
-<p>It ships with the OpenHAP source but not with OpenHAP: <code>make
-install</code> does not install it, and no release package contains it.</p>
+<p>The OpenHAP source includes FuguVM, but OpenHAP does not install it:
+<code>make install</code> ignores it, and no release package has it.</p>
 
 <h2>Reference</h2>
 
-<p>Options, subcommands, exit codes and configuration keys are documented in
-the <a href="manuals.html#fuguvm">manual</a>.</p>
+<p>The <a href="manuals.html#fuguvm">manual</a> lists the options, the
+subcommands, the exit codes, and the configuration keys.</p>

--- a/web/index.body.html
+++ b/web/index.body.html
@@ -45,11 +45,11 @@ doas make install
 </code></pre>
 
 <p>After these steps, the daemon also needs a user, a configuration file,
-and an MQTT broker.  <a href="install.html">Install</a> shows each step, and
+and an MQTT broker.  <a href="install.html">Install</a> shows each step.
 <a href="manuals.html">Manuals</a> is the reference for the daemon, the
-control utility, and the configuration format &mdash; with
-<a href="manuals.html#modules">a page for each module</a> for readers of the
-source.</p>
+control utility, and the configuration format.
+There is <a href="manuals.html#modules">a page for each module</a> for
+readers of the source.</p>
 
 <h2>Sub-projects</h2>
 

--- a/web/index.body.html
+++ b/web/index.body.html
@@ -1,6 +1,6 @@
 <h1>HomeKit Accessory Protocol for OpenBSD</h1>
 
-<p>OpenHAP shows MQTT-connected Tasmota devices in Apple&rsquo;s Home app.  An
+<p>OpenHAP shows MQTT-connected Tasmota devices in the iOS Home app.  An
 iPhone pairs with <code>openhapd</code> as a HomeKit accessory;
 <code>openhapd</code> uses MQTT to control the real devices.</p>
 
@@ -28,7 +28,7 @@ primitives.</dd>
 
 <dt>Devices as configuration</dt>
 <dd>You declare the accessories in <code>openhapd.conf(5)</code>, and the
-daemon loads them at start-up.  OpenHAP supports thermostats, heaters,
+daemon loads them at startup.  OpenHAP supports thermostats, heaters,
 switches, sensors, lightbulbs, and dimmers today.</dd>
 
 <dt>Small enough to read</dt>

--- a/web/index.body.html
+++ b/web/index.body.html
@@ -1,40 +1,42 @@
 <h1>HomeKit Accessory Protocol for OpenBSD</h1>
 
-<p>OpenHAP puts MQTT-connected Tasmota devices into Apple&rsquo;s Home app.  An
-iPhone pairs with <code>openhapd</code> as if it were an accessory;
-<code>openhapd</code> speaks MQTT to the real ones.</p>
+<p>OpenHAP shows MQTT-connected Tasmota devices in Apple&rsquo;s Home app.  An
+iPhone pairs with <code>openhapd</code> as a HomeKit accessory;
+<code>openhapd</code> uses MQTT to control the real devices.</p>
 
-<p>It is written in Perl against the base system: a daemon, a configuration
-file in <code>/etc</code>, and <code>rcctl</code>.  No cloud account, and no
-separate appliance.</p>
+<p>The server is Perl code on the base system: a daemon, a configuration
+file in <code>/etc</code>, and <code>rcctl</code>.  It does not need a cloud
+account or a separate appliance.</p>
 
 <h2>Design</h2>
 
 <dl>
 <dt>Native to OpenBSD</dt>
-<dd>Base-system Perl and a short list of packages.  Runs as
-<code>_openhap</code>, starts from <code>rc.d</code>, and confines itself with
+<dd>OpenHAP uses base-system Perl and a short list of packages.  The daemon
+runs as <code>_openhap</code>, starts from <code>rc.d</code>, and limits
+itself with
 <a href="https://man.openbsd.org/pledge.2">pledge(2)</a> and
 <a href="https://man.openbsd.org/unveil.2">unveil(2)</a>.</dd>
 
 <dt>Pairing and sessions</dt>
 <dd>Pair-setup is an SRP-6a exchange over the RFC 5054 3072-bit group;
-pair-verify is X25519 with Ed25519 signatures.  Sessions are encrypted with
-ChaCha20-Poly1305 under keys from HKDF-SHA-512.  Messages are TLV8 and JSON
-over HTTP/1.1, advertised by <code>mdnsd</code>.  The SRP exchange and the
-framing are written here; the primitives come from CPAN modules.</dd>
+pair-verify is X25519 with Ed25519 signatures.  ChaCha20-Poly1305 encrypts
+the sessions with keys from HKDF-SHA-512.  The messages are TLV8 and JSON
+over HTTP/1.1, and <code>mdnsd</code> advertises the service.  This project
+supplies the SRP exchange and the framing; CPAN modules supply the
+primitives.</dd>
 
 <dt>Devices as configuration</dt>
-<dd>Accessories are declared in <code>openhapd.conf(5)</code> and loaded at
-start-up.  Thermostats, heaters, switches, sensors, lightbulbs and dimmers are
-supported today.</dd>
+<dd>You declare the accessories in <code>openhapd.conf(5)</code>, and the
+daemon loads them at start-up.  OpenHAP supports thermostats, heaters,
+switches, sensors, lightbulbs, and dimmers today.</dd>
 
 <dt>Small enough to read</dt>
-<dd>Each module has a manual page or a POD sidecar, and the tests live
-beside the source in <code>t/</code>.</dd>
+<dd>Each module has a manual page or a POD sidecar, and the tests are
+adjacent to the source in <code>t/</code>.</dd>
 </dl>
 
-<h2>Getting started</h2>
+<h2>Quick start</h2>
 
 <pre><code>git clone https://github.com/dickolsson/openhap.git
 cd openhap
@@ -42,18 +44,18 @@ make deps
 doas make install
 </code></pre>
 
-<p>That leaves a daemon that still needs a user, a configuration file and a
-running MQTT broker.  <a href="install.html">Install</a> covers all of it, and
-<a href="manuals.html">Manuals</a> is the reference for the daemon, the control
-utility and the configuration format &mdash; plus
-<a href="manuals.html#modules">a page per module</a> for anyone reading the
+<p>After these steps, the daemon also needs a user, a configuration file,
+and an MQTT broker.  <a href="install.html">Install</a> shows each step, and
+<a href="manuals.html">Manuals</a> is the reference for the daemon, the
+control utility, and the configuration format &mdash; with
+<a href="manuals.html#modules">a page for each module</a> for readers of the
 source.</p>
 
 <h2>Sub-projects</h2>
 
-<p>Two pieces grew out of OpenHAP and are documented separately, because
-neither is about HomeKit:
-<a href="fugulib.html">FuguLib</a>, the OpenBSD-style daemon utilities the
-server is built on, and <a href="fuguvm.html">FuguVM</a>, which installs and
-manages OpenBSD virtual machines under QEMU, and is used here to run the
+<p>Two parts of OpenHAP are sub-projects with their own documentation,
+because they are not related to HomeKit.
+<a href="fugulib.html">FuguLib</a> holds the OpenBSD-style daemon utilities
+that the server uses.  <a href="fuguvm.html">FuguVM</a> installs and manages
+OpenBSD virtual machines under QEMU; this project uses it to run the
 tests.</p>

--- a/web/mkindex.sh
+++ b/web/mkindex.sh
@@ -133,8 +133,9 @@ emit_group()
 cat <<'EOF'
 <h1>Manuals</h1>
 
-<p>Rendered from the same sources <code>man</code> reads on an installed
-system.  Cross-references between them are links; everything else goes to
+<p>These pages come from the same sources that <code>man</code> reads on an
+installed system.  Cross-references between these pages are links; all
+other cross-references go to
 <a href="https://man.openbsd.org/">man.openbsd.org</a>.</p>
 
 EOF


### PR DESCRIPTION
This PR makes ASD-STE100 Simplified Technical English the rule for all output and all artifacts, and rewrites the documentation set to obey it.

## Changes

- Add a critical STE instruction at the top of the root `CLAUDE.md`.
- Rewrite `README.md`, `INSTALL.md`, the 13 man pages, the 24 `.pod` sidecars, and the website text in STE: active voice, present tense, approved words, and one instruction in each sentence.
- Make the terms the same across all documents: "runs", "shows", "adjacent to", "reports if", "the iOS Home app", parallel `.Nd` and NAME lines, and third-person method descriptions.
- Add `doas` and `mdnsd` to the README quick start, the same as `INSTALL.md`.
- Update the `INSTALL.md` anchor in `t/web/site.t` to the new wording.

Technical names, commands, code examples, quoted program output, and license headers stay unchanged. The `spec/` references and the `plans/` documents stay unchanged by design.

## Verification

- `make check` passes: tidy, lint, and all test tiers, with the full website build test.
- `mandoc -Tlint` output is identical to the baseline for each man page.
- `podchecker` reports no errors for each `.pod` file.
- Two cold reviewer agents examined the set for STE violations and for cross-file consistency. All confirmed findings are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcTJeRZBmiED18vzWvBjhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcTJeRZBmiED18vzWvBjhb)_