### PR TITLE
docs: rewrite all inline code comments in ASD-STE100 Simplified Technical English

### DIFF
--- a/.github/actions/setup-perl/action.yml
+++ b/.github/actions/setup-perl/action.yml
@@ -2,10 +2,10 @@ name: "Setup Perl with dependencies"
 description:
   "Install OpenHAP's dependencies for one environment, with the CPAN tree cached"
 
-# Linux only: the bootstrap below drives apt-get, and the cache key hashes
-# deps/Linux.txt.  Every runner this repository uses is Ubuntu, x86_64 or
-# arm64; the guest's dependencies are installed inside the VM by
-# scripts/vm-provision, never here.
+# Linux only. The bootstrap below uses apt-get, and the cache key hashes
+# deps/Linux.txt. Every runner this repository uses is Ubuntu, x86_64 or
+# arm64. scripts/vm-provision installs the guest's dependencies inside
+# the VM, never here.
 
 inputs:
   dependencies:
@@ -32,9 +32,9 @@ runs:
       env:
         DEPENDENCIES: ${{ inputs.dependencies }}
       run: |
-        # Fail closed, and fail first: an unrecognised environment
-        # selects nothing, and `make deps-typo` would then either be a
-        # no-op or an error many minutes into the job.
+        # Fail closed. Fail first. An unrecognised environment selects
+        # nothing. `make deps-typo` would then be a no-op, or an error
+        # many minutes into the job.
         case "$DEPENDENCIES" in
         runtime)
           echo "target=deps" >> "$GITHUB_OUTPUT"
@@ -52,11 +52,12 @@ runs:
     - name: Install the Perl toolchain
       shell: bash
       run: |
-        # Only the bootstrap: everything else comes from
+        # Only the bootstrap. Everything else comes from
         # deps/Linux.txt via `make deps*` below, which is the single
-        # authoritative list.  cpanminus is installed from a package
-        # rather than left to scripts/deps, which would otherwise fetch
-        # and build App::cpanminus from cpanmin.us on every run.
+        # authoritative list. This step installs cpanminus from a
+        # package instead of leaving it to scripts/deps. Otherwise
+        # scripts/deps would fetch and build App::cpanminus from
+        # cpanmin.us on every run.
         sudo apt-get update
         sudo apt-get install -y \
           cpanminus \
@@ -76,41 +77,44 @@ runs:
       id: cache
       shell: bash
       run: |
-        # Computed once and read by both the restore and the save step
-        # below: the cache API rejects a write to an existing key, so two
-        # copies of this expression that drifted apart would miss on
-        # every run and then fail to store the result.
+        # This step computes the key once, and both the restore and the
+        # save step below read it. The cache API rejects a write to an
+        # existing key. Thus two copies of this expression that drift
+        # apart would miss on every run and then fail to store the
+        # result.
         #
-        # The key covers exactly what decides the contents of the tree:
-        # the environment, the interpreter, the manifest that names the
-        # modules and the script that installs them.  Nothing else - the
-        # Makefile changes for unrelated reasons every other week and
-        # hashing it would rebuild the tree from source each time.
-        # cpanfile is not read on Linux (scripts/deps reads
-        # deps/Linux.txt) and the documented workflow keeps the two in
-        # sync, so a module added to one rotates this key through the
-        # other.
+        # The key covers exactly what decides the contents of the tree.
+        # That is the environment, the interpreter, the manifest that
+        # names the modules, and the script that installs them. Nothing
+        # else goes in. The Makefile changes for unrelated reasons
+        # every other week, and a hash of it would rebuild the tree
+        # from source each time. Linux does not read cpanfile, because
+        # scripts/deps reads deps/Linux.txt. The documented workflow
+        # keeps the two in sync, so a module that you add to one
+        # rotates this key through the other.
         #
-        # The tree holds compiled XS - CryptX, Net::SSH2,
-        # Math::BigInt::GMP - so it is only valid for the perl that built
-        # it.  archname carries the OS, the CPU and the threading model,
-        # so a runner image that bumps perl, or an arm64 runner, gets its
-        # own cache rather than a tree of unloadable .so files.
+        # The tree holds compiled XS: CryptX, Net::SSH2 and
+        # Math::BigInt::GMP. Thus it is only valid for the perl that
+        # built it. archname carries the OS, the CPU and the threading
+        # model. Thus a runner image that bumps perl, or an arm64
+        # runner, gets its own cache rather than a tree of unloadable
+        # .so files.
         #
-        # To force a cold rebuild, bump the v<N> below or delete the
-        # cache from Actions -> Caches.
+        # To force a cold rebuild, bump the v<N> below. As an
+        # alternative, delete the cache from Actions -> Caches.
         perl=$(perl -MConfig -e \
           'print "perl$Config{version}-$Config{archname}"')
 
-        # Same environment only, so that a develop tree is never
-        # restored for a test run and then saved back under the test key,
-        # growing it with modules that run never needs.
+        # Same environment only. Without this rule, a test run could
+        # restore a develop tree and then save it back under the test
+        # key. The test cache would then grow with modules that the run
+        # never needs.
         prefix="openhap-cpan-v1-${{ inputs.dependencies }}-$perl-"
 
-        # Bound to its own variable first. Interpolating the expression
-        # straight after $prefix made the digest part of the variable
-        # NAME - $prefixe6c451... is unset - so the key came out empty
-        # and actions/cache rejected it.
+        # Bind the hash to its own variable first. An interpolation of
+        # the expression straight after $prefix made the digest part of
+        # the variable NAME. $prefixe6c451... is unset, so the key came
+        # out empty, and actions/cache rejected it.
         hash="${{ hashFiles('deps/Linux.txt', 'scripts/deps') }}"
 
         echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
@@ -118,33 +122,35 @@ runs:
 
     - name: Restore the CPAN tree
       id: restore
-      # local/ is the whole of what cpanm installs: scripts/deps passes
+      # local/ is the whole of what cpanm installs. scripts/deps passes
       # --local-lib=$PERL_LOCAL_LIB_ROOT, so nothing lands in the system
-      # perl.  The OS packages are deliberately not cached - apt's
-      # archive directory is root-owned, which the cache post-step could
-      # not restore into, and the win would be the download only, never
-      # dpkg's unpack.
+      # perl. The cache deliberately omits the OS packages. apt's
+      # archive directory is root-owned, and the cache post-step could
+      # not restore into it. Also, the win would be the download only,
+      # never dpkg's unpack.
       uses: actions/cache/restore@v4
       with:
         path: ${{ github.workspace }}/local
         key: ${{ steps.cache.outputs.key }}
-        # A near miss still restores a tree built by the same perl from
-        # an older manifest; the install below reconciles it and the save
-        # step stores the result under the new key.
+        # A near miss still restores a tree that the same perl built
+        # from an older manifest. The install below reconciles it, and
+        # the save step stores the result under the new key.
         restore-keys: ${{ steps.cache.outputs.prefix }}
 
     - name: Install dependencies
       shell: bash
-      # Unconditional, cache hit or not: the OS packages are not cached,
-      # and cpanm over an already-complete tree is a version check per
-      # module rather than a build.  scripts/deps is idempotent, so this
-      # is also what verifies that a restored tree is actually usable.
+      # Unconditional, cache hit or not. The cache does not hold the OS
+      # packages. Also, cpanm over an already-complete tree is a
+      # version check per module, not a build. scripts/deps is
+      # idempotent, so this step also makes sure that a restored tree
+      # is actually usable.
       run: make ${{ steps.env.outputs.target }}
 
     - name: Save the CPAN tree
-      # Only on a miss - an exact hit has nothing new to store, and the
-      # cache API rejects a write to an existing key.  No `always()`:
-      # a failed install must not be cached as the tree for this key.
+      # Only on a miss. An exact hit has nothing new to store, and the
+      # cache API rejects a write to an existing key. No `always()`
+      # here. A failed install must not become the cached tree for this
+      # key.
       if: steps.restore.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:

--- a/.github/actions/setup-perl/action.yml
+++ b/.github/actions/setup-perl/action.yml
@@ -32,7 +32,7 @@ runs:
       env:
         DEPENDENCIES: ${{ inputs.dependencies }}
       run: |
-        # Fail closed. Fail first. An unrecognised environment selects
+        # Fail closed. Fail first. An unrecognized environment selects
         # nothing. `make deps-typo` would then be a no-op, or an error
         # many minutes into the job.
         case "$DEPENDENCIES" in
@@ -53,7 +53,7 @@ runs:
       shell: bash
       run: |
         # Only the bootstrap. Everything else comes from
-        # deps/Linux.txt via `make deps*` below, which is the single
+        # deps/Linux.txt with `make deps*` below, which is the single
         # authoritative list. This step installs cpanminus from a
         # package instead of leaving it to scripts/deps. Otherwise
         # scripts/deps would fetch and build App::cpanminus from
@@ -143,7 +143,7 @@ runs:
       # packages. Also, cpanm over an already-complete tree is a
       # version check per module, not a build. scripts/deps is
       # idempotent, so this step also makes sure that a restored tree
-      # is actually usable.
+      # is usable.
       run: make ${{ steps.env.outputs.target }}
 
     - name: Save the CPAN tree

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,12 @@ name: Build
 
 on:
   workflow_run:
-    # Gate releases on the test suite, which is also what filters this
-    # workflow: workflow_run takes no paths of its own. Test declares an
-    # explicit include list of the sources a release is built from, so a
-    # merge that touches nothing on that list produces no release; the
-    # commit-count-derived tag simply skips ahead on the next one.
+    # The test suite gates releases. The same suite filters this
+    # workflow, because workflow_run takes no paths of its own. Test
+    # declares an explicit include list of the sources that go into a
+    # release. Thus a merge that touches no path on that list makes no
+    # release. The tag comes from the commit count, so it skips ahead
+    # on the next release.
     workflows: ["Test"]
     types:
       - completed

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,29 +1,29 @@
 name: Check
 
-# Explicit includes, never excludes: a path that no job reads must not be
-# able to start this workflow just because nobody remembered to exclude it.
-# The list is the union of what the three jobs below actually consume.
+# Use explicit includes, never excludes. A path that no job reads must
+# not start this workflow only because nobody excluded it. The list is
+# the union of the paths that the three jobs below read.
 on:
   push:
     branches: [main]
     paths:
-      # Perl that tidy, lint and the syntax sweep read.  bin/ and
-      # scripts/ are extensionless, so a glob over the directory is the
-      # only way to name all of it.
+      # The Perl files that tidy, lint and the syntax sweep read. The
+      # files in bin/ and scripts/ have no extension. Thus a glob over
+      # each directory is the only way to name all of them.
       - "bin/*"
       - "scripts/*"
       - "lib/**.pm"
       - ".perlcriticrc"
       - ".perltidyrc"
-      # Prettier formats every Markdown, JSON and YAML file in the tree,
-      # so this workflow has to see all of them.  The YAML glob is also
-      # what makes the workflow re-run on edits to itself and to the
+      # Prettier formats every Markdown, JSON and YAML file in the
+      # tree, so this workflow must see all of them. The YAML glob also
+      # makes the workflow run again on edits to itself and to the
       # composite action under .github/.
       - "**.md"
       - "**.json"
       - "**.yml"
       - ".prettierrc"
-      # The toolchain the jobs install and drive
+      # The toolchain that the jobs install and use
       - "Makefile"
       - "cpanfile"
       - "deps/*.txt"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -157,7 +157,7 @@ jobs:
             'scripts/vm-provision') }}
           # A key rotation still restores the miniroot and any base
           # image that fuguvm's own keying still accepts. Thus the run
-          # rebuilds only the parts that actually changed.
+          # rebuilds only the parts that changed.
           restore-keys: |
             fuguvm-v1-${{ runner.arch }}-
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,36 +1,36 @@
 name: Integration
 
 # This job boots an OpenBSD guest under TCG emulation and can run for
-# hours, so its trigger set is the narrowest in the repository: only an
-# edit that can change what runs inside the VM, or how the VM is built,
-# belongs here.  Explicit includes, never excludes - a new top-level
-# directory must not silently start costing three hours a push.
+# hours. Thus its trigger set is the narrowest in the repository. Only
+# an edit that can change what runs inside the VM, or how the VM is
+# built, belongs here. Use explicit includes, never excludes. A new
+# top-level directory must not silently cost three hours for each push.
 #
-# Everything hashed into the image cache key below also appears here.
-# That is deliberate: an input that can rotate the cache key but cannot
-# start a run would be rebuilt on the next unrelated push instead of the
-# one that changed it.
+# Every input that goes into the image cache key below also appears
+# here. That is deliberate. An input that rotates the cache key must
+# also start a run. If not, the rebuild occurs on the next unrelated
+# push, not on the push that changed the input.
 #
-# Anything left out - unit tests, docs, man pages, the website, spec/,
-# plans/ - is still reachable through workflow_dispatch and the weekly
+# This list omits unit tests, docs, man pages, the website, spec/, and
+# plans/. They stay reachable through workflow_dispatch and the weekly
 # schedule.
 on:
   push:
     branches: [main]
     paths:
-      # The daemon, library and files installed into the guest
+      # The daemon, the library, and the files that go into the guest
       - "bin/hapctl"
       - "bin/openhapd"
       - "lib/FuguLib/*.pm"
       - "lib/OpenHAP/**.pm"
       - "etc/rc.d/openhapd"
       - "share/openhap/examples/*.sample"
-      # The suite itself and the mocks it carries over
+      # The suite itself and the mocks that it carries over
       - "t/openhap/integration/*.t"
       - "t/fugulib/sandbox.t"
       - "t/lib/**.pm"
-      # The harness that installs the guest, provisions it and drives
-      # the run
+      # The harness that installs the guest, provisions it, and
+      # controls the run
       - "bin/fuguvm"
       - "lib/FuguVM/**.pm"
       - ".fuguvmrc"
@@ -42,14 +42,14 @@ on:
       - "scripts/integration"
       - "scripts/vm-provision"
       - "scripts/vm-up"
-      # Guest dependencies, and the package and install rules that put
-      # the checkout on the guest
+      # The guest dependencies, and the package and install rules that
+      # put the checkout on the guest
       - "cpanfile"
       - "deps/OpenBSD.txt"
-      # Host dependencies: QEMU, expect and telnet are what boots and
-      # drives the guest, and setup-perl hashes this file into its own
-      # cache key - so by the rule above it has to be able to start a
-      # run of its own
+      # The host dependencies. QEMU, expect and telnet boot and control
+      # the guest. Also, setup-perl hashes this file into its own cache
+      # key. Thus, by the rule above, this file must be able to start a
+      # run of its own.
       - "deps/Linux.txt"
       - "Makefile"
       - ".github/actions/setup-perl/action.yml"
@@ -83,10 +83,10 @@ on:
       - "Makefile"
       - ".github/actions/setup-perl/action.yml"
       - ".github/workflows/integration.yml"
-  # Manual runs against any branch, e.g. to test workflow changes
-  # before merging
+  # Manual runs against any branch, for example to test workflow
+  # changes before a merge
   workflow_dispatch:
-  # Weekly run so regressions surface between pushes
+  # The weekly run makes regressions show between pushes
   schedule:
     - cron: "30 5 * * 1"
 
@@ -97,11 +97,11 @@ concurrency:
 jobs:
   integration:
     name: Integration tests (OpenBSD VM)
-    # arm64 runner: the OpenBSD guest is arm64, so the VM runs without
-    # cross-architecture translation. KVM is picked up automatically by
-    # fuguvm if the runner ever exposes /dev/kvm; until then QEMU falls
-    # back to TCG software emulation, which is why the timeouts below
-    # are generous.
+    # An arm64 runner. The OpenBSD guest is arm64, so the VM runs
+    # without cross-architecture translation. fuguvm uses KVM
+    # automatically if the runner ever exposes /dev/kvm. Until then,
+    # QEMU falls back to TCG software emulation. That is why the
+    # timeouts below are generous.
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 180
 
@@ -117,34 +117,36 @@ jobs:
           dependencies: develop
 
       - name: Cache OpenBSD images and downloads
-        # `.fuguvm` is fully ephemeral: fuguvm rebuilds the state
-        # directory on every run from three things that all live in
-        # ~/.cache/fuguvm - the installed OpenBSD image, the
-        # provisioning layer snapshotted over it, and the proxy's copies
-        # of everything the installer downloaded. Nothing here depends on
-        # a previous run's state.
+        # `.fuguvm` is fully ephemeral. On every run, fuguvm rebuilds
+        # the state directory from three things that live in
+        # ~/.cache/fuguvm. They are the installed OpenBSD image, the
+        # provisioning layer that sits as a snapshot over it, and the
+        # proxy's copies of all installer downloads. Nothing here
+        # depends on the state of a previous run.
         #
-        # The proxy store is what makes a reinstall cheap rather than
-        # free: a rotated key restores the previous entry through
-        # restore-keys, so an install.exp edit re-runs the installer but
-        # reads the file sets off local disk. It is also the half of this
-        # directory that nothing bounded until `cache clear --stale`
-        # learned to prune it - see the cleanup step below.
+        # The proxy store makes a reinstall cheap rather than free.
+        # A rotated key restores the previous entry through
+        # restore-keys. Thus an install.exp edit runs the installer
+        # again, but reads the file sets from local disk. The proxy
+        # store is also the half of this directory that had no bound
+        # until `cache clear --stale` learned to prune it. See the
+        # cleanup step below.
         #
         # The key hashes every input that either fuguvm's own cache key
-        # or scripts/deps-key derives from. That is a constraint, not
-        # a courtesy: the post-step saves only on a primary-key MISS, so
-        # an input this key cannot see would rotate a cached name,
+        # or scripts/deps-key derives from. That is a constraint, not a
+        # courtesy. The post-step saves only on a primary-key MISS.
+        # Thus an input this key cannot see would rotate a cached name,
         # rebuild it, and then discard the result on every single run.
         #
-        # To force a cold-cache run (a fresh OpenBSD install from the
-        # miniroot), bump the v<N> suffix below or delete the cache from
-        # Actions -> Caches. A warm cache exists only after a green run:
-        # the post-step saves on success. On a warm run the log must show
-        # `Guest dependencies already present` rather than a re-run of
-        # `make deps` — provisioning is idempotent, so a broken cache
-        # still yields a green suite, just a slow one. Check wall clock
-        # against the job's timeout.
+        # A cold-cache run is a fresh OpenBSD install from the
+        # miniroot. To force one, bump the v<N> suffix below. As an
+        # alternative, delete the cache from Actions -> Caches. A warm
+        # cache exists only after a green run, because the post-step
+        # saves on success. On a warm run, the log must show `Guest
+        # dependencies already present`, not a new run of `make deps`.
+        # Provisioning is idempotent, so a broken cache still gives a
+        # green suite, only a slow one. Check the wall clock against
+        # the job's timeout.
         uses: actions/cache@v4
         with:
           path: ~/.cache/fuguvm
@@ -154,20 +156,21 @@ jobs:
             'deps/OpenBSD.txt', 'cpanfile', 'scripts/deps', 'scripts/deps-key',
             'scripts/vm-provision') }}
           # A key rotation still restores the miniroot and any base
-          # image fuguvm's own keying still considers valid, so only
-          # the parts that actually changed are rebuilt.
+          # image that fuguvm's own keying still accepts. Thus the run
+          # rebuilds only the parts that actually changed.
           restore-keys: |
             fuguvm-v1-${{ runner.arch }}-
 
       - name: Generate ephemeral SSH key for the VM
-        # The harness installs an authorized_keys entry on the guest and
-        # then uses key-based auth for every later `fuguvm ssh`/`scp`.
-        # Developers configure this in ~/.fuguvmrc; CI has no key, so
-        # mint a throwaway one per run. Write the public half to the
-        # GLOBAL rc (~/.fuguvmrc) rather than the project .fuguvmrc,
-        # which the cache key hashes and which must therefore stay
-        # stable. A restored image carries the previous run's key; the
-        # harness reinstalls this one over the guest's root password.
+        # The harness installs an authorized_keys entry on the guest.
+        # It then uses key-based auth for every later `fuguvm
+        # ssh`/`scp`. Developers configure this in ~/.fuguvmrc. CI has
+        # no key, so mint a throwaway one per run. Write the public
+        # half to the GLOBAL rc (~/.fuguvmrc), not to the project
+        # .fuguvmrc. The cache key hashes the project file, so that
+        # file must stay stable. A restored image carries the key of
+        # the previous run. The harness reinstalls this key over the
+        # guest's root password.
         run: |
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
           ssh-keygen -t ed25519 -N '' -C fuguvm-ci -f ~/.ssh/id_ed25519
@@ -176,20 +179,21 @@ jobs:
 
       - name: Run integration tests
         env:
-          # Expect-script step timeout and post-boot SSH wait, both far
-          # beyond the defaults to accommodate TCG emulation
+          # The expect-script step timeout and the post-boot SSH wait.
+          # Both are far above the defaults to allow for TCG emulation.
           FUGUVM_TIMEOUT: 1800
           FUGUVM_WAIT_TIMEOUT: 1800
         run: |
-          # `fuguvm ssh` authenticates via the SSH agent; load the key
-          # so the harness and the test scripts can reach the guest.
+          # `fuguvm ssh` authenticates through the SSH agent. Load the
+          # key so that the harness and the test scripts can reach the
+          # guest.
           eval "$(ssh-agent -s)"
           ssh-add ~/.ssh/id_ed25519
           make integration
 
       - name: Show VM diagnostics on failure
-        # Not plain failure(): a timeout-minutes cancellation must
-        # still show the diagnostics
+        # Not plain failure(). A timeout-minutes cancellation must
+        # still show the diagnostics.
         if: always() && !success()
         run: |
           echo "==> fuguvm status"
@@ -202,25 +206,26 @@ jobs:
 
       - name: Shut down VM and bound cache growth
         # A clean shutdown keeps the qcow2 consistent for the snapshot
-        # machinery. `fuguvm down` is internally bounded (its guest
-        # interactions are time-limited and it force-stops the QEMU
-        # process as a last resort), so it cannot hang the job even when
-        # the guest is wedged.
+        # machinery. `fuguvm down` is internally bounded. Its guest
+        # interactions have time limits, and it force-stops the QEMU
+        # process as a last resort. Thus it cannot hang the job even
+        # when the guest does not respond.
         #
-        # `cache clear --stale` prunes both halves of ~/.cache/fuguvm:
-        # the images whose key the current configuration no longer
-        # derives, and the proxy's downloads for every OpenBSD version
-        # other than the one .fuguvmrc pins. It runs before the cache
-        # post-step, so what a version bump orphans is dropped on the run
-        # that bumped it rather than uploaded forever.
+        # `cache clear --stale` prunes both halves of ~/.cache/fuguvm.
+        # It removes the images whose key the current configuration no
+        # longer derives. It also removes the proxy's downloads for
+        # every OpenBSD version other than the one .fuguvmrc pins. It
+        # runs before the cache post-step. Thus the run that bumps a
+        # version also drops what the bump orphans, instead of
+        # uploading it forever.
         #
-        # Every command here is guarded. This step is `if: always()` and
-        # `run:` blocks are `bash -e`, while the cache post-step is
-        # `post-if: success()` - so a non-zero exit here would discard
-        # the cache this run just populated. No cleanup command may
-        # determine job status. The prune stays unconditional rather
-        # than gated on success, because a red run is exactly when the
-        # cache grows.
+        # Every command here is guarded. This step is `if: always()`,
+        # and `run:` blocks are `bash -e`, while the cache post-step is
+        # `post-if: success()`. Thus a non-zero exit here would discard
+        # the cache that this run just populated. No cleanup command
+        # may decide the job status. The prune stays unconditional, not
+        # gated on success, because a red run is exactly when the cache
+        # grows.
         if: always()
         run: |
           ./bin/fuguvm down || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test
 
 # Use explicit includes, never excludes. Only what `make test` and
-# `make spec-coverage` actually load may start a run. Note that the
+# `make spec-coverage` load may start a run. Note that the
 # Build workflow releases from a successful run of this one. Thus a
 # path that this list omits is also a change that never ships.
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,29 +1,31 @@
 name: Test
 
-# Explicit includes, never excludes: only what `make test` and
-# `make spec-coverage` actually load may start a run.  Note that the
-# Build workflow releases off a successful run of this one, so a path
-# missing here is also a change that never ships.
+# Use explicit includes, never excludes. Only what `make test` and
+# `make spec-coverage` actually load may start a run. Note that the
+# Build workflow releases from a successful run of this one. Thus a
+# path that this list omits is also a change that never ships.
 on:
   push:
     branches: [main]
     paths:
-      # Everything the suite loads
+      # The files that the suite loads
       - "bin/*"
       - "lib/**.pm"
-      # Every *.t in the tree, not just the four directories `make test`
-      # proves: spec-coverage scans all of t/ for spec citations, so a
-      # stale citation anywhere has to be able to fail this workflow.
+      # Every *.t in the tree, not only the four directories that
+      # `make test` proves. spec-coverage scans all of t/ for spec
+      # citations. Thus a stale citation anywhere must be able to fail
+      # this workflow.
       - "t/**.t"
       - "t/lib/**.pm"
       # The other half of the spec-coverage cross-check
       - "spec/*.md"
-      # The suite runs scripts as subprocesses - spec-coverage, deps and
-      # deps-key against fixtures, and scripts.t over the directory as a
-      # whole - so it has to see all of it.  A glob because scripts/ is
-      # extensionless, same as bin/ above.
+      # The suite runs scripts as subprocesses: spec-coverage, deps and
+      # deps-key against fixtures, and scripts.t over the directory as
+      # a whole. Thus the workflow must see all of scripts/. A glob is
+      # necessary because the files in scripts/ have no extension, the
+      # same as bin/ above.
       - "scripts/*"
-      # The toolchain and dependency set the job installs
+      # The toolchain and the dependency set that the job installs
       - "Makefile"
       - "cpanfile"
       - "deps/*.txt"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,20 +1,21 @@
 name: Website
 
-# Explicit includes, never excludes: the site is rendered from a known
-# set of sources, so anything outside that set cannot change the build.
-# The published site is derived entirely from these paths, which is what
-# makes it safe for a push to main to skip the deploy job below.
+# Use explicit includes, never excludes. The build renders the site
+# from a known set of sources, so no path outside that set can change
+# the build. The published site derives fully from these paths. That is
+# what makes it safe for a push to main to skip the deploy job below.
 on:
   push:
     branches: [main]
     paths:
-      # Hand-written pages, shared chrome, assets and the two renderers
+      # The hand-written pages, the shared chrome, the assets, and the
+      # two renderers
       - "web/*.html"
       - "web/*.css"
       - "web/*.sh"
       - "web/CNAME"
       - "web/robots.txt"
-      # Everything the build renders into a page
+      # The files that the build renders into pages
       - "man/**.1"
       - "man/**.3p"
       - "man/**.5"
@@ -43,11 +44,12 @@ on:
       - "t/web/*.t"
       - ".github/workflows/web.yml"
 
-# Deploying needs more than this; it is granted on the deploy job alone
+# A deploy needs more permissions than this. The deploy job alone
+# receives them.
 permissions:
   contents: read
 
-# One deploy at a time, and never cancel one that is already running
+# Run one deploy at a time. Never cancel a deploy that already runs.
 concurrency:
   group: pages
   cancel-in-progress: false

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -6,7 +6,7 @@ severity = 4
 # OpenBSD style allows these constructs
 #-----------------------------------------------------------------------------
 
-# File permissions are intentionally octal (0644, 0600, etc.)
+# File permissions are octal by design (for example 0644 and 0600)
 [-ValuesAndExpressions::ProhibitLeadingZeros]
 
 # use constant is the OpenBSD way for constants

--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,9 +1,9 @@
 # Perl::Critic configuration for OpenHAP
-# Following OpenBSD pkg_add style (see style.pod)
+# The rules follow OpenBSD pkg_add style. See style.pod.
 severity = 4
 
 #-----------------------------------------------------------------------------
-# Allowed by OpenBSD style
+# OpenBSD style allows these constructs
 #-----------------------------------------------------------------------------
 
 # File permissions are intentionally octal (0644, 0600, etc.)
@@ -15,46 +15,46 @@ severity = 4
 # Multiple packages per file is fine for related classes
 [-Modules::ProhibitMultiplePackages]
 
-# our @ISA is preferred over 'use parent' in OpenBSD style
+# OpenBSD style prefers our @ISA over 'use parent'
 [-ClassHierarchies::ProhibitExplicitISA]
 
-# File handles need to stay open during flock operations
+# File handles must stay open during flock operations
 [-InputOutput::RequireBriefOpen]
 
-# Modern Perl signatures handle prototypes differently
+# Modern Perl signatures use the prototype syntax in a different way
 [-Subroutines::ProhibitSubroutinePrototypes]
 
 # Postfix if/unless is fine for simple statements
 [-ControlStructures::ProhibitPostfixControls]
 
-# Empty parentheses on method calls without args is discouraged
-# in OpenBSD style: $obj->method not $obj->method()
+# OpenBSD style discourages empty parentheses on method calls
+# without args: $obj->method not $obj->method()
 [-CodeLayout::ProhibitParensWithBuiltins]
 
 #-----------------------------------------------------------------------------
-# Relaxed for practical reasons
+# The configuration relaxes these rules for practical reasons
 #-----------------------------------------------------------------------------
 
-# Void subroutines don't need explicit return statements
+# Void subroutines do not need explicit return statements
 [-Subroutines::RequireFinalReturn]
 
 # Allow unless for simple conditions
 [-ControlStructures::ProhibitUnlessBlocks]
 
-# Regex can use modifiers without /x for simple patterns
+# A regex can use modifiers without /x for simple patterns
 [-RegularExpressions::RequireExtendedFormatting]
 
 # Magic numbers are acceptable in context
 [-ValuesAndExpressions::ProhibitMagicNumbers]
 
 #-----------------------------------------------------------------------------
-# Tabs are required (8-char tabs per style(9))
+# style(9) requires tabs of 8 characters
 #-----------------------------------------------------------------------------
 [CodeLayout::ProhibitHardTabs]
 allow_leading_tabs = 1
 
 #-----------------------------------------------------------------------------
-# POD documentation - separate .pod files are acceptable
+# POD documentation. Separate .pod files are acceptable.
 #-----------------------------------------------------------------------------
 [-Documentation::RequirePodSections]
 [-Documentation::RequirePodAtEnd]

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,7 +1,7 @@
 # Perltidy configuration for OpenHAP
-# Following OpenBSD pkg_add style (see style.pod)
+# The settings follow OpenBSD pkg_add style. See style.pod.
 
-# Indentation: 8 character tabs as per style(9)
+# Indentation: 8-character tabs, as style(9) requires
 --indent-columns=8
 --tabs
 --entab-leading-whitespace=8
@@ -12,7 +12,7 @@
 # Opening brace on its own line for subroutines
 --opening-sub-brace-on-new-line
 
-# Opening brace on same line for control structures (default with -sbl)
+# Opening brace on the same line for control structures (default with -sbl)
 --noopening-brace-on-new-line
 
 # No cuddled else
@@ -29,10 +29,10 @@
 # Break before operators (not after)
 --want-break-before="&& || and or"
 
-# Don't add extra blank lines
+# Do not add extra blank lines
 --maximum-consecutive-blank-lines=1
 
-# Keep formatting of hash arrows aligned
+# Keep the formatting of the hash arrows aligned
 --valign-side-comments
 --valign-block-comments
 

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ LOWDOWN			?= lowdown
 MANDOC			?= mandoc
 POD2MAN			?= pod2man
 PERLTIDY		= perl -MPerl::Tidy -e 'Perl::Tidy::perltidy()'
-# Pinned so local runs and CI agree on formatting
+# Pin the version so that local runs and CI agree on formatting
 PRETTIER		= npx prettier@3.9.6
 
 # Every Perl source in the tree: modules by extension, executables by
-# shebang.  bin/ and scripts/ carry no extension - a tool's name does not
-# encode its language - so the shebang is what identifies them, which is
-# also how Perl::Critic selects files.  lint and tidy therefore cover the
-# same set, with no list to keep true.
+# shebang.  Files in bin/ and scripts/ carry no extension, because a
+# tool's name does not encode its language.  Thus the shebang identifies
+# them.  Perl::Critic selects files the same way.  lint and tidy
+# therefore cover the same set, with no list to keep true.
 PERLSRC			= find lib bin scripts -type f \( -name '*.pm' -o \
 			  -exec sh -c 'head -1 "$$1" | grep -q "^\#!.*perl"' \
 			  _ {} \; \) -print
@@ -43,7 +43,7 @@ FTP				= scripts/ftp
 DEPS			= scripts/deps
 
 # Man pages.  FuguLib sources drop the FuguLib:: prefix because a colon
-# cannot appear in a make target; install-man puts it back.
+# cannot appear in a make target.  install-man puts it back.
 MAN1			= man/fuguvm/fuguvm.1
 MAN3P			= man/fugulib/Daemon.3p man/fugulib/Imsg.3p \
 			  man/fugulib/Log.3p man/fugulib/MDNS.3p \
@@ -62,15 +62,17 @@ WEBOUT			?= web/build
 WEBMAN			= $(WEBOUT)/.man
 MKPAGE			= web/mkpage.sh
 MKINDEX			= web/mkindex.sh
-# The .pod sidecars are found, never listed: one added without a Makefile
-# line would otherwise never be published, and an exclusion list would be
-# one more thing to keep true.  LC_ALL=C so the order of the index does
-# not depend on the builder's locale.
+# The Makefile finds the .pod sidecars and never lists them.  Otherwise
+# a sidecar without its own Makefile line would never reach the site.
+# An exclusion list would be one more thing to keep true.  LC_ALL=C
+# makes sure the order of the index does not depend on the builder's
+# locale.
 FINDPOD			= find lib -name '*.pod' | LC_ALL=C sort
-# mandoc resolves .Xr against the working directory: a page named %N.%S
-# there becomes a local link, anything else goes to man.openbsd.org.
-# The './' matters: a module page is FuguLib::Daemon.3p.html, and a relative
-# URL whose first segment holds a colon is read as a scheme instead.
+# mandoc resolves .Xr against the working directory.  A page named %N.%S
+# there becomes a local link.  Anything else goes to man.openbsd.org.
+# The './' matters.  A module page is FuguLib::Daemon.3p.html.  The
+# browser reads a relative URL whose first segment holds a colon as a
+# scheme instead.
 # -I os= pins the footer so the site does not vary with the build host.
 MANHTML			= -Thtml -I os=OpenBSD \
 			  -O fragment,man='./%N.%S.html;https://man.openbsd.org/%N.%S'
@@ -112,8 +114,8 @@ install: install-man
 	install -m 644 lib/OpenHAP/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/
 	install -m 644 lib/OpenHAP/Tasmota/*.pm $(DESTDIR)$(LIBDIR)/OpenHAP/Tasmota/
 	install -m 644 lib/OpenHAP/Tasmota/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/Tasmota/
-	# Test helper modules ship only in the packaged tree; the glob
-	# loops handle zero, one, or many matches without stderr noise
+	# The test helper modules ship only in the packaged tree.  The
+	# glob loops accept zero, one, or many matches without stderr noise
 	for f in lib/OpenHAP/Test/*.pm lib/OpenHAP/Test/*.pod; do \
 		[ -e "$$f" ] || continue; \
 		install -m 644 "$$f" $(DESTDIR)$(LIBDIR)/OpenHAP/Test/; \
@@ -122,7 +124,7 @@ install: install-man
 		[ -e "$$f" ] || continue; \
 		install -m 644 "$$f" $(DESTDIR)$(LIBDIR)/OpenHAP/Test/Controller/; \
 	done
-	# FuguLib's API is documented in man3p, not in sidecars
+	# FuguLib's API documentation lives in man3p, not in sidecars
 	install -m 644 lib/FuguLib/*.pm $(DESTDIR)$(LIBDIR)/FuguLib/
 	# Install rc.d script
 	install -d $(DESTDIR)$(SYSCONFDIR)/rc.d
@@ -138,8 +140,8 @@ install-man:
 	install -d $(DESTDIR)$(MANDIR)/man3p
 	install -d $(DESTDIR)$(MANDIR)/man5
 	install -d $(DESTDIR)$(MANDIR)/man8
-	# The rename cannot be a glob: 'man FuguLib::Daemon' looks for a
-	# file of that name, which make cannot have as a target
+	# The rename cannot be a glob.  'man FuguLib::Daemon' looks for a
+	# file of that name.  make cannot have that name as a target
 	for f in $(MAN3P); do \
 		install -m 644 "$$f" \
 		    "$(DESTDIR)$(MANDIR)/man3p/FuguLib::$${f##*/}"; \
@@ -251,7 +253,7 @@ uninstall:
 	rm -f $(DESTDIR)$(SYSCONFDIR)/rc.d/openhapd
 	# Remove example configuration
 	rm -f $(DESTDIR)$(SYSCONFDIR)/examples/openhapd.conf
-	# Note: /etc/openhapd.conf and /var/db/openhapd are preserved
+	# Note: the uninstall keeps /etc/openhapd.conf and /var/db/openhapd
 
 upgrade:
 	@echo "==> Downloading $(TARBALL)"
@@ -274,9 +276,9 @@ web:
 	    { echo "$(POD2MAN) not found; it ships with Perl" >&2; exit 1; }
 	# A malformed page must fail the build, not render badly
 	$(MANDOC) -Tlint -W warning $(MAN1) $(MAN3P) $(MAN5) $(MAN8)
-	# Every mdoc source in one directory, so mandoc can tell a local
-	# cross-reference from one that belongs on man.openbsd.org.  The
-	# FuguLib pages are staged under the name .Xr refers to them by.
+	# Put every mdoc source in one directory.  Then mandoc can tell a
+	# local cross-reference from one that belongs on man.openbsd.org.
+	# Stage the FuguLib pages under the name that .Xr refers to them by.
 	mkdir -p $(WEBMAN)
 	cp $(MAN1) $(MAN5) $(MAN8) $(WEBMAN)/
 	for f in $(MAN3P); do \
@@ -284,8 +286,8 @@ web:
 	done
 	cp web/style.css $(WEBOUT)/style.css
 	cp web/robots.txt $(WEBOUT)/robots.txt
-	# The custom domain is a repository setting, but the deploy artifact
-	# carries it too so a rebuild can never drop it
+	# The custom domain is a repository setting.  The deploy artifact
+	# carries it too.  Thus a rebuild can never drop it
 	cp web/CNAME $(WEBOUT)/CNAME
 	$(MKPAGE) 'HomeKit Accessory Protocol for OpenBSD' \
 	    < web/index.body.html > $(WEBOUT)/index.html
@@ -309,10 +311,10 @@ web:
 		( cd $(WEBMAN) && $(MANDOC) $(MANHTML) "$$n.3p" ) | \
 		    $(MKPAGE) "$$n(3p)" > "$(WEBOUT)/$$n.3p.html"; \
 	done
-	# One page per .pod sidecar.  --name, --center and --release are
-	# given so the chrome matches the mdoc pages; the date comes from
-	# the checkout rather than from file mtimes, which git does not
-	# preserve.
+	# One page per .pod sidecar.  The recipe gives --name, --center
+	# and --release so the chrome matches the mdoc pages.  The date
+	# comes from the checkout, not from file mtimes.  git does not
+	# preserve mtimes.
 	d=`git log -1 --format=%cs 2>/dev/null || date +%F`; \
 	$(FINDPOD) | while read -r p; do \
 		n="$${p#lib/}"; n="$${n%.pod}"; \

--- a/bin/hapctl
+++ b/bin/hapctl
@@ -34,7 +34,7 @@ else {
 }
 
 # cmd_check():
-#	Validate configuration file syntax.
+#	Validate the configuration file syntax.
 sub cmd_check()
 {
 	my $config = OpenHAP::Config->new( file => $config_file );
@@ -53,7 +53,7 @@ sub cmd_check()
 }
 
 # cmd_status():
-#	Show daemon status and pairing information.
+#	Show the daemon status and the pairing information.
 sub cmd_status()
 {
 	my $pidfile = '/var/run/openhapd.pid';
@@ -66,7 +66,7 @@ sub cmd_status()
 		print "openhapd is not running\n";
 	}
 
-	# Check pairing status from storage
+	# Check the pairing status from storage
 	my $db_path = get_db_path();
 	if ( -d $db_path ) {
 		my $storage = OpenHAP::Storage->new( path => $db_path );
@@ -93,7 +93,7 @@ sub cmd_status()
 }
 
 # cmd_devices():
-#	List configured devices from configuration file.
+#	List the configured devices from the configuration file.
 sub cmd_devices()
 {
 	my $config = OpenHAP::Config->new( file => $config_file );
@@ -131,7 +131,7 @@ sub cmd_devices()
 }
 
 # get_db_path():
-#	Get database path from config or use default.
+#	Get the database path from the config, or use the default.
 sub get_db_path()
 {
 	my $config = eval {

--- a/bin/openhapd
+++ b/bin/openhapd
@@ -212,7 +212,7 @@ eval { require Net::MQTT::Simple; 1 };
 
 # Steps 2 and 3: OpenHAP::Daemon->unveil_paths assembles the
 # inventory with its required/optional dispositions. Storage's
-# make_path already created $db_path via HAP->new. Thus a $db_path
+# make_path already created $db_path through HAP->new. Thus a $db_path
 # that is still missing is a hard failure. That failure is correct.
 FuguLib::Sandbox->unveil(
 	paths => [

--- a/bin/openhapd
+++ b/bin/openhapd
@@ -28,7 +28,7 @@ GetOptions(
 	'h|help'       => \&usage,
 ) or usage();
 
-# Load configuration
+# Load the configuration
 my $config = OpenHAP::Config->new( file => $config_file );
 $config->load() if -f $config_file;
 
@@ -37,18 +37,19 @@ if ($check_config) {
 	exit 0;
 }
 
-# Daemonize first, before initializing logging
-# This ensures syslog connection is opened in the child process
+# Daemonize first, before the log setup. This makes sure that the
+# child process opens the syslog connection.
 if ( !$foreground ) {
 	OpenHAP::Daemon->daemonize('/var/log/openhapd.log');
 }
 
-# Initialize logging after daemonizing
+# Set up logging after the daemonize step
 my $log_level    = $config->get( 'log_level',    'info' );
 my $log_facility = $config->get( 'log_facility', 'daemon' );
 my $log_mode     = $foreground ? 'stderr' : 'syslog';
 
-# Create logger and set as package variable for all OpenHAP modules
+# Create the logger. Set it as the package variable for all OpenHAP
+# modules.
 $OpenHAP::logger = FuguLib::Log->new(
 	mode     => $log_mode,
 	ident    => 'openhapd',
@@ -58,13 +59,13 @@ $OpenHAP::logger = FuguLib::Log->new(
 
 $OpenHAP::logger->info('OpenHAP daemon initializing');
 
-# Get HAP settings
+# Get the HAP settings
 my $hap_name = $config->get( 'hap_name', 'OpenHAP Bridge' );
 my $hap_port = $config->get( 'hap_port', 51827 );
 my $hap_pin  = $config->get( 'hap_pin',  '1995-1018' );
 my $db_path  = $config->get( 'db_path',  '/var/db/openhapd' );
 
-# Create HAP server
+# Create the HAP server
 my $hap = OpenHAP::HAP->new(
 	port         => $hap_port,
 	pin          => $hap_pin,
@@ -72,7 +73,7 @@ my $hap = OpenHAP::HAP->new(
 	storage_path => $db_path,
 );
 
-# Initialize MQTT client
+# Set up the MQTT client
 my $mqtt_host = $config->get( 'mqtt_host', '127.0.0.1' );
 my $mqtt_port = $config->get( 'mqtt_port', 1883 );
 my $mqtt_user = $config->get('mqtt_user');
@@ -85,7 +86,7 @@ my $mqtt = OpenHAP::MQTT->new(
 	password => $mqtt_pass,
 );
 
-# Try to connect to MQTT with timeout
+# Try to connect to MQTT with a timeout
 if ( $mqtt->mqtt_connect(5) ) {
 	$OpenHAP::logger->info( 'Connected to MQTT broker at %s:%d',
 		$mqtt_host, $mqtt_port );
@@ -94,29 +95,29 @@ if ( $mqtt->mqtt_connect(5) ) {
 else {
 	$OpenHAP::logger->warning(
 		'MQTT broker not available, will retry in background');
-	$hap->set_mqtt_client($mqtt);    # Set client anyway for reconnection
+	$hap->set_mqtt_client($mqtt);    # Set it anyway for reconnection
 }
 
-# Load devices from configuration
+# Load the devices from the configuration
 my $loader = OpenHAP::DeviceLoader->new();
 $loader->load_devices( $config, $hap, $mqtt );
 
 # Bump c# if the accessory database changed since the last run
 $hap->update_config_number();
 
-# Create the mDNS handle (connection and publish happen after the
-# privilege drop); the HAP server re-advertises the TXT record on
-# pairing changes
+# Create the mDNS handle. The connect and publish steps happen after
+# the privilege drop. The HAP server advertises the TXT record again
+# on pairing changes.
 my $mdns = FuguLib::MDNS->new;
 $hap->set_mdns($mdns);
 
-# Drop privileges before talking to mdnsd, so the daemon opens and
-# holds the control socket as _openhap - the held socket is the
-# advertisement's lifetime, and it must not be a root fd
+# Drop privileges before the daemon talks to mdnsd. Then the daemon
+# opens and holds the control socket as _openhap. The held socket is
+# the lifetime of the advertisement. It must not be a root fd.
 if ( $> == 0 ) {
 
-	# Ensure db_path is owned by _openhap before dropping privileges
-	# so pairings and device state stay writable
+	# Make sure that _openhap owns db_path before the privilege
+	# drop. Then pairings and device state stay writable.
 	my ( $uid, $gid ) = ( getpwnam('_openhap') )[ 2, 3 ];
 	if ( defined $uid && -d $db_path ) {
 		chown $uid, $gid, $db_path
@@ -142,8 +143,9 @@ if ( $> == 0 ) {
 	use FuguLib::Privdrop;
 	FuguLib::Privdrop->drop_privileges( user => '_openhap' );
 
-	# Reinitialize logging after dropping privileges
-	# The syslog connection opened as root needs to be reopened as _openhap
+	# Set up logging again after the privilege drop. The process
+	# opened the syslog connection as root. It must open the
+	# connection again as _openhap.
 	$OpenHAP::logger = undef;
 	$OpenHAP::logger = FuguLib::Log->new(
 		mode     => $log_mode,
@@ -156,9 +158,9 @@ if ( $> == 0 ) {
 }
 
 # Publish the mDNS advertisement after the privilege drop. The daemon
-# speaks the mdnsd control protocol directly (spec/MDNS-Control.md) and
-# keeps the socket open: closing it is what withdraws the service. A
-# missing mdnsd degrades discovery, never HAP service.
+# uses the mdnsd control protocol directly (spec/MDNS-Control.md) and
+# keeps the socket open. A close of the socket withdraws the service.
+# A missing mdnsd degrades discovery. It never degrades HAP service.
 if ( $mdns->connect ) {
 	if (
 		$mdns->publish_service(
@@ -186,30 +188,32 @@ else {
 		$mdns->error // 'unknown' );
 }
 
-# Restrict the process for good; FuguLib::Sandbox is a no-op off
-# OpenBSD. Four steps whose order is load-bearing, all after the
-# privilege drop (unveil only removes reachability, so applying it as
-# _openhap keeps the root-only chown loop above working):
+# Restrict the process for good. FuguLib::Sandbox is a no-op off
+# OpenBSD. Four steps follow, and their order is load-bearing. All of
+# them come after the privilege drop. unveil only removes
+# reachability. Thus an unveil done as _openhap keeps the root-only
+# chown loop above working:
 #
-#	1. resolve the lazy load - it reads from the library tree
+#	1. resolve the lazy load, which reads from the library tree
 #	2. unveil the filesystem view
 #	3. lock the view
 #	4. pledge the syscall surface
 #
-# Step 1: Net::MQTT::Simple is pure Perl, so this is not about
-# prot_exec - it is about its transitive dependencies (sockets, and
-# whatever getprotobyname touches) being resolved while @INC is still
-# fully reachable. It stays optional: it is the only cpan runtime
-# dependency, and openhapd keeps serving HomeKit without it, so an
-# unguarded require would turn a missing optional dependency into a
-# startup failure. If a future change introduces another lazily-loaded
-# module, it belongs here.
+# Step 1: Net::MQTT::Simple is pure Perl. Thus this step is not about
+# prot_exec. The step resolves the transitive dependencies of the
+# module while @INC is still fully reachable. Those dependencies are
+# sockets, and whatever getprotobyname touches. The module stays
+# optional. It is the only cpan runtime dependency, and openhapd
+# keeps serving HomeKit without it. Thus an unguarded require would
+# turn a missing optional dependency into a startup failure. If a
+# future change introduces another lazily-loaded module, it belongs
+# here.
 eval { require Net::MQTT::Simple; 1 };
 
-# Steps 2 and 3: the inventory (with its required/optional
-# dispositions) is assembled by OpenHAP::Daemon->unveil_paths;
-# Storage's make_path already created $db_path via HAP->new, so a
-# $db_path that is still missing is a hard failure, and correctly so
+# Steps 2 and 3: OpenHAP::Daemon->unveil_paths assembles the
+# inventory with its required/optional dispositions. Storage's
+# make_path already created $db_path via HAP->new. Thus a $db_path
+# that is still missing is a hard failure. That failure is correct.
 FuguLib::Sandbox->unveil(
 	paths => [
 		OpenHAP::Daemon->unveil_paths(
@@ -225,8 +229,8 @@ FuguLib::Sandbox->unveil(
 );
 FuguLib::Sandbox->unveil_lock;
 
-# Step 4: one promise set, applied once, before any network input is
-# handled:
+# Step 4: apply one promise set once, before the daemon reads any
+# network input:
 #
 #	stdio	always
 #	rpath	/dev/urandom (Crypto), Storage reads, lazy require
@@ -236,14 +240,14 @@ FuguLib::Sandbox->unveil_lock;
 #	flock	Storage locking
 #	inet	the HAP listener, MQTT connects and reconnects
 #	dns	resolving mqtt_host when it is a name
-#	unix	reconnecting to mdnsd: update_txt withdraws and
-#		republishes over a fresh control socket, so socket(2)
-#		and connect(2) on the AF_UNIX path happen after this
-#		point (spec/MDNS-Control.md §8)
+#	unix	reconnecting to mdnsd. update_txt withdraws and
+#		publishes again over a fresh control socket. Thus
+#		socket(2) and connect(2) on the AF_UNIX path happen
+#		after this point (spec/MDNS-Control.md §8)
 #
-# proc, exec and prot_exec are deliberately absent: the daemon spawns
-# nothing, and every shared object is loaded by a compile-time use
-# before this line.
+# proc, exec and prot_exec are deliberately absent. The daemon spawns
+# nothing. A compile-time use loads every shared object before this
+# line.
 my $promises = 'stdio rpath wpath cpath fattr flock inet dns unix';
 FuguLib::Sandbox->pledge( promises => $promises );
 $OpenHAP::logger->info( 'Pledged: %s', $promises )
@@ -254,7 +258,7 @@ if ( !$hap->is_paired() ) {
 		$hap_pin );
 }
 
-# Setup signal handlers for graceful shutdown
+# Set up the signal handlers for a graceful shutdown
 my $sig = FuguLib::Signal->new;
 $sig->add_cleanup(
 	sub ($signal) {
@@ -262,15 +266,15 @@ $sig->add_cleanup(
 			'Received signal %s, shutting down gracefully',
 			$signal );
 
-		# Closing the mdnsd control socket withdraws the
+		# A close of the mdnsd control socket withdraws the
 		# advertisement
 		$mdns->withdraw;
 
-		$OpenHAP::logger = undef;    # Close logger
+		$OpenHAP::logger = undef;    # Close the logger
 	} );
 $sig->setup_graceful_exit( 'INT', 'TERM', 'HUP' );
 
-# Run server
+# Run the server
 $OpenHAP::logger->info('Starting OpenHAP server');
 $hap->run();
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
-# NOTE: Production deployments should use deps/*.txt with 'make deps'
-# This file is maintained for development convenience and carton compatibility
+# NOTE: For production deployments, use deps/*.txt with 'make deps'.
+# This file exists for development convenience and carton compatibility.
 
-# Crypto dependencies required for HAP protocol
+# Crypto dependencies for the HAP protocol
 requires 'Crypt::Ed25519';
 requires 'Crypt::Curve25519';
 requires 'CryptX';
@@ -9,9 +9,9 @@ requires 'CryptX';
 # JSON parsing
 requires 'JSON::XS';
 
-# GMP backend for Math::BigInt: SRP does 3072-bit modular exponentiation,
-# which is impractically slow in the pure-Perl backend. Math::BigInt loads
-# this automatically when present.
+# GMP backend for Math::BigInt. SRP does 3072-bit modular exponentiation.
+# That operation is impractically slow in the pure-Perl backend.
+# Math::BigInt loads this backend automatically when present.
 requires 'Math::BigInt::GMP';
 
 # MQTT client for device integration

--- a/etc/rc.d/openhapd
+++ b/etc/rc.d/openhapd
@@ -5,7 +5,8 @@
 
 daemon="/usr/local/bin/openhapd"
 daemon_flags="-c /etc/openhapd.conf"
-# Note: daemon starts as root and drops to _openhap after privileged operations
+# Note: the daemon starts as root. It drops to _openhap after the
+# privileged operations.
 
 . /etc/rc.d/rc.subr
 

--- a/lib/FuguLib/Daemon.pm
+++ b/lib/FuguLib/Daemon.pm
@@ -22,13 +22,13 @@ package FuguLib::Daemon;
 use POSIX qw(setsid);
 
 # $class->daemonize(%args):
-#	Fork into background, detach from terminal, and redirect
-#	standard file descriptors. Returns in child process only.
-#	Parent process exits successfully.
+#	Fork into the background. Detach from the terminal. Redirect
+#	the standard file descriptors. The method returns in the child
+#	process only. The parent process exits successfully.
 #
 #	%args:
-#		logfile => $path  # Where to redirect stdout/stderr (default: /dev/null)
-#		on_fork => sub($) # Callback after fork, receives PID in parent
+#		logfile => $path  # Target of stdout/stderr (default: /dev/null)
+#		on_fork => sub($) # Runs in the parent after the fork, with the PID
 sub daemonize ( $class, %args )
 {
 	my $logfile = $args{logfile} // '/dev/null';
@@ -50,7 +50,7 @@ sub daemonize ( $class, %args )
 	$DB::inhibit_exit = 0;
 	setsid() or die "Cannot start new session: $!";
 
-	# Redirect standard file descriptors
+	# Redirect the standard file descriptors
 	open STDIN,  '<',  '/dev/null' or die "Cannot read /dev/null: $!";
 	open STDOUT, '>>', $logfile    or die "Cannot write to $logfile: $!";
 	open STDERR, '>&', \*STDOUT    or die "Cannot dup STDOUT: $!";

--- a/lib/FuguLib/Imsg.pm
+++ b/lib/FuguLib/Imsg.pm
@@ -24,14 +24,16 @@ use IO::Select;
 use Time::HiRes qw(time);
 
 # FuguLib::Imsg - the base-system imsg(3) framing over a connected
-# stream socket: a fixed native-endian header followed by a payload.
-# Pure serialisation; the module never opens or names a socket itself,
-# and never logs - callers decide what an error means.
+# stream socket. Each message is a fixed native-endian header followed
+# by a payload. The module does serialisation only. It never opens or
+# names a socket itself, and it never logs. The callers decide what an
+# error means.
 
-# Header and size constants per spec/MDNS-Imsg.md §1-§2: four native
-# uint32 fields (type, len, peerid, pid), len counts the whole message,
-# MAX_IMSGSIZE bounds it. The field order and widths are pinned by the
-# HEADER_TEMPLATE pack template; change them only against the spec.
+# Header and size constants per spec/MDNS-Imsg.md §1-§2. The header
+# has four native uint32 fields: type, len, peerid, pid. The len field
+# counts the whole message, and MAX_IMSGSIZE bounds it. The
+# HEADER_TEMPLATE pack template pins the field order and widths.
+# Change them only against the spec.
 use constant {
 	HEADER_SIZE     => 16,
 	HEADER_TEMPLATE => 'L4',    # type, len, peerid, pid; native order
@@ -39,14 +41,14 @@ use constant {
 };
 use constant MAX_PAYLOAD => MAX_IMSGSIZE - HEADER_SIZE;
 
-# The high bit of len marks fd-passing messages [MDNS-Imsg §2]; the
-# protocols this module serves never set it, but a receiver must mask
-# it off before trusting the length.
+# The high bit of len marks fd-passing messages [MDNS-Imsg §2]. The
+# protocols this module serves never set it. But a receiver must mask
+# it off before it trusts the length.
 use constant FD_MARK => 0x80000000;
 
 # FuguLib::Imsg->new(%args):
 #	fh => $fh	connected stream socket (required)
-#	Framing object over an already-connected handle.
+#	Make a framing object over an already-connected handle.
 sub new ( $class, %args )
 {
 	my $fh = $args{fh} or die 'fh parameter required';
@@ -60,15 +62,17 @@ sub new ( $class, %args )
 }
 
 # _encode_header($type, $len, $peerid, $pid):
-#	Encode one header [MDNS-Imsg §1]. Internal seam so tests can
-#	assert the encoded bytes without scraping a socketpair.
+#	Encode one header [MDNS-Imsg §1]. This internal seam lets the
+#	tests assert the encoded bytes. The tests do not have to
+#	scrape a socketpair.
 sub _encode_header ( $type, $len, $peerid, $pid )
 {
 	return pack( HEADER_TEMPLATE, $type, $len, $peerid, $pid );
 }
 
 # _decode_header($bytes):
-#	Decode one header; returns ($type, $len, $peerid, $pid).
+#	Decode one header. The function returns ($type, $len, $peerid,
+#	$pid).
 sub _decode_header ($bytes)
 {
 	return unpack( HEADER_TEMPLATE, $bytes );
@@ -77,10 +81,10 @@ sub _decode_header ($bytes)
 # $self->send(%args):
 #	type => $n	message type (required)
 #	data => $bytes	payload (default empty)
-#	Frame and write one message. Returns 1 on success, undef with
-#	$! set on an oversized payload, a dead connection, or a write
-#	error. A peer that closed the socket surfaces as EPIPE, not as
-#	a fatal SIGPIPE.
+#	Frame and write one message. The method returns 1 on success.
+#	It returns undef, with $! set, on an oversized payload, a dead
+#	connection, or a write error. A peer that closed the socket
+#	shows as EPIPE, not as a fatal SIGPIPE.
 sub send ( $self, %args )
 {
 	my $type = $args{type} // die 'type parameter required';
@@ -116,11 +120,11 @@ sub send ( $self, %args )
 
 # $self->recv(%args):
 #	timeout => $seconds	how long to wait (undef blocks forever)
-#	Return one whole message as { type => $n, data => $bytes },
-#	accumulating short reads across calls. Returns undef on
-#	timeout, clean EOF, or an unrecoverable framing error ($! set
-#	to EBADMSG, and the connection is marked dead per
-#	spec/MDNS-Imsg.md §4).
+#	Return one whole message as { type => $n, data => $bytes }.
+#	The method accumulates short reads across calls. It returns
+#	undef on timeout, clean EOF, or an unrecoverable framing
+#	error. For a framing error, it sets $! to EBADMSG and marks
+#	the connection dead per spec/MDNS-Imsg.md §4.
 sub recv ( $self, %args )
 {
 	my $timeout  = $args{timeout};
@@ -149,8 +153,9 @@ sub recv ( $self, %args )
 		}
 		if ( $n == 0 ) {
 
-			# Clean EOF only on a message boundary; EOF with
-			# buffered bytes is a truncated message either way
+			# A clean EOF occurs only on a message boundary.
+			# An EOF with buffered bytes is a truncated
+			# message either way.
 			$self->{dead} = 1;
 			return;
 		}
@@ -159,9 +164,9 @@ sub recv ( $self, %args )
 }
 
 # $self->_extract_message:
-#	Pop one complete message off the buffer, or return undef when
-#	more bytes are needed. An invalid length poisons the
-#	connection [MDNS-Imsg §2].
+#	Pop one complete message off the buffer. Return undef when
+#	more bytes are necessary. An invalid length marks the
+#	connection dead [MDNS-Imsg §2].
 sub _extract_message ($self)
 {
 	return if length( $self->{buffer} ) < HEADER_SIZE;

--- a/lib/FuguLib/Imsg.pm
+++ b/lib/FuguLib/Imsg.pm
@@ -25,7 +25,7 @@ use Time::HiRes qw(time);
 
 # FuguLib::Imsg - the base-system imsg(3) framing over a connected
 # stream socket. Each message is a fixed native-endian header followed
-# by a payload. The module does serialisation only. It never opens or
+# by a payload. The module does serialization only. It never opens or
 # names a socket itself, and it never logs. The callers decide what an
 # error means.
 

--- a/lib/FuguLib/Log.pm
+++ b/lib/FuguLib/Log.pm
@@ -23,9 +23,9 @@ use Sys::Syslog qw(:standard :macros);
 
 # FuguLib::Log - Unified logging for syslog and stderr
 #
-# Provides a single interface for logging that works with both syslog
-# (for daemons) and stderr (for CLI tools), with level filtering and
-# printf-style formatting.
+# The module gives one logging interface for both syslog (for
+# daemons) and stderr (for CLI tools). It filters messages by level
+# and formats them printf-style.
 
 use constant {
 	MODE_SYSLOG => 'syslog',
@@ -39,12 +39,12 @@ sub new ( $class, %args )
 	my $level = $args{level} // 'info';
 	my $ident = $args{ident} // 'fugulib';
 
-	# Validate mode
+	# Validate the mode
 	unless ( $mode =~ /^(syslog|stderr|quiet)$/ ) {
 		die "Invalid log mode: $mode";
 	}
 
-	# Convert facility string to constant if needed
+	# Convert the facility string to a constant if necessary
 	my $facility = $args{facility} // LOG_DAEMON;
 	if ( ref($facility) eq '' && $facility =~ /^\w+$/ ) {
 		$facility = _parse_facility($facility);
@@ -106,7 +106,7 @@ sub _log ( $self, $level, $fmt, @args )
 }
 
 # $self->set_level($level):
-#	Change minimum log level
+#	Change the minimum log level
 sub set_level ( $self, $level )
 {
 	$self->{level} = _parse_level($level);
@@ -149,7 +149,7 @@ my %facility_map = (
 sub _parse_level ($level)
 {
 	$level = lc($level);
-	return $level_map{$level} // 1;    # Default to info
+	return $level_map{$level} // 1;    # The default is info
 }
 
 sub _level_to_priority ($level)

--- a/lib/FuguLib/MDNS.pm
+++ b/lib/FuguLib/MDNS.pm
@@ -25,14 +25,15 @@ use Socket      qw(SOCK_STREAM);
 use Time::HiRes qw(time);
 
 # FuguLib::MDNS - publish services through OpenBSD's mdnsd(8) over its
-# control socket, natively: no mdnsctl(8) child process. The socket is
-# the advertisement's lifetime - closing it withdraws the service.
-# Protocol per spec/MDNS-Control.md. The module never logs; it returns
-# outcomes and keeps the last failure in ->error for the caller.
+# control socket, natively. There is no mdnsctl(8) child process. The
+# socket is the advertisement's lifetime. Close the socket to withdraw
+# the service. The protocol is per spec/MDNS-Control.md. The module
+# never logs. It returns outcomes and keeps the last failure in
+# ->error for the caller.
 
-# The imsg_type enum ordinals [MDNS-Control §2]. Positional in the
-# upstream header, so all of them are pinned here in order even though
-# only the group subset is used.
+# The imsg_type enum ordinals [MDNS-Control §2]. The values are
+# positional in the upstream header. Thus the list pins all of them in
+# order, although the module uses only the group subset.
 use constant {
 	IMSG_NONE                     => 0,
 	IMSG_CTL_END                  => 1,
@@ -54,10 +55,11 @@ use constant {
 	IMSG_CTL_GROUP_PUBLISHED      => 17,
 };
 
-# Field limits and the struct mdns_service layout [MDNS-Control §3-§4],
-# LP64 as measured for OpenBSD 7.8/openmdns-0.7p3 (the LIST_ENTRY width
-# and the 864-byte total are LP64-specific). NAME_MAX etc. are the
-# usable lengths: one byte of each field is the terminating NUL.
+# Field limits and the struct mdns_service layout [MDNS-Control §3-§4].
+# The layout is LP64 as measured for OpenBSD 7.8/openmdns-0.7p3. The
+# LIST_ENTRY width and the 864-byte total are LP64-specific. NAME_MAX
+# and the other maximums are the usable lengths. One byte of each field
+# is the terminating NUL.
 use constant {
 	GROUP_NAME_LEN => 256,    # char[MAXHOSTNAMELEN] [MDNS-Control §3.1]
 	SERVICE_LEN    => 864,    # sizeof(struct mdns_service)
@@ -66,17 +68,18 @@ use constant {
 	TXT_MAX        => 255,
 };
 
-# struct mdns_service, one template [MDNS-Control §4]: 16 zero bytes of
-# LIST_ENTRY, app[64], proto[4], name[256], target[256] (zeros: mdnsd
-# substitutes its own hostname), u16 priority/weight/port native order,
-# txt[256], 2 bytes padding, in_addr (zeros: INADDR_ANY, mdnsd patches
-# in the interface address).
+# struct mdns_service, one template [MDNS-Control §4]. The fields are:
+# 16 zero bytes of LIST_ENTRY, app[64], proto[4], name[256],
+# target[256], u16 priority/weight/port in native order, txt[256],
+# 2 bytes padding, and in_addr. The target field is zeros: mdnsd
+# substitutes its own hostname. The in_addr field is zeros, INADDR_ANY:
+# mdnsd patches in the interface address.
 use constant SERVICE_TEMPLATE => 'x16 Z64 Z4 Z256 x256 S S S Z256 x2 x4';
 
 # FuguLib::MDNS->new(%args):
 #	socket_path => $path	control socket (default /var/run/mdnsd.sock)
-#	timeout     => $secs	reply deadline (default 10; PUBLISHED
-#				takes ~4-4.5s [MDNS-Control §6.2])
+#	timeout     => $secs	reply deadline (default 10). PUBLISHED
+#				takes ~4-4.5s [MDNS-Control §6.2].
 sub new ( $class, %args )
 {
 	return bless {
@@ -90,9 +93,10 @@ sub new ( $class, %args )
 }
 
 # $self->connect:
-#	Connect to mdnsd's control socket. Returns 1, or undef when
-#	the socket is missing or refuses - mdnsd not running is a
-#	normal condition the caller decides about [MDNS-Control §1].
+#	Connect to mdnsd's control socket. The method returns 1, or
+#	undef when the socket is missing or refuses. An mdnsd that
+#	does not run is a normal condition. The caller decides about
+#	it [MDNS-Control §1].
 sub connect ($self)
 {
 	my $sock = IO::Socket::UNIX->new(
@@ -110,24 +114,25 @@ sub connect ($self)
 }
 
 # $self->publish_service(%args):
-#	name    => $instance	service instance name (also the group
-#				name; mdnsd requires them equal
-#				[MDNS-Control §7])
+#	name    => $instance	service instance name, also the group
+#				name. mdnsd requires them equal
+#				[MDNS-Control §7].
 #	app     => $app		application protocol, no underscore
 #	proto   => $proto	'tcp' or 'udp'
 #	port    => $port	port number
 #	txt     => $string	formatted TXT string [MDNS-Control §5]
 #	timeout => $secs	overrides the object default
-#	Send the ADD/ADD_SERVICE/COMMIT sequence and wait for
-#	GROUP_PUBLISHED. Returns 1 once published; undef on invalid
-#	arguments, no connection, an error reply, EOF, or timeout,
-#	with the reason in ->error.
+#	Send the ADD/ADD_SERVICE/COMMIT sequence. Wait for
+#	GROUP_PUBLISHED. The method returns 1 when the service is
+#	published. It returns undef on invalid arguments, no
+#	connection, an error reply, EOF, or timeout. The reason is in
+#	->error.
 sub publish_service ( $self, %args )
 {
 	my $service = $self->_check_service(%args) or return;
 
-	# Republishing on a held connection must go through update_txt:
-	# mdnsd silently ignores the duplicate GROUP_ADD, drops the
+	# To republish on a held connection, use update_txt. mdnsd
+	# silently ignores the duplicate GROUP_ADD, drops the
 	# ADD_SERVICE, and answers the COMMIT with a success-looking
 	# reply sequence for the old records [MDNS-Control §8]
 	if ( $self->{published} ) {
@@ -149,10 +154,10 @@ sub publish_service ( $self, %args )
 #	txt     => $string	replacement TXT string
 #	timeout => $secs	overrides the object default
 #	Re-advertise with a new TXT record. Same-socket replacement
-#	does not work [MDNS-Control §8], so this withdraws and
-#	republishes over a fresh connection, reusing the service
-#	parameters from publish_service. A no-op returning 1 while
-#	unpublished, mirroring the old mdnsctl wrapper.
+#	does not work [MDNS-Control §8]. Thus the method withdraws and
+#	republishes over a fresh connection. It reuses the service
+#	parameters from publish_service. While unpublished, it is a
+#	no-op that returns 1. This mirrors the old mdnsctl wrapper.
 sub update_txt ( $self, %args )
 {
 	return 1 unless $self->{published};
@@ -171,7 +176,7 @@ sub update_txt ( $self, %args )
 }
 
 # $self->withdraw:
-#	Close the control socket. That is the entire operation: mdnsd
+#	Close the control socket. That is the entire operation. mdnsd
 #	kills the connection's groups and sends goodbyes
 #	[MDNS-Control §6].
 sub withdraw ($self)
@@ -186,23 +191,25 @@ sub withdraw ($self)
 }
 
 # $self->is_published:
-#	True while the service is advertised on a held connection.
+#	The method returns true while the service is published on a
+#	held connection.
 sub is_published ($self)
 {
 	return $self->{published};
 }
 
 # $self->error:
-#	The most recent failure, for the caller to log.
+#	Return the most recent failure. The caller can log it.
 sub error ($self)
 {
 	return $self->{error};
 }
 
 # $self->_check_service(%args):
-#	Validate lengths against the wire field limits - over-length
-#	input is an error, never a silent truncation [MDNS-Control §4]
-#	- and return the parameter set publish and update reuse.
+#	Validate the lengths against the wire field limits.
+#	Over-length input is an error, never a silent truncation
+#	[MDNS-Control §4]. Return the parameter set that publish and
+#	update reuse.
 sub _check_service ( $self, %args )
 {
 	my %service = (
@@ -232,7 +239,7 @@ sub _check_service ( $self, %args )
 		return;
 	}
 
-	# The wire field is a u16 [MDNS-Control §4]; pack would
+	# The wire field is a u16 [MDNS-Control §4]. pack would
 	# silently truncate anything wider
 	if ( $service{port} !~ /^\d+$/ || $service{port} > 65535 ) {
 		$self->{error} = 'port out of range';
@@ -243,9 +250,9 @@ sub _check_service ( $self, %args )
 }
 
 # $self->_publish($timeout):
-#	The three-message publish conversation and its reply loop
-#	[MDNS-Control §6]. On any failure the connection is closed so
-#	mdnsd forgets the half-built group.
+#	Run the three-message publish conversation and its reply loop
+#	[MDNS-Control §6]. On any failure, the method closes the
+#	connection so that mdnsd forgets the half-built group.
 sub _publish ( $self, $timeout )
 {
 	my $s     = $self->{service};
@@ -253,8 +260,8 @@ sub _publish ( $self, $timeout )
 
 	$self->{error} = undef;
 
-	# ADD must precede COMMIT on this connection, unconditionally:
-	# committing an unknown group crashes mdnsd [MDNS-Control §9]
+	# ADD must precede COMMIT on this connection, unconditionally.
+	# A COMMIT for an unknown group crashes mdnsd [MDNS-Control §9]
 	my $sent = $self->{imsg}->send(
 		type => IMSG_CTL_GROUP_ADD,
 		data => $group
@@ -317,8 +324,8 @@ sub _publish ( $self, $timeout )
 
 # $self->_encode_service:
 #	Encode the stored parameters as one struct mdns_service
-#	[MDNS-Control §4]. Lengths were validated in _check_service,
-#	so the Z templates never truncate.
+#	[MDNS-Control §4]. _check_service already validates the
+#	lengths. Thus the Z templates never truncate.
 sub _encode_service ($self)
 {
 	my $s   = $self->{service};

--- a/lib/FuguLib/Privdrop.pm
+++ b/lib/FuguLib/Privdrop.pm
@@ -71,15 +71,15 @@ sub drop_privileges ( $class, %args )
 	unless ( POSIX::setgid($gid) ) {
 		die "Cannot setgid to $gid: $!";
 	}
-	$( = $gid;    # Set the effective GID
-	$) = $gid;    # Set the real GID
+	$( = $gid;    # Set the real GID
+	$) = $gid;    # Set the effective GID
 
 	# Drop the user privileges
 	unless ( POSIX::setuid($uid) ) {
 		die "Cannot setuid to $uid: $!";
 	}
-	$< = $uid;    # Set the effective UID
-	$> = $uid;    # Set the real UID
+	$< = $uid;    # Set the real UID
+	$> = $uid;    # Set the effective UID
 
 	# Make sure the process cannot get root back
 	if ( $> == 0 || $< == 0 ) {

--- a/lib/FuguLib/Privdrop.pm
+++ b/lib/FuguLib/Privdrop.pm
@@ -22,25 +22,26 @@ package FuguLib::Privdrop;
 use POSIX qw(setuid setgid);
 
 # $class->drop_privileges(%args):
-#	Drop privileges from root to specified user and group.
-#	This is a common pattern in OpenBSD daemons - start as root
-#	to bind privileged ports and fork privileged processes,
-#	then drop to unprivileged user for the main event loop.
+#	Drop privileges from root to the specified user and group.
+#	This is a common pattern in OpenBSD daemons. The daemon starts
+#	as root to bind privileged ports and fork privileged
+#	processes. It then drops to an unprivileged user for the main
+#	event loop.
 #
 #	%args:
 #		user  => $username  # Username to drop to (required)
-#		group => $groupname # Group to drop to (optional, defaults to user's primary group)
+#		group => $groupname # Group to drop to (optional, default: the user's primary group)
 #
-#	Returns 1 on success, dies on error.
+#	The method returns 1 on success. It dies on error.
 #
 #	Example:
-#		# Start as root, do privileged operations
+#		# Start as root. Do the privileged operations.
 #		$state->chown_runtime_files();
 #
-#		# Drop privileges before entering event loop
+#		# Drop privileges before you start the event loop
 #		FuguLib::Privdrop->drop_privileges(user => '_openhap');
 #
-#		# Now running as _openhap
+#		# The process now runs as _openhap
 #		$server->run();
 sub drop_privileges ( $class, %args )
 {
@@ -48,16 +49,17 @@ sub drop_privileges ( $class, %args )
 	    or die "user parameter required for drop_privileges";
 	my $group = $args{group};
 
-	# Already non-root? Nothing to do
+	# If the process is already non-root, there is nothing to do
 	return 1 if $> != 0;
 
-	# Get user info
+	# Get the user info
 	my ( $uid, $gid ) = ( getpwnam($user) )[ 2, 3 ];
 	unless ( defined $uid ) {
 		die "Cannot get UID for user '$user': $!";
 	}
 
-	# Get group info if specified, otherwise use user's primary group
+	# Get the group info if the caller gives a group. Otherwise
+	# use the user's primary group.
 	if ( defined $group ) {
 		$gid = getgrnam($group);
 		unless ( defined $gid ) {
@@ -65,26 +67,26 @@ sub drop_privileges ( $class, %args )
 		}
 	}
 
-	# Drop group privileges first (must be done before setuid)
+	# Drop the group privileges first. Do this before setuid.
 	unless ( POSIX::setgid($gid) ) {
 		die "Cannot setgid to $gid: $!";
 	}
-	$( = $gid;    # Set effective GID
-	$) = $gid;    # Set real GID
+	$( = $gid;    # Set the effective GID
+	$) = $gid;    # Set the real GID
 
-	# Drop user privileges
+	# Drop the user privileges
 	unless ( POSIX::setuid($uid) ) {
 		die "Cannot setuid to $uid: $!";
 	}
-	$< = $uid;    # Set effective UID
-	$> = $uid;    # Set real UID
+	$< = $uid;    # Set the effective UID
+	$> = $uid;    # Set the real UID
 
-	# Verify we can't get root back
+	# Make sure the process cannot get root back
 	if ( $> == 0 || $< == 0 ) {
 		die "Failed to drop privileges - still running as root";
 	}
 
-	# Try to escalate (should fail)
+	# Try to escalate. The attempt must fail.
 	eval {
 		POSIX::setuid(0);
 		if ( $> == 0 || $< == 0 ) {

--- a/lib/FuguLib/Process.pm
+++ b/lib/FuguLib/Process.pm
@@ -23,23 +23,24 @@ use POSIX qw(setsid WNOHANG);
 
 # FuguLib::Process - Robust process management
 #
-# Handles forking, exec, PID tracking, signal handling, and zombie reaping
-# with proper error detection and logging integration.
+# The module does forking, exec, PID tracking, signal handling, and
+# zombie reaping. It adds proper error detection and logging
+# integration.
 
 # $class->spawn_command(%args):
-#	Fork and execute a command, optionally as a daemon
-#	Returns hashref with {pid => $pid, success => 1} on success,
-#	or {success => 0, error => $msg} on failure
+#	Fork and execute a command. Optionally run it as a daemon.
+#	The method returns a hashref: {pid => $pid, success => 1} on
+#	success, or {success => 0, error => $msg} on failure.
 #
 #	%args:
-#		cmd       => \@command  # Required: command to execute
-#		daemonize => 0|1        # Optional: detach from terminal
+#		cmd       => \@command  # Required: the command to execute
+#		daemonize => 0|1        # Optional: detach from the terminal
 #		stdout    => $path|undef # Optional: redirect stdout (default: /dev/null)
 #		stderr    => $path|undef # Optional: redirect stderr (default: /dev/null)
 #		stdin     => $path|undef # Optional: redirect stdin (default: /dev/null)
 #		on_error  => sub($err)  # Optional: error callback
 #		on_success => sub($pid) # Optional: success callback
-#		check_alive => $seconds # Optional: wait and verify process is alive
+#		check_alive => $seconds # Optional: wait, then make sure the process is alive
 sub spawn_command ( $class, %args )
 {
 	my $cmd = $args{cmd}
@@ -73,11 +74,11 @@ sub spawn_command ( $class, %args )
 
 		if ($daemonize) {
 
-			# Become session leader
+			# Become the session leader
 			setsid() or exit 1;
 		}
 
-		# Redirect file descriptors
+		# Redirect the file descriptors
 		if ( !open STDIN, '<', $stdin ) {
 			warn "Cannot redirect stdin: $!";
 			exit 1;
@@ -91,20 +92,21 @@ sub spawn_command ( $class, %args )
 			exit 1;
 		}
 
-		# Execute command
+		# Execute the command
 		exec @$cmd or exit 1;
 	}
 
 	# Parent process
 	if ($check_alive) {
 
-		# Give process time to start
+		# Give the process time to start
 		sleep $check_alive;
 
-	      # Try to reap zombie without blocking (is_alive would do this too)
+		# Try to reap the zombie without blocking. is_alive
+		# would do this too.
 		my $reaped = waitpid( $pid, WNOHANG );
 
-		# If we reaped the process, it died
+		# If waitpid reaped the process, the process died
 		if ( $reaped == $pid ) {
 			my $exit_status = $? >> 8;
 			my $err =
@@ -120,7 +122,8 @@ sub spawn_command ( $class, %args )
 			};
 		}
 
-		# Double-check with kill(0) to ensure process is alive
+		# Check again with kill(0) to make sure the process is
+		# alive
 		unless ( kill( 0, $pid ) ) {
 			my $err =
 "Process $pid is not alive (not reaped, possible race)";
@@ -139,39 +142,43 @@ sub spawn_command ( $class, %args )
 }
 
 # $class->is_alive($pid):
-#	Check if process is alive (not dead, not zombie)
-#	Returns 1 if alive, 0 if dead or doesn't exist or zombie
+#	Check if the process is alive (not dead, not a zombie).
+#	The method returns 1 if the process is alive. It returns 0 if
+#	the process is dead, a zombie, or does not exist.
 sub is_alive ( $class, $pid )
 {
 	return 0 unless defined $pid;
 	return 0 unless $pid =~ /^\d+$/;
 
-	# First check if process exists
+	# First check if the process exists
 	return 0 unless kill( 0, $pid );
 
-	# Don't try to wait on ourselves
+	# Do not try to wait on the current process
 	return 1 if $pid == $$;
 
 	# Try to reap zombies without blocking
 	my $result = waitpid( $pid, WNOHANG );
 
-	# If waitpid returned the PID, it was a zombie and is now reaped
+	# If waitpid returns the PID, the process was a zombie.
+	# waitpid has now reaped it.
 	return 0 if $result == $pid;
 
-	# If waitpid returned -1, no such child (not our child, but still alive)
+	# If waitpid returns -1, there is no such child. The process
+	# is not a child of the current process, but it is still alive.
 	#return 0 if $result == -1;
 
-	# Otherwise, process is alive
+	# Otherwise, the process is alive
 	return 1;
 }
 
 # $class->terminate($pid, %args):
-#	Terminate a process gracefully, with force if needed
-#	Returns 1 if process was killed or is dead, 0 on failure
+#	Stop a process gracefully. Use force if necessary.
+#	The method returns 1 if the process is killed or dead. It
+#	returns 0 on failure.
 #
 #	%args:
 #		grace_period => $seconds # Time to wait after TERM before KILL (default: 5)
-#		on_kill      => sub()    # Called after successful kill
+#		on_kill      => sub()    # Runs after a successful kill
 sub terminate ( $class, $pid, %args )
 {
 	return 1 unless defined $pid;
@@ -184,11 +191,12 @@ sub terminate ( $class, $pid, %args )
 	my $killed = kill 'TERM', $pid;
 	unless ($killed) {
 
-		# Process already dead or no permission
+		# The process is already dead, or there is no
+		# permission
 		return $class->is_alive($pid) ? 0 : 1;
 	}
 
-	# Wait for process to exit
+	# Wait for the process to exit
 	my $waited = 0;
 	while ( $waited < $grace_period && $class->is_alive($pid) ) {
 		sleep 1;
@@ -198,7 +206,7 @@ sub terminate ( $class, $pid, %args )
 		waitpid( $pid, WNOHANG );
 	}
 
-	# If still alive, force kill
+	# If the process is still alive, kill it with force
 	if ( $class->is_alive($pid) ) {
 		kill 'KILL', $pid;
 		sleep 1;
@@ -208,7 +216,7 @@ sub terminate ( $class, $pid, %args )
 		return 0 if $class->is_alive($pid);
 	}
 
-	# Reap zombie
+	# Reap the zombie
 	waitpid( $pid, WNOHANG );
 
 	$on_kill->() if $on_kill;
@@ -216,8 +224,9 @@ sub terminate ( $class, $pid, %args )
 }
 
 # $class->reap($pid):
-#	Attempt to reap a zombie process
-#	Returns 1 if process was reaped or doesn't exist, 0 if still running
+#	Try to reap a zombie process.
+#	The method returns 1 if the process is reaped or does not
+#	exist. It returns 0 if the process still runs.
 sub reap ( $class, $pid )
 {
 	return 1 unless defined $pid;
@@ -225,15 +234,15 @@ sub reap ( $class, $pid )
 
 	my $result = waitpid( $pid, WNOHANG );
 
-	# $result > 0: child was reaped
-	# $result == -1: no such child
-	# $result == 0: child still running
+	# $result > 0: waitpid reaped the child
+	# $result == -1: there is no such child
+	# $result == 0: the child still runs
 	return $result != 0;
 }
 
 # $class->reap_all():
-#	Reap all zombie children (non-blocking)
-#	Returns count of children reaped
+#	Reap all zombie children without blocking.
+#	The method returns the count of reaped children.
 sub reap_all ($class)
 {
 	my $count = 0;
@@ -244,8 +253,9 @@ sub reap_all ($class)
 }
 
 # $class->wait_exit($pid, $timeout):
-#	Wait for process to exit
-#	Returns 1 if process exited, 0 if timeout
+#	Wait for the process to exit.
+#	The method returns 1 if the process exits. It returns 0 on
+#	timeout.
 sub wait_exit ( $class, $pid, $timeout = 30 )
 {
 	my $start = time;
@@ -259,13 +269,14 @@ sub wait_exit ( $class, $pid, $timeout = 30 )
 }
 
 # $class->spawn_perl(%args):
-#	Spawn a Perl subprocess with the parent's @INC paths inherited
-#	This is a convenience wrapper around spawn_command() for running Perl code
+#	Spawn a Perl subprocess that inherits the parent's @INC paths.
+#	This is a convenience wrapper around spawn_command() to run
+#	Perl code.
 #
 #	%args:
-#		code      => $string    # Required: Perl code to execute
-#		args      => \@args     # Optional: arguments passed to the code
-#		All other args are passed to spawn_command()
+#		code      => $string    # Required: the Perl code to execute
+#		args      => \@args     # Optional: arguments for the code
+#		The method passes all other args to spawn_command().
 #
 #	Example:
 #		FuguLib::Process->spawn_perl(
@@ -279,7 +290,7 @@ sub spawn_perl ( $class, %args )
 	    or return { success => 0, error => 'No code specified' };
 	my $extra_args = delete $args{args} // [];
 
-	# Build -I flags for all non-default @INC paths
+	# Build the -I flags for all non-default @INC paths
 	my @inc_flags = map { "-I$_" } _custom_inc_paths();
 
 	$args{cmd} = [ $^X, @inc_flags, '-e', $code, @$extra_args ];
@@ -288,13 +299,14 @@ sub spawn_perl ( $class, %args )
 }
 
 # _custom_inc_paths:
-#	Get @INC paths that are not part of Perl's default installation
-#	These are typically paths added via -I, use lib, or PERL5LIB
+#	Get the @INC paths that are not part of Perl's default
+#	installation. These paths usually come from -I, use lib, or
+#	PERL5LIB.
 sub _custom_inc_paths()
 {
 	require Config;
 
-	# Build set of default Perl lib paths
+	# Build the set of default Perl lib paths
 	my %default_paths;
 	for my $key (qw(privlib archlib sitelib sitearch vendorlib vendorarch))
 	{
@@ -302,11 +314,12 @@ sub _custom_inc_paths()
 		$default_paths{$path} = 1 if defined $path && length $path;
 	}
 
-	# Return @INC paths not in the default set (excluding '.' and CODE refs)
+	# Return the @INC paths that are not in the default set.
+	# Skip '.' and CODE refs.
 	my @custom;
 	for my $inc (@INC) {
 		next if ref $inc;               # Skip CODE refs
-		next if $inc eq '.';            # Skip current directory
+		next if $inc eq '.';            # Skip the current directory
 		next if $default_paths{$inc};
 		push @custom, $inc;
 	}

--- a/lib/FuguLib/Sandbox.pm
+++ b/lib/FuguLib/Sandbox.pm
@@ -74,7 +74,7 @@ sub pledge ( $, %args )
 #	Restrict the filesystem view. The list is ordered, not a hash.
 #	unveil(2) replaces rather than merges a path's permissions.
 #	Thus the parent-then-child order is load-bearing, and hash key
-#	order would randomise it. Each entry may carry
+#	order would randomize it. Each entry may carry
 #	{ optional => 1 } as a third element. The method skips a
 #	missing optional path and reports it through on_skip. A
 #	missing required path dies. To accept a typo'd path silently

--- a/lib/FuguLib/Sandbox.pm
+++ b/lib/FuguLib/Sandbox.pm
@@ -19,31 +19,32 @@ use v5.36;
 
 package FuguLib::Sandbox;
 
-# FuguLib::Sandbox - pledge(2) and unveil(2) as a platform abstraction:
-# real on OpenBSD, a no-op returning success everywhere else, so
-# callers never write $^O checks. Stateless class methods wrapping two
-# process-global syscalls. Failures die - a daemon that cannot
-# restrict itself must not start - and there is no force or
-# warn-and-continue mode. The module never logs; is_supported, not a
-# log line, is how a caller or a test tells enforcement from
-# emulation.
+# FuguLib::Sandbox - pledge(2) and unveil(2) as a platform
+# abstraction. The calls are real on OpenBSD. Everywhere else they are
+# no-ops that return success. Thus callers never write $^O checks. The
+# class methods are stateless. They wrap two process-global syscalls.
+# Failures die. A daemon that cannot restrict itself must not start.
+# There is no force or warn-and-continue mode. The module never logs.
+# A caller or a test uses is_supported, not a log line, to tell
+# enforcement from emulation.
 
 use constant SUPPORTED => $^O eq 'openbsd';
 
 BEGIN {
 	if (SUPPORTED) {
 
-		# Base-system modules: failing to load them on OpenBSD
-		# means a broken perl, not an unsupported system, so
-		# this is deliberately fatal rather than a runtime
-		# fallback to "no protection"
+		# These are base-system modules. A load failure on
+		# OpenBSD means a broken perl, not an unsupported
+		# system. Thus the failure is deliberately fatal, not
+		# a runtime fallback to "no protection".
 		require OpenBSD::Pledge;
 		require OpenBSD::Unveil;
 	}
 }
 
 # FuguLib::Sandbox->is_supported:
-#	True only where pledge and unveil are enforced.
+#	The method returns true only where the system enforces pledge
+#	and unveil.
 sub is_supported ($)
 {
 	return SUPPORTED;
@@ -51,8 +52,8 @@ sub is_supported ($)
 
 # FuguLib::Sandbox->pledge(%args):
 #	promises => $string	space-separated promise set
-#	Restrict the process to the promised syscalls. Returns 1, dies
-#	with the promise string and $! on failure.
+#	Restrict the process to the promised syscalls. The method
+#	returns 1. On failure it dies with the promise string and $!.
 sub pledge ( $, %args )
 {
 	my $promises = $args{promises};
@@ -69,15 +70,16 @@ sub pledge ( $, %args )
 
 # FuguLib::Sandbox->unveil(%args):
 #	paths   => [[$path, $perms], ...]	ordered unveil list
-#	on_skip => sub($path)			called per skipped path
-#	Restrict the filesystem view. The list is ordered, not a hash:
-#	unveil(2) replaces rather than merges a path's permissions, so
-#	parent-then-child ordering is load-bearing, and hash key order
-#	would randomise it. Each entry may carry { optional => 1 } as
-#	a third element: a missing optional path is skipped (reported
-#	through on_skip), while a missing required path dies - a
-#	typo'd path silently accepted is the failure mode that makes
-#	unveil useless. Returns 1, dies naming the failing path.
+#	on_skip => sub($path)			runs for each skipped path
+#	Restrict the filesystem view. The list is ordered, not a hash.
+#	unveil(2) replaces rather than merges a path's permissions.
+#	Thus the parent-then-child order is load-bearing, and hash key
+#	order would randomise it. Each entry may carry
+#	{ optional => 1 } as a third element. The method skips a
+#	missing optional path and reports it through on_skip. A
+#	missing required path dies. To accept a typo'd path silently
+#	is the failure mode that makes unveil useless. The method
+#	returns 1, or dies and names the failing path.
 sub unveil ( $, %args )
 {
 	my $paths = $args{paths};
@@ -94,11 +96,11 @@ sub unveil ( $, %args )
 
 	return 1 unless SUPPORTED;
 
-	# Settle every disposition before the first unveil(2) call: that
-	# call already hides the rest of the filesystem, so a later
-	# existence test would see nothing. The check also carries the
-	# required-path contract - unveil(2) itself succeeds on a
-	# missing final component as long as the parent exists, so the
+	# Settle every disposition before the first unveil(2) call.
+	# That call already hides the rest of the filesystem. Thus a
+	# later existence test would see nothing. The check also
+	# carries the required-path contract. unveil(2) itself succeeds
+	# on a missing final component when the parent exists. Thus the
 	# syscall alone would silently accept a typo'd required path.
 	my @apply;
 	for my $entry (@$paths) {
@@ -125,10 +127,10 @@ sub unveil ( $, %args )
 }
 
 # FuguLib::Sandbox->unveil_lock:
-#	Forbid further unveil calls. This must reach the C layer with
-#	no arguments at all: unveil(undef, undef) arrives as
-#	unveil("", "") and fails with ENOENT. Returns 1, dies on
-#	failure.
+#	Forbid further unveil calls. The call must reach the C layer
+#	with no arguments at all. unveil(undef, undef) arrives as
+#	unveil("", "") and fails with ENOENT. The method returns 1.
+#	It dies on failure.
 sub unveil_lock ($)
 {
 	return 1 unless SUPPORTED;

--- a/lib/FuguLib/Signal.pm
+++ b/lib/FuguLib/Signal.pm
@@ -21,9 +21,9 @@ package FuguLib::Signal;
 
 # FuguLib::Signal - Robust signal handling for graceful shutdown
 #
-# Provides safe signal handler registration with cleanup and interrupt
-# handling. Ensures processes can be interrupted cleanly without leaving
-# orphaned resources.
+# The module gives safe signal handler registration with cleanup and
+# interrupt support. It makes sure a process can stop cleanly on an
+# interrupt and leave no orphaned resources.
 
 # Global flag for interrupt detection
 our $interrupted = 0;
@@ -40,8 +40,9 @@ sub new ($class)
 }
 
 # $self->setup_graceful_exit(@signals):
-#	Setup handlers for graceful exit on specified signals
-#	Calls all registered cleanup handlers and exits
+#	Set up handlers for a graceful exit on the specified signals.
+#	On a signal, the handler calls all registered cleanup handlers
+#	and exits.
 sub setup_graceful_exit ( $self, @signals )
 {
 	for my $sig (@signals) {
@@ -57,8 +58,9 @@ sub setup_graceful_exit ( $self, @signals )
 }
 
 # $self->setup_interrupt_flag(@signals):
-#	Setup handlers that set interrupt flag without exiting
-#	Allows long-running operations to check and exit cleanly
+#	Set up handlers that set the interrupt flag and do not exit.
+#	Long-running operations can then check the flag and exit
+#	cleanly.
 sub setup_interrupt_flag ( $self, @signals )
 {
 	for my $sig (@signals) {
@@ -70,8 +72,8 @@ sub setup_interrupt_flag ( $self, @signals )
 }
 
 # $self->add_cleanup($handler):
-#	Add cleanup handler to be called on signal
-#	Handler receives signal name as argument
+#	Add a cleanup handler that runs on a signal.
+#	The handler receives the signal name as its argument.
 sub add_cleanup ( $self, $handler )
 {
 	push @cleanup_handlers, $handler;
@@ -79,7 +81,7 @@ sub add_cleanup ( $self, $handler )
 }
 
 # $self->restore():
-#	Restore original signal handlers
+#	Restore the original signal handlers
 sub restore ($self)
 {
 	for my $sig ( keys %{ $self->{handlers} } ) {
@@ -90,15 +92,16 @@ sub restore ($self)
 }
 
 # check_interrupted():
-#	Check if process has been interrupted
-#	Returns true if interrupt signal received
+#	Check if the process received an interrupt.
+#	The function returns true if an interrupt signal arrived.
 sub check_interrupted()
 {
 	return $interrupted;
 }
 
 # reset_interrupted():
-#	Reset interrupt flag (for testing or manual control)
+#	Reset the interrupt flag. Use this for tests or manual
+#	control.
 sub reset_interrupted()
 {
 	$interrupted = 0;
@@ -112,7 +115,7 @@ sub _run_cleanup_handlers ( $self, $signal )
 	@cleanup_handlers = ();
 }
 
-# DESTROY runs when object goes out of scope
+# DESTROY runs when the object goes out of scope
 sub DESTROY ($self)
 {
 	$self->restore;

--- a/lib/FuguLib/State.pm
+++ b/lib/FuguLib/State.pm
@@ -24,7 +24,8 @@ use FuguLib::Process;
 
 # FuguLib::State - Simple PID file management
 #
-# Provides safe PID file reading/writing with locking and stale PID detection.
+# The module reads and writes PID files safely, with locking and
+# stale PID detection.
 
 sub new ( $class, $pidfile )
 {
@@ -37,8 +38,8 @@ sub new ( $class, $pidfile )
 }
 
 # $self->write_pid($pid):
-#	Write PID to file with exclusive lock
-#	Returns 1 on success, 0 on failure
+#	Write the PID to the file with an exclusive lock.
+#	The method returns 1 on success and 0 on failure.
 sub write_pid ( $self, $pid = $$ )
 {
 	my $pidfile = $self->{pidfile};
@@ -55,8 +56,9 @@ sub write_pid ( $self, $pid = $$ )
 }
 
 # $self->read_pid():
-#	Read PID from file
-#	Returns PID or undef if not found or invalid
+#	Read the PID from the file.
+#	The method returns the PID. It returns undef when the PID is
+#	missing or invalid.
 sub read_pid ($self)
 {
 	my $pidfile = $self->{pidfile};
@@ -73,7 +75,7 @@ sub read_pid ($self)
 }
 
 # $self->remove():
-#	Remove PID file
+#	Remove the PID file
 sub remove ($self)
 {
 	my $pidfile = $self->{pidfile};
@@ -82,8 +84,9 @@ sub remove ($self)
 }
 
 # $self->is_running():
-#	Check if process from PID file is running
-#	Returns PID if running, undef otherwise
+#	Check if the process from the PID file runs.
+#	The method returns the PID if the process runs. Otherwise it
+#	returns undef.
 sub is_running ($self)
 {
 	my $pid = $self->read_pid;
@@ -93,7 +96,8 @@ sub is_running ($self)
 }
 
 # $self->is_stale():
-#	Check if PID file is stale (process not running)
+#	Check if the PID file is stale. Stale means the process does
+#	not run.
 sub is_stale ($self)
 {
 	my $pid = $self->read_pid;

--- a/lib/FuguVM/CLI.pm
+++ b/lib/FuguVM/CLI.pm
@@ -46,8 +46,9 @@ use constant {
 	EXIT_EXPECT_FAILED   => 9,
 	EXIT_DOWNLOAD_FAILED => 10,
 
-	# Scriptable: lets 'snapshot restore || provision-from-scratch'
-	# tell a missing layer from a real failure
+	# Scriptable: a script that runs
+	# 'snapshot restore || provision-from-scratch' can tell a
+	# missing layer from a real failure.
 	EXIT_SNAPSHOT_NOT_FOUND => 11,
 };
 
@@ -120,7 +121,7 @@ sub run ( $class, @argv )
 
 	my $self = $class->new(%opts);
 
-	# Load config if not init command
+	# Load the configuration if the command is not init
 	if ( $command ne 'init' && $command ne 'help' ) {
 		my $project_root = $opts{project}
 		    // FuguVM::Config->find_project_root;
@@ -131,7 +132,7 @@ sub run ( $class, @argv )
 			return EXIT_CONFIG_ERROR;
 		}
 
-		# Validate project path exists
+		# Make sure that the project path exists
 		if ( !-d $project_root ) {
 			$self->{log}->error(
 				"Project path does not exist: $project_root");
@@ -168,7 +169,7 @@ sub _load_vm ( $self, %opts )
 	);
 }
 
-# Idempotent: ensure VM is running
+# The command is idempotent. It makes sure that the VM runs.
 sub cmd_up ( $self, @args )
 {
 	my $no_cache = 0;
@@ -182,27 +183,27 @@ sub cmd_up ( $self, @args )
 	return $vm->up;
 }
 
-# Stop VM gracefully
+# Stop the VM gracefully
 sub cmd_down ( $self, @args )
 {
 	my $vm = $self->_load_vm or return EXIT_VM_NOT_FOUND;
 	return $vm->down;
 }
 
-# Stop VM and delete disk image
+# Stop the VM. Delete the disk image.
 sub cmd_destroy ( $self, @args )
 {
 	my $vm = $self->_load_vm or return EXIT_VM_NOT_FOUND;
 	return $vm->destroy;
 }
 
-# Show VM status
+# Show the VM status
 sub cmd_status ( $self, @args )
 {
 	my $vm     = $self->_load_vm or return EXIT_VM_NOT_FOUND;
 	my $status = $vm->status;
 
-	# Format and log status data
+	# Format the status data. Then log it.
 	for my $key ( sort keys %$status ) {
 		my $value = $status->{$key} // '';
 		$self->{log}->info("$key: $value");
@@ -211,14 +212,14 @@ sub cmd_status ( $self, @args )
 	return EXIT_SUCCESS;
 }
 
-# Start VM in background
+# Start the VM in the background
 sub cmd_start ( $self, @args )
 {
 	my $vm = $self->_load_vm or return EXIT_VM_NOT_FOUND;
 	return $vm->start;
 }
 
-# Stop VM
+# Stop the VM
 sub cmd_stop ( $self, @args )
 {
 	my $force  = 0;
@@ -231,14 +232,15 @@ sub cmd_stop ( $self, @args )
 	return $vm->stop($force);
 }
 
-# SSH into VM or run command
+# Open an SSH session into the VM, or run a command
 sub cmd_ssh ( $self, @args )
 {
 	my $vm = $self->_load_vm or return EXIT_VM_NOT_FOUND;
 
-	# Uses SSH agent for authentication. Connect over IPv4: QEMU
-	# forwards the guest SSH port on 127.0.0.1 only, but 'localhost'
-	# resolves to ::1 first on dual-stack hosts (e.g. CI runners).
+	# The connection uses the SSH agent for authentication. Connect
+	# over IPv4: QEMU forwards the guest SSH port on 127.0.0.1 only.
+	# On dual-stack hosts, for example CI runners, 'localhost'
+	# resolves to ::1 first.
 	my $ssh = FuguVM::SSH->new(
 		host => '127.0.0.1',
 		port => $vm->ssh_port,
@@ -256,7 +258,7 @@ sub cmd_ssh ( $self, @args )
 	}
 }
 
-# Show console connection info
+# Show the console connection info
 sub cmd_console ( $self, @args )
 {
 	my $vm   = $self->_load_vm or return EXIT_VM_NOT_FOUND;
@@ -268,7 +270,7 @@ sub cmd_console ( $self, @args )
 	return EXIT_SUCCESS;
 }
 
-# Run expect script
+# Run an expect script
 sub cmd_expect ( $self, @args )
 {
 	my $script = shift @args;
@@ -296,7 +298,7 @@ sub cmd_wait ( $self, @args )
 	$parser->getoptionsfromarray( \@args, 'timeout=s' => \$timeout, )
 	    or return EXIT_INVALID_ARGS;
 
-	# Validate timeout is a positive integer
+	# Make sure that the timeout is a positive integer
 	if ( $timeout !~ /^\d+$/ ) {
 		$self->{log}->error("Invalid timeout value: $timeout");
 		return EXIT_INVALID_ARGS;
@@ -344,8 +346,8 @@ sub cmd_image ( $self, @args )
 		return EXIT_SUCCESS;
 	}
 
-	# 'download' action - show URL for manual download
-	# Images are cached by the proxy when VM boots
+	# The 'download' action shows the URL for a manual download.
+	# The proxy caches the images when the VM boots.
 	my $version = shift @args // '7.8';
 	my $path    = $image->path($version);
 
@@ -377,8 +379,9 @@ sub cmd_cache ( $self, @args )
 }
 
 # $self->_cache_list($cache):
-#	One line per cached entry, marking the one the invoked VM's
-#	configuration currently derives, then what the proxy holds.
+#	Show one line for each cached entry. Mark the entry that the
+#	configuration of the invoked VM currently derives. Then show
+#	what the proxy holds.
 sub _cache_list ( $self, $cache )
 {
 	my $entries = $cache->list;
@@ -412,10 +415,11 @@ sub _cache_list ( $self, $cache )
 }
 
 # $self->_proxy_list:
-#	What the proxy's download cache holds, one line per OpenBSD
-#	version. Reported by 'cache list' because it shares cache_dir with
-#	the images and is pruned by the same 'cache clear': a half of the
-#	directory that nothing printed was a half nobody knew to bound.
+#	Show what the download cache of the proxy holds, one line for
+#	each OpenBSD version. 'cache list' reports it because it shares
+#	cache_dir with the images, and the same 'cache clear' prunes
+#	it. A half of the directory that nothing printed was a half
+#	nobody knew to bound.
 sub _proxy_list ($self)
 {
 	my $cache = FuguVM::Proxy::Cache->new( $self->{config}->cache_dir );
@@ -426,10 +430,11 @@ sub _proxy_list ($self)
 		return EXIT_SUCCESS;
 	}
 
-	# Per version, since that is the granularity 'clear --stale'
-	# prunes at. A URL naming no version - nothing is_cacheable()
-	# admits today - is counted under '-' rather than dropped, so an
-	# unprunable entry is still visible as one.
+	# Group the sizes per version, because 'clear --stale' prunes
+	# at that granularity. The code counts a URL that names no
+	# version under '-' and does not drop it. is_cacheable() admits
+	# no such URL today. Thus an entry that cannot be pruned is
+	# still visible as one.
 	my %bytes;
 	for my $file (@$files) {
 		my ($version) =
@@ -450,10 +455,10 @@ sub _proxy_list ($self)
 }
 
 # $self->_cache_clear($cache, @args):
-#	Remove cached entries. Bare 'clear' removes them all; --stale
-#	keeps the one the VM named by --vm derives. Because the key inputs
-#	'version' and 'disk_size' are per-VM, --stale run for one VM does
-#	prune bases another VM would have hit.
+#	Remove cached entries. Bare 'clear' removes them all. --stale
+#	keeps the entry that the VM named by --vm derives. The key
+#	inputs 'version' and 'disk_size' are per-VM. Thus --stale run
+#	for one VM does prune bases that another VM would have hit.
 sub _cache_clear ( $self, $cache, @args )
 {
 	my $stale  = 0;
@@ -462,7 +467,8 @@ sub _cache_clear ( $self, $cache, @args )
 	$parser->getoptionsfromarray( \@args, 'stale' => \$stale )
 	    or return EXIT_INVALID_ARGS;
 
-	# Interrupted stores leave partial trees behind whichever form ran
+	# An interrupted store leaves partial trees behind. Both forms
+	# of 'clear' sweep them.
 	my $swept = $cache->sweep_temp;
 	$self->{log}->info("Removed $swept incomplete cache entries")
 	    if $swept;
@@ -489,9 +495,10 @@ sub _cache_clear ( $self, $cache, @args )
 			return EXIT_VM_RUNNING;
 		}
 
-		# A stopped disk can be rebuilt with 'fuguvm destroy', so
-		# this is a warning. It cannot cover checkouts other than
-		# this one, which share cache_dir but not state_dir.
+		# The user can rebuild a stopped disk with
+		# 'fuguvm destroy'. Thus this is a warning. The check
+		# cannot cover checkouts other than this one. Those
+		# checkouts share cache_dir but not state_dir.
 		for my $user (@$users) {
 			$self->{log}->warning(
 				sprintf(
@@ -516,14 +523,16 @@ sub _cache_clear ( $self, $cache, @args )
 }
 
 # $self->_proxy_clear($stale):
-#	The other half of cache_dir: the proxy's download cache. Bare
-#	'clear' empties it, --stale keeps the OpenBSD version the invoked
-#	VM installs - the same one-VM scope the image prune above has.
+#	Clear the other half of cache_dir: the download cache of the
+#	proxy. Bare 'clear' empties it. --stale keeps the OpenBSD
+#	version that the invoked VM installs. That is the same one-VM
+#	scope that the image prune above has.
 #
-#	Not reachable from the image loop, which is why this is a second
-#	pass rather than a branch inside it: the two caches share nothing
-#	but cache_dir, and the images have running-VM and orphaned-disk
-#	checks that a re-downloadable file set does not need.
+#	The image loop cannot reach this cache. That is why this is a
+#	second pass, not a branch inside the loop. The two caches share
+#	nothing but cache_dir. Also, the images have running-VM and
+#	orphaned-disk checks that a re-downloadable file set does not
+#	need.
 sub _proxy_clear ( $self, $stale )
 {
 	my $cache = FuguVM::Proxy::Cache->new( $self->{config}->cache_dir );
@@ -540,8 +549,8 @@ sub _proxy_clear ( $self, $stale )
 		return EXIT_SUCCESS;
 	}
 
-	# --stale got this far, so the VM resolves; keeping its version is
-	# the point of the flag.
+	# The --stale path got this far. Thus the VM resolves. To keep
+	# its version is the point of the flag.
 	my $vm      = $self->{config}->load_vm( $self->{vm_name} );
 	my $removed = $cache->prune( $vm->{version} );
 
@@ -557,8 +566,9 @@ sub _proxy_clear ( $self, $stale )
 }
 
 # $self->_current_cache_key($cache):
-#	The key the invoked VM's configuration derives, or undef when the
-#	VM or one of the key inputs cannot be resolved.
+#	Return the key that the configuration of the invoked VM
+#	derives. Return undef when the VM or one of the key inputs
+#	cannot be resolved.
 sub _current_cache_key ( $self, $cache )
 {
 	my $vm_config = $self->{config}->load_vm( $self->{vm_name} );
@@ -568,10 +578,11 @@ sub _current_cache_key ( $self, $cache )
 }
 
 # $self->_disks_backed_by($entry_dir):
-#	Every VM in this checkout whose working disk hangs off an image in
-#	$entry_dir, as [ { vm => name, running => bool } ]. Enumerated
-#	from the state directory rather than the configuration, so a disk
-#	counts whether or not a 'vm' block still declares it.
+#	Return every VM in this checkout whose working disk hangs off
+#	an image in $entry_dir, as [ { vm => name, running => bool } ].
+#	The method enumerates the state directory, not the
+#	configuration. Thus a disk counts whether a 'vm' block still
+#	declares it or not.
 sub _disks_backed_by ( $self, $entry_dir )
 {
 	my $state_dir = $self->{config}->state_dir;
@@ -648,9 +659,9 @@ sub cmd_snapshot ( $self, @args )
 }
 
 # $self->_snapshot_save($cache, $name):
-#	Flatten the stopped working disk into the cache under the base it
-#	was built on. A live overlay is not consistent, so a running VM is
-#	refused rather than copied.
+#	Flatten the stopped working disk into the cache, under the base
+#	it was built on. A live overlay is not consistent. Thus the
+#	command refuses a running VM and does not copy it.
 sub _snapshot_save ( $self, $cache, $name )
 {
 	my $vm = $self->_load_vm or return EXIT_VM_NOT_FOUND;
@@ -670,9 +681,9 @@ sub _snapshot_save ( $self, $cache, $name )
 		return EXIT_ERROR;
 	}
 
-	# The snapshot belongs under whichever base the disk actually
-	# hangs off, directly or through another snapshot - re-saving
-	# after a restore is normal.
+	# The snapshot belongs under the base that the disk hangs off,
+	# directly or through another snapshot. To save again after a
+	# restore is normal.
 	my $key = $self->_disk_cache_key($cache);
 	if ( !defined $key ) {
 		$self->{log}->error(
@@ -705,9 +716,10 @@ sub _snapshot_save ( $self, $cache, $name )
 }
 
 # $self->_snapshot_restore($cache, $name):
-#	Replace the working disk with a fresh overlay on a snapshot and
-#	reseed the state that disk embodies. Works from nothing - no disk,
-#	no state - so a fresh checkout can restore before its first 'up'.
+#	Replace the working disk with a fresh overlay on a snapshot.
+#	Reseed the state that the disk embodies. The command works from
+#	nothing: no disk, no state. Thus a fresh checkout can restore
+#	before its first 'up'.
 sub _snapshot_restore ( $self, $cache, $name )
 {
 	my $vm    = $self->_load_vm or return EXIT_VM_NOT_FOUND;
@@ -730,8 +742,8 @@ sub _snapshot_restore ( $self, $cache, $name )
 		return EXIT_SNAPSHOT_NOT_FOUND;
 	}
 
-	# Disk::create returns early on an existing path, so without this
-	# a restore would report success and change nothing.
+	# Disk::create returns early on an existing path. Without this
+	# removal, a restore would report success and change nothing.
 	my $disk_path = $state->disk_path;
 	if ( -f $disk_path ) {
 		unlink $disk_path or do {
@@ -749,8 +761,8 @@ sub _snapshot_restore ( $self, $cache, $name )
 		return EXIT_ERROR;
 	}
 
-	# Reseed what the disk embodies. A checkout whose SSH key differs
-	# from the saved one is reconciled by the next 'fuguvm up'.
+	# Reseed what the disk embodies. The next 'fuguvm up' reconciles
+	# a checkout whose SSH key differs from the saved one.
 	my $meta = $found->{meta};
 	$state->mark_installed;
 	$state->set_root_password( $meta->{root_password} )
@@ -830,16 +842,16 @@ sub _snapshot_remove ( $self, $cache, $name )
 }
 
 # $self->_disk_cache_key($cache):
-#	The cache entry the working disk is built on, whether directly on
-#	its base image or through a snapshot of it.
+#	Return the cache entry that backs the working disk, directly
+#	with its base image or through a snapshot of it.
 sub _disk_cache_key ( $self, $cache )
 {
 	my $vm_config = $self->{config}->load_vm( $self->{vm_name} );
 	return if !defined $vm_config;
 
 	# Scalar context: backing_file returns an empty list for a
-	# standalone disk, which would reach key_for_path as no argument
-	# at all rather than as undef.
+	# standalone disk. Without scalar context, the empty list would
+	# reach key_for_path as no argument at all, not as undef.
 	my $disk    = FuguVM::Disk->new( $self->{config}->state_dir );
 	my $backing = $disk->backing_file( $vm_config->{name} );
 
@@ -864,7 +876,7 @@ sub cmd_disk ( $self, @args )
 			return EXIT_ERROR;
 		}
 
-		# Print info in a readable format
+		# Print the info in a readable format
 		for my $key ( sort keys %$info ) {
 			$self->{log}->info("$key: $info->{$key}");
 		}
@@ -892,7 +904,7 @@ sub cmd_disk ( $self, @args )
 	if ( $action eq 'repair' ) {
 		$self->{log}->info("Repairing disk image...");
 
-		# Check if VM is running first
+		# First, check if the VM runs
 		my $vm = $self->_load_vm;
 		if ( defined $vm && $vm->is_running ) {
 			$self->{log}
@@ -903,7 +915,8 @@ sub cmd_disk ( $self, @args )
 		my $ok = $disk->repair( $self->{vm_name} );
 		if ($ok) {
 
-			# Clear unclean shutdown state after successful repair
+			# Clear the unclean shutdown state after a
+			# successful repair
 			$self->{state}->clear_shutdown_state;
 			$self->{log}->info("Disk repaired");
 			return EXIT_SUCCESS;
@@ -916,7 +929,7 @@ sub cmd_disk ( $self, @args )
 	return EXIT_ERROR;
 }
 
-# Initialize project
+# Initialize the project
 sub cmd_init ( $self, @args )
 {
 	my $dir         = shift @args // '.';
@@ -929,7 +942,7 @@ sub cmd_init ( $self, @args )
 		return EXIT_SUCCESS;
 	}
 
-	# Check if directory is writable
+	# Check if the directory is writable
 	if ( !-d $dir ) {
 		$self->{log}->error("Directory does not exist: $dir");
 		return EXIT_ERROR;
@@ -950,8 +963,9 @@ sub cmd_init ( $self, @args )
 		return EXIT_ERROR;
 	}
 
-	# Create project config.  state_dir has to agree with the directory
-	# created above, so it derives from the same constant.
+	# Create the project configuration. state_dir must agree with
+	# the directory created above. Thus it derives from the same
+	# constant.
 	_write_file( $config_file, <<"EOF" );
 # FuguVM project configuration
 
@@ -960,7 +974,7 @@ state_dir = $data_dir/state
 default_vm = default
 EOF
 
-	# Create default VM config
+	# Create the default VM config
 	_write_file( "$fuguvm_dir/vms/default.conf", <<"EOF" );
 # Default OpenBSD VM
 
@@ -973,7 +987,7 @@ ssh_port = 2222
 console_port = 4444
 EOF
 
-	# Create .gitignore
+	# Create the .gitignore file
 	_write_file( "$fuguvm_dir/.gitignore", <<'EOF' );
 state/
 *.log

--- a/lib/FuguVM/Config.pm
+++ b/lib/FuguVM/Config.pm
@@ -44,7 +44,7 @@ sub new ( $class, $project_root )
 	return $self;
 }
 
-# Walk up directory tree looking for .fuguvmrc
+# Walk up the directory tree to find .fuguvmrc
 sub find_project_root ($class)
 {
 	my $dir = File::Spec->rel2abs('.');
@@ -54,7 +54,7 @@ sub find_project_root ($class)
 		return $dir if -f $config_file;
 
 		my $parent = dirname($dir);
-		last if $parent eq $dir;    # Reached root
+		last if $parent eq $dir;    # The walk reached the root
 		$dir = $parent;
 	}
 
@@ -63,13 +63,13 @@ sub find_project_root ($class)
 
 sub _load_configs ($self)
 {
-	# Load global config from home directory
+	# Load the global config from the home directory
 	my $home          = $ENV{HOME} // '/root';
 	my $global_config = "$home/" . GLOBAL_CONFIG;
 	$self->{global} =
 	    -f $global_config ? $self->_parse_config($global_config) : {};
 
-	# Load project config from project root
+	# Load the project config from the project root
 	my $project_config = "$self->{project_root}/" . PROJECT_CONFIG;
 	$self->{project} =
 	    -f $project_config ? $self->_parse_config($project_config) : {};
@@ -77,7 +77,7 @@ sub _load_configs ($self)
 	return $self;
 }
 
-# Parse OpenBSD-style config with optional block syntax:
+# Parse an OpenBSD-style config with the optional block syntax:
 #
 #   key value
 #
@@ -99,8 +99,8 @@ sub _parse_config ( $self, $path )
 
 	while (<$fh>) {
 		chomp;
-		s/#.*//;           # Remove comments
-		s/^\s+|\s+$//g;    # Trim whitespace
+		s/#.*//;           # Remove the comments
+		s/^\s+|\s+$//g;    # Trim the whitespace
 		next if $_ eq '';
 
 		# Block start: vm "name" { or vm name {
@@ -124,11 +124,12 @@ sub _parse_config ( $self, $path )
 			next;
 		}
 
-		# Key-value pair (inside or outside block)
-		# Supports both "key value" and "key = value" syntax
+		# A key-value pair, inside or outside a block. The parser
+		# supports both the "key value" and the "key = value"
+		# syntax.
 		if (/^(\w+)\s+(.+)$/) {
 			my ( $key, $value ) = ( $1, $2 );
-			$value =~ s/^=\s*//;      # Strip leading '=' if present
+			$value =~ s/^=\s*//;       # Remove a leading '=' if any
 			$value =~ s/^\s+|\s+$//g;
 			$value =~ s/^"(.*)"$/$1/;
 			if ( defined $block_data ) {
@@ -146,10 +147,11 @@ sub _parse_config ( $self, $path )
 
 sub load_vm ( $self, $name )
 {
-	# First check for VM block in project config, then global config
+	# First check for a VM block in the project config. Then check
+	# the global config.
 	my $vm = $self->{project}{vm}{$name} // $self->{global}{vm}{$name};
 
-	# Fall back to separate VM file for backwards compatibility
+	# Fall back to a separate VM file for backwards compatibility
 	if ( !defined $vm ) {
 		my $vm_file = "$self->{data_dir}/vms/$name.conf";
 		$vm = $self->_parse_config($vm_file) if -f $vm_file;
@@ -157,7 +159,7 @@ sub load_vm ( $self, $name )
 
 	return if !defined $vm;
 
-	# Apply defaults
+	# Apply the defaults
 	$vm->{name}         //= $name;
 	$vm->{version}      //= DEFAULT_VERSION;
 	$vm->{memory}       //= DEFAULT_MEMORY;
@@ -165,13 +167,14 @@ sub load_vm ( $self, $name )
 	$vm->{ssh_port}     //= DEFAULT_SSH_PORT;
 	$vm->{console_port} //= DEFAULT_CONSOLE_PORT;
 
-	# Include ssh_pubkey from global/project config
+	# Include ssh_pubkey from the global or project config
 	$vm->{ssh_pubkey} //= $self->ssh_pubkey;
 
-	# Include the resolved cache_dir so VM operations (proxy cache,
-	# installed-image cache) all use the configured location. Without
-	# it 'fuguvm up' would write its images under $HOME while the
-	# cache subcommands worked on a different tree.
+	# Include the resolved cache_dir. Then the VM operations, the
+	# proxy cache and the installed-image cache, all use the
+	# configured location. Without it, 'fuguvm up' would write its
+	# images under $HOME while the cache subcommands worked on a
+	# different tree.
 	$vm->{cache_dir} //= $self->cache_dir;
 
 	# Normalize the installed-image cache switch, whether it came from
@@ -196,8 +199,9 @@ sub cache_dir ($self)
 }
 
 # $self->image_cache:
-#	Whether 'fuguvm up' may use the installed-image cache. Project
-#	configuration wins over global; the default is on.
+#	Return whether 'fuguvm up' may use the installed-image cache.
+#	The project configuration wins over the global one. The default
+#	is on.
 sub image_cache ($self)
 {
 	my $value = $self->{project}{image_cache}
@@ -208,9 +212,9 @@ sub image_cache ($self)
 }
 
 # _parse_bool($value, $default):
-#	Accept the spellings an OpenBSD-style configuration file uses for
-#	a switch. An unrecognized value warns and falls back rather than
-#	silently meaning its opposite.
+#	Accept the spellings that an OpenBSD-style configuration file
+#	uses for a switch. An unrecognized value warns and falls back.
+#	It does not silently mean its opposite.
 sub _parse_bool ( $value, $default )
 {
 	my $normalized = lc $value;
@@ -235,7 +239,7 @@ sub state_dir ($self)
 {
 	my $dir = $self->{project}{state_dir} // "$self->{data_dir}/state";
 
-	# Make relative paths absolute to project root
+	# Make relative paths absolute to the project root
 	if ( $dir !~ m{^/} ) {
 		$dir = "$self->{project_root}/$dir";
 	}

--- a/lib/FuguVM/Disk.pm
+++ b/lib/FuguVM/Disk.pm
@@ -30,13 +30,14 @@ sub new ( $class, $state_dir )
 }
 
 # $self->create($name, $size, $backing_image, $backing_format):
-#	Create the VM disk image. $size may be undef for an overlay, which
-#	then inherits the virtual size of $backing_image. $backing_format
-#	names the format of $backing_image ('qcow2' for cached base images
-#	and snapshots, 'raw' otherwise).
+#	Create the VM disk image. $size can be undef for an overlay.
+#	The overlay then inherits the virtual size of $backing_image.
+#	$backing_format names the format of $backing_image. Use 'qcow2'
+#	for cached base images and snapshots. Use 'raw' in other cases.
 #
-#	Returns early when the path already exists, so callers replacing a
-#	disk with an overlay must unlink it first.
+#	The method returns early when the path already exists. Thus
+#	callers that replace a disk with an overlay must unlink the
+#	disk first.
 sub create (
 	$self, $name,
 	$size           = undef,
@@ -60,8 +61,9 @@ sub create (
 	push @cmd, $path;
 	push @cmd, $size if defined $size;
 
-# Suppress qemu-img's verbose "Formatting..." output by redirecting to /dev/null
-# We use shell redirection since system() doesn't provide output control
+	# Redirect the output to /dev/null. This removes the verbose
+	# "Formatting..." messages of qemu-img. The code uses a shell
+	# redirection because system() gives no output control.
 	my $cmd_str =
 	    join( ' ', map { my $s = $_; $s =~ s/'/'\\''/g; "'$s'" } @cmd );
 	my $result = system("$cmd_str >/dev/null 2>&1");
@@ -97,12 +99,14 @@ sub remove ( $self, $name )
 }
 
 # $self->info($name):
-#	qemu-img's report on the disk as a hashref, or undef when there is
-#	no disk or it cannot be read. Inspection is read-only, so it asks
-#	for shared access (-U): a running QEMU holds an exclusive lock, and
-#	without this the query fails on exactly the VMs whose backing chain
-#	callers most need to resolve - 'cache clear' skipping a running
-#	VM's disk would remove the base out from under it.
+#	Get the qemu-img report on the disk as a hashref. The method
+#	returns undef when there is no disk or when it cannot read the
+#	disk. The inspection is read-only. Thus it asks for shared
+#	access with -U. A running QEMU holds an exclusive lock. Without
+#	shared access, the query fails on exactly the VMs whose backing
+#	chain callers most need to resolve. If 'cache clear' skips the
+#	disk of a running VM, it can remove the base from under that
+#	VM.
 sub info ( $self, $name )
 {
 	my $path = $self->path($name);
@@ -116,10 +120,11 @@ sub info ( $self, $name )
 }
 
 # $self->backing_file($name):
-#	Absolute path of the image the disk is backed by, or undef when
-#	the disk is standalone or cannot be inspected. qemu-img reports a
-#	backing reference even when the file it names is gone, which is
-#	what makes a broken chain diagnosable.
+#	Get the absolute path of the image that backs the disk. The
+#	method returns undef when the disk is standalone or when it
+#	cannot inspect the disk. qemu-img reports a backing reference
+#	even when the file it names is gone. This lets callers diagnose
+#	a broken chain.
 sub backing_file ( $self, $name )
 {
 	my $info = $self->info($name);
@@ -137,8 +142,9 @@ sub backing_file ( $self, $name )
 	return $backing;
 }
 
-# P5: Check disk image integrity
-# Returns hashref with 'status' ('ok' or 'corrupted') and 'output'
+# P5: Check the disk image integrity. The method returns a hashref
+# with the 'status' and 'output' keys. The 'status' key is 'ok' or
+# 'corrupted'.
 sub check ( $self, $name )
 {
 	my $path = $self->path($name);
@@ -162,14 +168,14 @@ sub check ( $self, $name )
 	};
 }
 
-# P5: Repair disk image
-# Returns true on success, false on failure
+# P5: Repair the disk image. The method returns true on success and
+# false on failure.
 sub repair ( $self, $name )
 {
 	my $path = $self->path($name);
 	return 0 if !-f $path;
 
-	# Run qemu-img check with repair option
+	# Run qemu-img check with the repair option
 	my $result = system( 'qemu-img', 'check', '-r', 'all', $path );
 	return $result == 0;
 }

--- a/lib/FuguVM/Expect.pm
+++ b/lib/FuguVM/Expect.pm
@@ -60,10 +60,11 @@ sub run_script ( $self, $script, @args )
 }
 
 # $class_or_self->script_path($script_name):
-#	Path of a shipped expect script, or undef when it cannot be
-#	found. Callable on the class: FuguVM::ImageCache hashes the
-#	installer script into its cache key and must resolve it the same
-#	way run_install does.
+#	Get the path of a shipped expect script. The method returns
+#	undef when it cannot find the script. The method also works on
+#	the class. FuguVM::ImageCache hashes the installer script into
+#	its cache key. Thus it must resolve the script the same way
+#	run_install does.
 sub script_path ( $self, $script_name )
 {
 	return $self->_find_script($script_name);
@@ -93,7 +94,7 @@ sub run_install ( $self, $config )
 		return 0;
 	}
 
-	# Pass timeout via environment variable
+	# Pass the timeout in the environment variable
 	local $ENV{FUGUVM_TIMEOUT} = $self->{timeout};
 
 	my @cmd = (
@@ -119,7 +120,8 @@ sub install_ssh_key ( $self, $password, $ssh_pubkey )
 		return 0;
 	}
 
-	# Pass timeout via environment variable for expect script
+	# Pass the timeout in the environment variable for the expect
+	# script
 	local $ENV{FUGUVM_TIMEOUT} = $self->{timeout};
 
 	my @cmd = (
@@ -139,7 +141,7 @@ sub halt_system ( $self, $password )
 		return 0;
 	}
 
-	# Pass timeout via environment variable
+	# Pass the timeout in the environment variable
 	local $ENV{FUGUVM_TIMEOUT} = $self->{timeout};
 
 	my @cmd = (

--- a/lib/FuguVM/Image.pm
+++ b/lib/FuguVM/Image.pm
@@ -21,10 +21,11 @@ package FuguVM::Image;
 
 # FuguVM::Image - Download and cache OpenBSD miniroot images
 #
-# This module provides access to OpenBSD miniroot images. Images are
-# automatically downloaded when needed and stored in the proxy cache for reuse.
-# Downloads use the scripts/ftp helper (curl/wget/ftp fallbacks) and files are
-# stored via the Proxy::Cache module for consistent caching.
+# This module gives access to OpenBSD miniroot images. It downloads an
+# image when necessary and stores it in the proxy cache for reuse.
+# Downloads use the scripts/ftp helper, which falls back through curl,
+# wget, and ftp. The Proxy::Cache module stores the files for
+# consistent caching.
 
 use constant {
 	CDN_HOST => 'cdn.openbsd.org',
@@ -33,7 +34,7 @@ use constant {
 
 sub new ( $class, $cache_dir, $proxy = undef )
 {
-	# Expand ~ in path
+	# Expand ~ in the path
 	$cache_dir =~ s/^~/$ENV{HOME}/;
 
 	my $self = bless {
@@ -45,8 +46,8 @@ sub new ( $class, $cache_dir, $proxy = undef )
 }
 
 # $self->path($version):
-#	Return path to cached miniroot image for given version
-#	Returns undef if not cached
+#	Return the path to the cached miniroot image for the given
+#	version. Return undef if the image is not cached.
 sub path ( $self, $version )
 {
 	my $path = $self->_image_path($version);
@@ -54,25 +55,26 @@ sub path ( $self, $version )
 }
 
 # $self->ensure($version):
-#	Ensure image is available, downloading if necessary
-#	Returns path on success, undef on failure
+#	Make sure that the image is available. Download it if
+#	necessary. Return the path on success, or undef on failure.
 sub ensure ( $self, $version )
 {
-	# Check if already cached
+	# Check if the image is already cached
 	my $path = $self->path($version);
 	return $path if defined $path;
 
-	# Download via proxy if available
+	# Download through the proxy if one is available
 	return $self->download($version);
 }
 
 # _ftp_script():
-#	Absolute path to the scripts/ftp helper, resolved from this
-#	module's own location: lib/FuguVM/Image.pm is two directories
-#	below the project root.  Factored out of download so a test can
-#	assert the path still resolves - download only warns when it does
-#	not, so a rename would otherwise degrade silently to "no download"
-#	instead of failing.
+#	Return the absolute path to the scripts/ftp helper. The path
+#	resolves from the location of this module: lib/FuguVM/Image.pm
+#	is two directories below the project root. The code factors
+#	this function out of download. Thus a test can make sure that
+#	the path still resolves. download only warns when the path does
+#	not resolve. Thus a rename would otherwise degrade silently to
+#	"no download" and would not fail.
 sub _ftp_script ()
 {
 	require File::Basename;
@@ -87,8 +89,8 @@ sub _ftp_script ()
 }
 
 # $self->download($version):
-#	Download miniroot image for version via proxy cache
-#	Returns path on success, undef on failure
+#	Download the miniroot image for the version through the proxy
+#	cache. Return the path on success, or undef on failure.
 sub download ( $self, $version )
 {
 	if ( !defined $self->{proxy} ) {
@@ -98,8 +100,8 @@ sub download ( $self, $version )
 
 	my $url = $self->url($version);
 
-	# Download using the scripts/ftp helper (uses curl/wget/ftp)
-	# Then store in proxy cache
+	# Download with the scripts/ftp helper, which uses curl, wget,
+	# or ftp. Then store the file in the proxy cache.
 	require File::Temp;
 	my $tmp      = File::Temp->new( SUFFIX => '.img' );
 	my $tmp_path = $tmp->filename;
@@ -111,20 +113,20 @@ sub download ( $self, $version )
 		return;
 	}
 
-	# Download to temp file
+	# Download to the temp file
 	my $result = system( $ftp, $tmp_path, $url );
 	if ( $result != 0 ) {
 		warn "Download failed: exit code $result\n";
 		return;
 	}
 
-	# Verify file was downloaded
+	# Make sure that the download wrote a file
 	if ( !-f $tmp_path || -z $tmp_path ) {
 		warn "Download succeeded but file is empty\n";
 		return;
 	}
 
-	# Store in proxy cache
+	# Store the file in the proxy cache
 	my $cache       = $self->{proxy}->cache;
 	my $cached_path = $cache->store_from_file( $url, $tmp_path );
 	if ( !defined $cached_path ) {
@@ -149,8 +151,8 @@ sub url ( $self, $version )
 }
 
 # $self->list:
-#	List all cached miniroot images
-#	Returns arrayref of { version, filename, path }
+#	List all the cached miniroot images. Return an arrayref of
+#	{ version, filename, path }.
 sub list ($self)
 {
 	my @images;
@@ -183,14 +185,15 @@ sub list ($self)
 	}
 	closedir $dh;
 
-	# Sort by version descending
+	# Sort by version in descending order
 	@images = sort { $b->{version} cmp $a->{version} } @images;
 
 	return \@images;
 }
 
 # $self->_image_filename($version):
-#	Generate miniroot filename for version (e.g., "miniroot78.img")
+#	Make the miniroot filename for the version, for example
+#	"miniroot78.img".
 sub _image_filename ( $self, $version )
 {
 	( my $ver = $version ) =~ s/\.//g;
@@ -198,7 +201,7 @@ sub _image_filename ( $self, $version )
 }
 
 # $self->_image_path($version):
-#	Return expected cache path for miniroot image
+#	Return the expected cache path for the miniroot image.
 sub _image_path ( $self, $version )
 {
 	my $filename = $self->_image_filename($version);
@@ -206,7 +209,7 @@ sub _image_path ( $self, $version )
 }
 
 # $self->_proxy_cache_path:
-#	Return base path for proxy-cached OpenBSD files
+#	Return the base path for the proxy-cached OpenBSD files.
 sub _proxy_cache_path ($self)
 {
 	return "$self->{cache_dir}/proxy/" . CDN_HOST . "/pub/OpenBSD";

--- a/lib/FuguVM/ImageCache.pm
+++ b/lib/FuguVM/ImageCache.pm
@@ -19,10 +19,10 @@ use v5.36;
 
 # FuguVM::ImageCache - cache of installed OpenBSD disk images
 #
-# Installing OpenBSD under TCG emulation costs tens of minutes. This
-# module keeps the result: a pristine, compacted copy of the disk taken
-# the moment the installer finished, which later runs use as the backing
-# image of a throwaway overlay.
+# An OpenBSD installation under TCG emulation costs tens of minutes.
+# This module keeps the result: a pristine, compacted copy of the disk,
+# taken the moment the installer finished. Later runs use that copy as
+# the backing image of a throwaway overlay.
 
 package FuguVM::ImageCache;
 
@@ -46,10 +46,11 @@ use constant {
 	MAX_SNAPSHOT_NAME => 128,
 };
 
-# Temporary entry trees still being built, removed by _cleanup_temp on
-# any failure path and from the END guard. The convert step runs for
-# minutes over multi-gigabyte images; an interrupt in the middle of it
-# is what would otherwise orphan them.
+# Temporary entry trees that are still under construction.
+# _cleanup_temp removes them on each failure path and from the END
+# guard. The convert step runs for minutes over multi-gigabyte images.
+# An interrupt in the middle of that step would otherwise orphan the
+# trees.
 my %TEMP_DIRS;
 
 END {
@@ -71,21 +72,22 @@ sub cache_dir ($self)
 }
 
 # $self->installed_dir:
-#	Directory holding every cached entry
+#	Return the directory that holds every cached entry.
 sub installed_dir ($self)
 {
 	return "$self->{cache_dir}/" . INSTALLED_DIR;
 }
 
 # $self->entry_dir($key):
-#	Directory of one cached entry
+#	Return the directory of one cached entry.
 sub entry_dir ( $self, $key )
 {
 	return $self->installed_dir . "/$key";
 }
 
 # $self->base_path($key):
-#	Absolute path of an entry's base image, whether or not it exists
+#	Return the absolute path of the base image of an entry. The
+#	method does not check that the image exists.
 sub base_path ( $self, $key )
 {
 	return $self->entry_dir($key) . '/' . BASE_NAME;
@@ -93,12 +95,13 @@ sub base_path ( $self, $key )
 
 # $self->key($vm_config):
 #	Derive the cache key for a VM configuration:
-#	<version>-<arch>-<hash8>. The hash covers everything that shapes
-#	an installed disk - the OpenBSD version, the architecture, the
-#	disk size, the installer script, and the generation counter - and
-#	nothing that does not, so memory and port changes keep hitting the
-#	same entry. Returns undef when an input cannot be read, which
-#	leaves the caller with no key and therefore no caching.
+#	<version>-<arch>-<hash8>. The hash covers everything that
+#	shapes an installed disk: the OpenBSD version, the
+#	architecture, the disk size, the installer script, and the
+#	generation counter. It covers nothing else. Thus memory and
+#	port changes keep hitting the same entry. Return undef when an
+#	input cannot be read. Then the caller has no key and thus no
+#	caching.
 sub key ( $self, $vm_config )
 {
 	my $version   = _sanitize( $vm_config->{version} // '' );
@@ -123,8 +126,9 @@ sub key ( $self, $vm_config )
 	my $generation = _read_file($generation_file);
 	return if !defined $generation;
 
-	# Hash file contents separately so the joined record stays free of
-	# newlines and the delimiter cannot be forged by an input value.
+	# Hash the file contents separately. Thus the joined record
+	# stays free of newlines, and an input value cannot forge the
+	# delimiter.
 	my @inputs = (
 		"version=$version",
 		"arch=$arch",
@@ -140,8 +144,9 @@ sub key ( $self, $vm_config )
 
 # $self->lookup($key):
 #	Return { base => path, meta => hashref, dir => path } for a
-#	complete entry, undef otherwise. A half-written entry is a miss,
-#	not an error: the caller falls back to a full installation.
+#	complete entry, or undef otherwise. A half-written entry is a
+#	miss, not an error. The caller falls back to a full
+#	installation.
 sub lookup ( $self, $key )
 {
 	return if !defined $key;
@@ -162,16 +167,17 @@ sub lookup ( $self, $key )
 }
 
 # $self->store($key, $disk_path, $meta):
-#	Publish $disk_path as the cached base image for $key. The entry is
-#	built whole in a sibling temporary directory and published by
-#	renaming that directory, so no reader ever sees one installation's
-#	base image beside another installation's metadata - a mismatch
-#	that would look live and then wedge every later boot with a root
+#	Publish $disk_path as the cached base image for $key. The
+#	method builds the entry whole in a sibling temporary directory.
+#	Then it publishes the entry with a rename of that directory.
+#	Thus no reader sees the base image of one installation beside
+#	the metadata of another installation. Such a mismatch would
+#	look live. It would then wedge every later boot with a root
 #	password that does not open the image.
 #
-#	Entries are write-once: rename onto a populated directory fails
-#	with ENOTEMPTY, and the existing entry wins. Returns the base
-#	image path, or undef on any failure.
+#	Entries are write-once: a rename onto a populated directory
+#	fails with ENOTEMPTY, and the existing entry wins. Return the
+#	base image path, or undef on any failure.
 sub store ( $self, $key, $disk_path, $meta = {} )
 {
 	return if !defined $key;
@@ -234,7 +240,7 @@ sub store ( $self, $key, $disk_path, $meta = {} )
 }
 
 # $self->list:
-#	Every complete entry, newest first, as
+#	Return every complete entry, newest first, as
 #	{ key, dir, base, size, created_at, meta, snapshots }
 sub list ($self)
 {
@@ -261,9 +267,10 @@ sub list ($self)
 }
 
 # $self->key_for_path($path):
-#	The cache key whose entry contains $path - a base image or a
-#	snapshot - or undef when $path lies outside the cache. Lets a
-#	caller answer "which cached image is this disk built on?".
+#	Return the cache key whose entry contains $path. The path can
+#	point to a base image or to a snapshot. Return undef when $path
+#	lies outside the cache. The method lets a caller answer "which
+#	cached image is this disk built on?".
 sub key_for_path ( $self, $path )
 {
 	return if !defined $path;
@@ -278,23 +285,26 @@ sub key_for_path ( $self, $path )
 }
 
 # $self->snapshot_dir($key):
-#	Directory holding an entry's named snapshot layers
+#	Return the directory that holds the named snapshot layers of
+#	an entry.
 sub snapshot_dir ( $self, $key )
 {
 	return $self->entry_dir($key) . '/' . SNAPSHOT_DIR;
 }
 
 # $self->snapshot_path($key, $name):
-#	Absolute path of a named snapshot, whether or not it exists
+#	Return the absolute path of a named snapshot. The method does
+#	not check that the snapshot exists.
 sub snapshot_path ( $self, $key, $name )
 {
 	return $self->snapshot_dir($key) . "/$name.qcow2";
 }
 
 # valid_snapshot_name($name):
-#	Snapshot names become file names inside the cache, so they are
-#	held to the same restrictions as VM names plus a leading
-#	alphanumeric, which keeps them clear of the cache's own dot-files.
+#	Snapshot names become file names inside the cache. Thus they
+#	obey the same restrictions as VM names, plus a leading
+#	alphanumeric. The leading alphanumeric keeps them clear of the
+#	dot-files of the cache.
 sub valid_snapshot_name ( $, $name )
 {
 	return 0 if !defined $name || $name eq '';
@@ -305,20 +315,21 @@ sub valid_snapshot_name ( $, $name )
 }
 
 # $self->snapshot_store($key, $name, $disk_path, $meta):
-#	Publish the (stopped) working disk as the named snapshot layer of
+#	Publish the stopped working disk as the named snapshot layer of
 #	entry $key.
 #
-#	The disk is flattened onto base.qcow2 rather than copied. A copy
-#	would carry the working disk's backing-file header verbatim, which
-#	is only correct while that disk hangs directly off the base: after
-#	a restore it hangs off a snapshot, so a copy would either stack
-#	chains without bound or - when the same name is re-saved, which a
-#	normal second run does - name itself as its own backing file.
-#	Flattening also keeps every snapshot a direct child of the base,
-#	so no snapshot is ever another's parent and removing one cannot
-#	orphan another.
+#	The method flattens the disk onto base.qcow2 and does not copy
+#	it. A copy would carry the backing-file header of the working
+#	disk verbatim. That header is only correct while the disk hangs
+#	directly off the base. After a restore the disk hangs off a
+#	snapshot. Thus a copy would stack chains without bound. A
+#	normal second run saves the same name again. Then a copy would
+#	name itself as its own backing file. The flatten operation also
+#	keeps every snapshot a direct child of the base. Thus no
+#	snapshot is the parent of another snapshot, and the removal of
+#	one snapshot cannot orphan another.
 #
-#	Returns the snapshot path, or undef on failure.
+#	Return the snapshot path, or undef on failure.
 sub snapshot_store ( $self, $key, $name, $disk_path, $meta = {} )
 {
 	if ( !$self->valid_snapshot_name($name) ) {
@@ -363,8 +374,8 @@ sub snapshot_store ( $self, $key, $name, $disk_path, $meta = {} )
 		return;
 	};
 
-	# The root password belongs to the base image, so it is copied
-	# from there rather than trusted from the caller.
+	# The root password belongs to the base image. Thus the method
+	# copies it from there and does not trust the caller.
 	my %record = (
 		%$meta,
 		key           => $key,
@@ -377,9 +388,10 @@ sub snapshot_store ( $self, $key, $name, $disk_path, $meta = {} )
 		return;
 	}
 
-	# Two renames, metadata first. Re-saving a name is normal, and a
-	# reader catching the window sees the previous image with the new
-	# metadata - fields that describe the base, which has not changed.
+	# Two renames, metadata first. To save a name again is normal.
+	# A reader that catches the window sees the previous image with
+	# the new metadata. Those fields describe the base, which did
+	# not change.
 	if ( !rename $tmp_meta, "$dir/$name.json" ) {
 		warn "Cannot publish snapshot metadata $name: $!\n";
 		unlink $tmp_disk, $tmp_meta;
@@ -395,10 +407,11 @@ sub snapshot_store ( $self, $key, $name, $disk_path, $meta = {} )
 }
 
 # $self->snapshot_lookup($key, $name):
-#	Return { key, name, path, meta } for a snapshot whose image, its
-#	metadata, and its backing chain all resolve; undef otherwise. A
-#	snapshot whose base has been removed is a miss, so a caller can
-#	fall back to provisioning from scratch instead of failing hard.
+#	Return { key, name, path, meta } for a snapshot whose image,
+#	metadata, and backing chain all resolve. Return undef
+#	otherwise. A snapshot whose base was removed is a miss. Thus a
+#	caller can fall back to a provision from scratch and does not
+#	fail hard.
 sub snapshot_lookup ( $self, $key, $name )
 {
 	return if !$self->valid_snapshot_name($name);
@@ -422,7 +435,8 @@ sub snapshot_lookup ( $self, $key, $name )
 }
 
 # $self->snapshot_list($key):
-#	Sorted snapshots of an entry, as { name, path, size, created_at }
+#	Return the sorted snapshots of an entry, as
+#	{ name, path, size, created_at }
 sub snapshot_list ( $self, $key )
 {
 	my @snapshots;
@@ -443,8 +457,9 @@ sub snapshot_list ( $self, $key )
 }
 
 # $self->snapshot_remove($key, $name):
-#	Delete a snapshot and its metadata. Safe in any order: snapshots
-#	are always direct children of the base, never of each other.
+#	Delete a snapshot and its metadata. Removal is safe in any
+#	order: snapshots are always direct children of the base, never
+#	of each other.
 sub snapshot_remove ( $self, $key, $name )
 {
 	return 0 if !$self->valid_snapshot_name($name);
@@ -465,7 +480,8 @@ sub snapshot_remove ( $self, $key, $name )
 }
 
 # $self->_snapshot_names($key):
-#	Sorted names of the named snapshot layers stored under an entry
+#	Return the sorted names of the named snapshot layers under an
+#	entry.
 sub _snapshot_names ( $self, $key )
 {
 	my $dir = $self->snapshot_dir($key);
@@ -483,7 +499,7 @@ sub _snapshot_names ( $self, $key )
 }
 
 # $self->remove($key):
-#	Delete a cached entry and everything under it. Returns true when
+#	Delete a cached entry and everything under it. Return true when
 #	the entry is gone afterwards.
 sub remove ( $self, $key )
 {
@@ -500,8 +516,9 @@ sub remove ( $self, $key )
 }
 
 # $self->sweep_temp:
-#	Remove temporary entry trees left behind by an interrupted store,
-#	including those from earlier processes. Returns the count removed.
+#	Remove the temporary entry trees that an interrupted store left
+#	behind. This includes trees from earlier processes. Return the
+#	count of removed trees.
 sub sweep_temp ($self)
 {
 	my $installed = $self->installed_dir;
@@ -525,7 +542,7 @@ sub sweep_temp ($self)
 
 # $self->_make_temp_dir:
 #	Create a private sibling directory for an entry under
-#	construction, registered for cleanup.
+#	construction. Register the directory for cleanup.
 sub _make_temp_dir ($self)
 {
 	my $installed = $self->installed_dir;
@@ -561,8 +578,9 @@ sub _cleanup_temp ()
 }
 
 # _convert($source, $target, $backing, $backing_format):
-#	Compact $source into a fresh qcow2 at $target, optionally leaving
-#	$backing as its parent so only the difference is stored.
+#	Compact $source into a fresh qcow2 at $target. When $backing is
+#	given, keep it as the parent. Then the target stores only the
+#	difference.
 sub _convert ( $source, $target, $backing = undef, $backing_format = 'qcow2' )
 {
 	my @cmd = ( 'qemu-img', 'convert', '-O', 'qcow2' );
@@ -579,18 +597,18 @@ sub _convert ( $source, $target, $backing = undef, $backing_format = 'qcow2' )
 }
 
 # $self->_install_script:
-#	The installer script whose bytes go into the cache key. Resolved
-#	through FuguVM::Expect so it is always the same file run_install
-#	would execute.
+#	Return the installer script whose bytes go into the cache key.
+#	The path resolves through FuguVM::Expect. Thus it is always the
+#	same file that run_install would execute.
 sub _install_script ($)
 {
 	return FuguVM::Expect->script_path(INSTALL_SCRIPT);
 }
 
 # $self->_generation_file:
-#	Locate share/fuguvm/cache-generation, whose contents rotate the
-#	cache key when the install driver changes in ways the install.exp
-#	hash cannot see.
+#	Locate share/fuguvm/cache-generation. Its contents rotate the
+#	cache key when the install driver changes in ways that the
+#	install.exp hash cannot see.
 sub _generation_file ($)
 {
 	my $module_dir = dirname( File::Spec->rel2abs(__FILE__) );
@@ -642,8 +660,8 @@ sub _read_json ($path)
 }
 
 # _write_json($path, $data):
-#	Write metadata readable only by its owner: it carries the guest
-#	root password.
+#	Write the metadata so that only its owner can read it. The
+#	metadata carries the guest root password.
 sub _write_json ( $path, $data )
 {
 	open my $fh, '>', $path or do {

--- a/lib/FuguVM/Output.pm
+++ b/lib/FuguVM/Output.pm
@@ -93,14 +93,14 @@ sub _format_data ( $self, $data, $indent = 0 )
 
 	if ( $indent == 0 ) {
 
-		# Top level: log all lines
+		# Top level: log all the lines
 		for my $line (@lines) {
 			$self->{log}->info($line);
 		}
 	}
 	else {
 
-		# Nested: return lines for parent
+		# Nested: return the lines to the parent
 		return @lines;
 	}
 }

--- a/lib/FuguVM/Proxy.pm
+++ b/lib/FuguVM/Proxy.pm
@@ -30,8 +30,8 @@ use FuguVM::Proxy::Cache;
 use FuguVM::Proxy::MetaCache;
 
 # $class->run_child($port, $cache_dir):
-#	Entry point for spawned child process
-#	Sets up cache and runs the proxy server
+#	The entry point for the spawned child process. The method sets
+#	up the cache and runs the proxy server.
 sub run_child ( $class, $port, $cache_dir )
 {
 	my $log       = FuguLib::Log->new( mode => 'stderr', level => 'debug' );
@@ -46,7 +46,7 @@ sub run_child ( $class, $port, $cache_dir )
 	$log->info( 'Proxy starting on port %d', $port );
 	$log->info( 'Cache directory: %s',       $cache_dir );
 
-	# Pre-warm metadata cache
+	# Warm the metadata cache before the proxy serves requests
 	my $start_time = time;
 	$metacache->warm($cache);
 	my $warm_time = time - $start_time;
@@ -77,11 +77,11 @@ sub new ( $class, $state, $cache_dir )
 }
 
 # $self->start:
-#	Start the proxy server
-#	Returns port number on success, undef on failure
+#	Start the proxy server. The method returns the port number on
+#	success and undef on failure.
 sub start ($self)
 {
-	# Check if already running
+	# Check if the proxy already runs
 	if ( $self->is_running ) {
 		return $self->{state}->get_proxy_port;
 	}
@@ -94,7 +94,7 @@ sub start ($self)
 		return;
 	}
 
-	# Spawn proxy using FuguLib::Process
+	# Spawn the proxy with FuguLib::Process
 	my $log       = $self->{state}->vm_state_dir . "/proxy.log";
 	my $cache_dir = $self->{cache_dir};
 	my $result    = FuguLib::Process->spawn_perl(
@@ -106,7 +106,7 @@ sub start ($self)
 		check_alive => 1,
 		on_success  => sub ($pid) {
 
-			# Record state in callback
+			# Record the state in the callback
 			$self->{state}->set_proxy_pid($pid);
 			$self->{state}->set_proxy_port($port);
 		},
@@ -117,7 +117,7 @@ sub start ($self)
 
 	return unless $result->{success};
 
-	# Wait for proxy to be ready
+	# Wait until the proxy is ready
 	if ( !$self->wait_ready(CONNECT_TIMEOUT) ) {
 		warn "Proxy failed to become ready\n";
 		$self->stop;
@@ -128,7 +128,8 @@ sub start ($self)
 }
 
 # $self->stop:
-#	Stop the proxy server gracefully
+#	Stop the proxy server. Send SIGTERM first, then SIGKILL if the
+#	process stays.
 sub stop ($self)
 {
 	my $pid = $self->{state}->get_proxy_pid;
@@ -138,14 +139,14 @@ sub stop ($self)
 	if ( kill( 0, $pid ) ) {
 		kill( 'TERM', $pid );
 
-		# Wait for exit
+		# Wait until the process exits
 		my $waited = 0;
 		while ( $waited < 5 && kill( 0, $pid ) ) {
 			sleep 1;
 			$waited++;
 		}
 
-		# Force kill if needed
+		# Send SIGKILL if the process does not exit
 		if ( kill( 0, $pid ) ) {
 			kill( 'KILL', $pid );
 			sleep 1;
@@ -159,21 +160,22 @@ sub stop ($self)
 }
 
 # $self->is_running:
-#	Check if proxy is running
+#	Check if the proxy runs
 sub is_running ($self)
 {
 	return $self->{state}->is_proxy_running;
 }
 
 # $self->port:
-#	Get current proxy port
+#	Get the current proxy port
 sub port ($self)
 {
 	return $self->{state}->get_proxy_port;
 }
 
 # $self->guest_url:
-#	Get proxy URL for use from VM guest (via QEMU gateway)
+#	Get the proxy URL for use from the VM guest. The URL goes
+#	through the QEMU gateway.
 sub guest_url ($self)
 {
 	my $port = $self->port;
@@ -183,7 +185,8 @@ sub guest_url ($self)
 }
 
 # $self->host_url:
-#	Get proxy URL for use from host (localhost)
+#	Get the proxy URL for use from the host. The URL points to
+#	localhost.
 sub host_url ($self)
 {
 	my $port = $self->port;
@@ -193,7 +196,7 @@ sub host_url ($self)
 }
 
 # $self->wait_ready($timeout):
-#	Wait for proxy to accept connections
+#	Wait until the proxy accepts connections
 sub wait_ready ( $self, $timeout = CONNECT_TIMEOUT )
 {
 	my $port = $self->{state}->get_proxy_port;
@@ -243,7 +246,7 @@ sub _find_available_port ($self)
 }
 
 # $self->_run_proxy($port):
-#	Run the proxy server (called in child process)
+#	Run the proxy server. The child process calls this method.
 sub _run_proxy ( $self, $port )
 {
 	require HTTP::Daemon;
@@ -251,7 +254,7 @@ sub _run_proxy ( $self, $port )
 	require HTTP::Response;
 	require IO::Select;
 
-	# Ignore SIGPIPE - clients may disconnect mid-transfer
+	# Ignore SIGPIPE. Clients can disconnect during a transfer.
 	local $SIG{PIPE} = 'IGNORE';
 
 	my $daemon = HTTP::Daemon->new(
@@ -263,15 +266,15 @@ sub _run_proxy ( $self, $port )
 
 	$self->{log}->info( 'Proxy listening on 0.0.0.0:%d', $port );
 
-	# Self-pipe trick for reliable signal handling
+	# Use the self-pipe trick for reliable signal handling
 	pipe( my $sig_read, my $sig_write ) or die "pipe: $!";
 	$sig_read->blocking(0);
 	$sig_write->blocking(0);
 
-	# Use IO::Select to wait on both daemon and signal pipe
+	# Use IO::Select to wait on the daemon and the signal pipe
 	my $select = IO::Select->new( $daemon, $sig_read );
 
-	# Handle SIGTERM gracefully by writing to self-pipe
+	# On SIGTERM, write to the self-pipe. This stops the loop safely.
 	my $running = 1;
 	local $SIG{TERM} = sub {
 		$self->{log}->info('Received SIGTERM, shutting down');
@@ -281,13 +284,13 @@ sub _run_proxy ( $self, $port )
 
 	while ($running) {
 
-		# Wait for either client connection or signal
+		# Wait for a client connection or a signal
 		my @ready = $select->can_read;
 		last if !$running;
 
 		for my $fh (@ready) {
 
-			# Drain signal pipe if signaled
+			# Drain the signal pipe after a signal
 			if ( $fh == $sig_read ) {
 				my $buf;
 				sysread $sig_read, $buf, 100;
@@ -311,7 +314,7 @@ sub _handle_client ( $self, $client )
 {
 	while ( my $request = $client->get_request ) {
 
-		# Check if we can stream directly from cache
+		# Check if the proxy can stream directly from the cache
 		my $method      = $request->method;
 		my $url         = $request->uri->as_string;
 		my $client_addr = $client->peerhost;
@@ -359,19 +362,19 @@ sub _process_request ( $self, $request )
 	my $method = $request->method;
 	my $url    = $request->uri->as_string;
 
-	# Only handle GET and HEAD for caching
+	# Cache only GET and HEAD requests
 	if ( $method ne 'GET' && $method ne 'HEAD' ) {
 		return $self->_forward_request($request);
 	}
 
-	# Check cache first
+	# Check the cache first
 	my $cached = $self->{cache}->lookup($url);
 	if ( defined $cached ) {
 		$self->{log}->info( 'CACHE HIT (disk): %s', $url );
 		return $self->_serve_cached( $cached, $request );
 	}
 
-	# Fetch from upstream
+	# Fetch the response from the upstream server
 	$self->{log}->info( 'CACHE MISS: Fetching from upstream: %s', $url );
 	my $fetch_start   = time;
 	my $response      = $self->_forward_request($request);
@@ -385,7 +388,7 @@ sub _process_request ( $self, $request )
 	    ->info( 'Fetched %d bytes in %.3f seconds (%.2f MB/s) - Status: %d',
 		$content_size, $fetch_elapsed, $fetch_rate, $response->code );
 
-	# Cache if appropriate
+	# Cache the response if it is cacheable
 	if (       $response->is_success
 		&& $self->{cache}->is_cacheable( $url, $response->code ) )
 	{
@@ -420,7 +423,7 @@ sub _forward_request ( $self, $request )
 		agent   => 'FuguVM-Proxy/1.0',
 	);
 
-	# Clone request for forwarding
+	# Clone the request to forward it
 	my $url = $request->uri->as_string;
 	my $forwarded =
 	    HTTP::Request->new( $request->method, $url,
@@ -452,7 +455,7 @@ sub _serve_cached ( $self, $path, $request )
 	$response->header( 'Content-Length' => length($content) );
 	$response->header( 'X-Cache'        => 'HIT' );
 
-	# Guess content type from URL
+	# Guess the content type from the URL
 	my $url = $request->uri->as_string;
 	if ( $url =~ /\.tgz$/ ) {
 		$response->header( 'Content-Type' => 'application/x-gzip' );
@@ -466,7 +469,7 @@ sub _serve_cached ( $self, $path, $request )
 			'Content-Type' => 'application/octet-stream' );
 	}
 
-	# Only include content for GET requests
+	# Include the content only for GET requests
 	if ( $request->method eq 'GET' ) {
 		$response->content($content);
 	}
@@ -477,11 +480,11 @@ sub _serve_cached ( $self, $path, $request )
 # New optimized streaming implementation
 sub _serve_cached_streaming ( $self, $socket, $meta, $request )
 {
-	# Optimize socket for large transfers
-	# Disable Nagle's algorithm for immediate sends
+	# Set the socket options for large transfers. Disable Nagle's
+	# algorithm to send data immediately.
 	setsockopt( $socket, IPPROTO_TCP, TCP_NODELAY, 1 );
 
-	# Increase send buffer to 1MB to reduce syscall overhead
+	# Increase the send buffer to 1MB to reduce the syscall overhead
 	setsockopt( $socket, SOL_SOCKET, SO_SNDBUF, pack( 'I', 1048576 ) );
 
 	$self->{log}->debug('Applied TCP_NODELAY and 1MB send buffer');
@@ -491,7 +494,7 @@ sub _serve_cached_streaming ( $self, $socket, $meta, $request )
 	my $size   = $meta->{size};
 	my $etag   = $meta->{etag};
 
-	# Handle If-None-Match for 304 responses
+	# Send a 304 response when If-None-Match matches the ETag
 	my $if_none_match = $request->header('If-None-Match');
 	if ( defined $if_none_match && $if_none_match eq $etag ) {
 		$self->{log}->info('Sending 304 Not Modified (ETag match)');
@@ -500,7 +503,7 @@ sub _serve_cached_streaming ( $self, $socket, $meta, $request )
 		return;
 	}
 
-	# Send headers
+	# Send the headers
 	my $headers = {
 		'Content-Type'   => $meta->{content_type},
 		'Content-Length' => $size,
@@ -512,7 +515,7 @@ sub _serve_cached_streaming ( $self, $socket, $meta, $request )
 		200, 'OK', $size, $meta->{content_type} );
 	$self->_send_response_headers( $socket, 200, 'OK', $headers );
 
-	# Stream file body for GET requests
+	# Stream the file body for GET requests
 	if ( $method eq 'GET' ) {
 		$self->{log}
 		    ->debug( 'Starting stream: %s (%d bytes)', $path, $size );
@@ -538,7 +541,7 @@ sub _serve_cached_streaming ( $self, $socket, $meta, $request )
 	}
 }
 
-# Send HTTP response headers to socket
+# Send the HTTP response headers to the socket
 sub _send_response_headers ( $self, $socket, $code, $message, $headers )
 {
 	my $response = "HTTP/1.1 $code $message\r\n";
@@ -547,7 +550,7 @@ sub _send_response_headers ( $self, $socket, $code, $message, $headers )
 	}
 	$response .= "\r\n";
 
-	# Use syswrite to ensure all bytes are sent
+	# Use syswrite in a loop to make sure that all bytes go out
 	my $len    = length $response;
 	my $offset = 0;
 	while ( $offset < $len ) {
@@ -558,7 +561,7 @@ sub _send_response_headers ( $self, $socket, $code, $message, $headers )
 	}
 }
 
-# Stream file to socket using large buffers (256KB)
+# Stream the file to the socket with large 256KB buffers
 sub _stream_file_to_socket ( $self, $socket, $path, $size )
 {
 	open my $fh, '<', $path or do {
@@ -568,7 +571,7 @@ sub _stream_file_to_socket ( $self, $socket, $path, $size )
 	};
 	binmode $fh;
 
-	# Use 256KB chunks for optimal throughput
+	# Use 256KB chunks to get the best throughput
 	use constant CHUNK_SIZE => 262144;    # 256KB
 
 	my $bytes_sent = 0;
@@ -584,7 +587,7 @@ sub _stream_file_to_socket ( $self, $socket, $path, $size )
 			last;
 		}
 
-		# Handle partial writes
+		# Write the remaining bytes after a partial write
 		my $offset = 0;
 		while ( $offset < $n ) {
 			my $written =

--- a/lib/FuguVM/Proxy/Cache.pm
+++ b/lib/FuguVM/Proxy/Cache.pm
@@ -22,7 +22,7 @@ package FuguVM::Proxy::Cache;
 use File::Basename;
 use File::Path qw(make_path);
 
-# Patterns for content that should be cached (OpenBSD-specific)
+# The patterns match the content to cache. They are OpenBSD-specific.
 my @CACHEABLE_PATTERNS = (
 	qr{/pub/OpenBSD/\d+\.\d+/\w+/.*\.(tgz|img|gz)$},    # File sets
 	qr{/pub/OpenBSD/syspatch/.*\.tgz$},                 # Patches
@@ -52,8 +52,8 @@ sub _ensure_dir ($self)
 }
 
 # $self->cache_path($url):
-#	Convert URL to filesystem cache path
-#	Returns undef if URL cannot be converted safely
+#	Convert the URL to a filesystem cache path. The method returns
+#	undef if it cannot convert the URL safely.
 sub cache_path ( $self, $url )
 {
 	require URI;
@@ -66,20 +66,20 @@ sub cache_path ( $self, $url )
 	my $path = $uri->path // return;
 	$path =~ s|^/||;
 
-	# Security: reject hostile paths outright
+	# Security: reject hostile paths before any use
 	return if $path eq '' || $path =~ /\.\./;
 
 	return "$self->{cache_dir}/proxy/$host/$path";
 }
 
 # $self->is_cacheable($url, $status_code):
-#	Determine if a URL response should be cached
+#	Check if a URL response is cacheable
 sub is_cacheable ( $self, $url, $status_code = 200 )
 {
-	# Only cache successful responses
+	# Cache only successful responses
 	return 0 if $status_code != 200;
 
-	# Check against cacheable patterns
+	# Check the URL against the cacheable patterns
 	for my $pattern (@CACHEABLE_PATTERNS) {
 		return 1 if $url =~ $pattern;
 	}
@@ -88,8 +88,8 @@ sub is_cacheable ( $self, $url, $status_code = 200 )
 }
 
 # $self->lookup($url):
-#	Check if URL is in cache
-#	Returns cache file path if found, undef otherwise
+#	Check if the URL is in the cache. The method returns the cache
+#	file path if the file exists and undef otherwise.
 sub lookup ( $self, $url )
 {
 	my $path = $self->cache_path($url);
@@ -99,14 +99,14 @@ sub lookup ( $self, $url )
 }
 
 # $self->store($url, $content):
-#	Store content in cache
-#	Returns cache file path on success, undef on failure
+#	Store the content in the cache. The method returns the cache
+#	file path on success and undef on failure.
 sub store ( $self, $url, $content )
 {
 	my $path = $self->cache_path($url);
 	return if !defined $path;
 
-	# Create directory structure
+	# Create the directory structure
 	my $dir = dirname($path);
 	make_path( $dir, { error => \my $err } );
 	if ( $err && @$err ) {
@@ -115,7 +115,8 @@ sub store ( $self, $url, $content )
 		return;
 	}
 
-	# Write to temp file then rename for atomicity
+	# Write to a temp file. Then rename the file to make the store
+	# atomic.
 	my $tmp = "$path.tmp.$$";
 	open my $fh, '>', $tmp or do {
 		warn "Cannot write cache file $tmp: $!";
@@ -136,14 +137,14 @@ sub store ( $self, $url, $content )
 }
 
 # $self->store_from_file($url, $source_path):
-#	Store content from a file into cache
-#	Returns cache file path on success, undef on failure
+#	Store the content of a file into the cache. The method returns
+#	the cache file path on success and undef on failure.
 sub store_from_file ( $self, $url, $source_path )
 {
 	my $path = $self->cache_path($url);
 	return if !defined $path;
 
-	# Create directory structure
+	# Create the directory structure
 	my $dir = dirname($path);
 	make_path( $dir, { error => \my $err } );
 	if ( $err && @$err ) {
@@ -152,7 +153,7 @@ sub store_from_file ( $self, $url, $source_path )
 		return;
 	}
 
-	# Copy file
+	# Copy the file
 	require File::Copy;
 	File::Copy::copy( $source_path, $path ) or do {
 		warn "Cannot copy $source_path to $path: $!";
@@ -163,7 +164,7 @@ sub store_from_file ( $self, $url, $source_path )
 }
 
 # $self->size:
-#	Calculate total cache size in bytes
+#	Calculate the total cache size in bytes
 sub size ($self)
 {
 	my $proxy_dir = "$self->{cache_dir}/proxy";
@@ -174,24 +175,27 @@ sub size ($self)
 
 # $self->prune(@keep):
 #	Remove the cached download tree of every OpenBSD version other
-#	than @keep. Returns [ { version, path, size } ] for what went.
+#	than @keep. The method returns [ { version, path, size } ] for
+#	each removed tree.
 #
 #	Nothing else bounds this cache. 'fuguvm cache clear --stale'
-#	prunes installed images, which live beside these downloads under
-#	the same cache_dir but are keyed by nothing in common, so a
-#	version bump used to leave the whole previous version's file sets
-#	here for good - unreadable afterwards, since every pattern
-#	is_cacheable() admits is version-scoped, and still carried by
-#	every copy of the directory a continuous-integration cache makes.
+#	prunes installed images. Those images live beside these
+#	downloads under the same cache_dir, but no common key connects
+#	them. Thus a version bump left the full file sets of the
+#	previous version here for good. Nothing read them again,
+#	because every pattern that is_cacheable() admits is
+#	version-scoped. And every copy of the directory that a
+#	continuous-integration cache made still carried them.
 #
-#	Whole directories, not matching files: removing the files alone
-#	would leave the empty version tree behind, and the tree is what
-#	such a copy walks.
+#	The method removes whole directories, not matching files.
+#	Removal of the files alone leaves the empty version tree
+#	behind, and such a copy walks the tree.
 #
-#	A directory whose name is not a version is left alone. In
-#	practice there are none - the patterns put everything under
-#	pub/OpenBSD/<version>/ or pub/OpenBSD/syspatch/<version>/ - and a
-#	cache under $HOME is the wrong place to delete on a guess.
+#	The method does not touch a directory whose name is not a
+#	version. In practice there are none. The patterns put
+#	everything under pub/OpenBSD/<version>/ or
+#	pub/OpenBSD/syspatch/<version>/. And a cache under $HOME is the
+#	wrong place to delete on a guess.
 sub prune ( $self, @keep )
 {
 	my $proxy_dir = "$self->{cache_dir}/proxy";
@@ -212,8 +216,8 @@ sub prune ( $self, @keep )
 			my $dir = "$root/$version";
 			next if !-d $dir;
 
-			# Measured before removal, so the caller can say
-			# what the prune bought
+			# Measure the size before removal. Thus the caller
+			# can say what the prune freed.
 			my $size = $self->_dir_size($dir);
 
 			require File::Path;
@@ -251,8 +255,8 @@ sub clear ($self)
 }
 
 # $self->list:
-#	List all cached files
-#	Returns arrayref of {url => $url, path => $path, size => $size}
+#	List all cached files. The method returns an arrayref of
+#	{url => $url, path => $path, size => $size}.
 sub list ($self)
 {
 	my $proxy_dir = "$self->{cache_dir}/proxy";
@@ -265,11 +269,12 @@ sub list ($self)
 		sub ($path) {
 			return if !-f $path;
 
-			# Reconstruct URL from path
+			# Reconstruct the URL from the path
 			my $rel = $path;
 			$rel =~ s|^\Q$proxy_dir/\E||;
 
-			# First component is host, rest is path
+			# The first component is the host. The rest is
+			# the path.
 			my ( $host, @rest ) = split '/', $rel;
 			my $url_path = join '/', @rest;
 
@@ -285,10 +290,10 @@ sub list ($self)
 }
 
 # $self->_version_roots($proxy_dir):
-#	Every directory under $proxy_dir whose immediate children are
-#	OpenBSD version numbers, across all cached hosts. Release trees
-#	hang off pub/OpenBSD, syspatch sets one level deeper; both are
-#	named for a version and neither outlives it.
+#	Get every directory under $proxy_dir whose immediate children
+#	are OpenBSD version numbers, across all cached hosts. Release
+#	trees hang off pub/OpenBSD. Syspatch sets sit one level deeper.
+#	Both have the name of a version, and neither outlives it.
 sub _version_roots ( $self, $proxy_dir )
 {
 	opendir my $dh, $proxy_dir or return ();
@@ -308,7 +313,7 @@ sub _version_roots ( $self, $proxy_dir )
 }
 
 # $self->_dir_size($dir):
-#	Total bytes of the regular files under $dir.
+#	Get the total bytes of the regular files under $dir.
 sub _dir_size ( $self, $dir )
 {
 	my $total = 0;

--- a/lib/FuguVM/Proxy/MetaCache.pm
+++ b/lib/FuguVM/Proxy/MetaCache.pm
@@ -19,9 +19,9 @@ use v5.36;
 
 package FuguVM::Proxy::MetaCache;
 
-# In-memory metadata cache for file serving optimization
-# Caches file metadata (path, size, mtime, content_type, etag)
-# to avoid repeated stat() calls and content-type detection
+# The in-memory metadata cache makes file serving faster. It caches
+# the file metadata: path, size, mtime, content_type, and etag. This
+# prevents repeated stat() calls and repeated content-type detection.
 
 sub new ($class)
 {
@@ -31,15 +31,16 @@ sub new ($class)
 }
 
 # $self->lookup($url):
-#	Lookup cached metadata for a URL
-#	Returns metadata hashref if found and still valid, undef otherwise
-#	Validates that file still exists and hasn't been modified
+#	Look up the cached metadata for a URL. The method returns the
+#	metadata hashref if the entry is present and still valid, and
+#	undef otherwise. It makes sure that the file still exists and
+#	did not change.
 sub lookup ( $self, $url )
 {
 	my $entry = $self->{entries}{$url};
 	return unless $entry;
 
-	# Verify file still exists and hasn't been modified
+	# Make sure that the file still exists and did not change
 	my @stat = stat $entry->{path};
 	return unless @stat;
 
@@ -50,9 +51,9 @@ sub lookup ( $self, $url )
 }
 
 # $self->store($url, $path):
-#	Store metadata for a URL
-#	Stats the file and caches all relevant metadata
-#	Returns metadata hashref on success, undef on failure
+#	Store the metadata for a URL. The method stats the file and
+#	caches all applicable metadata. It returns the metadata hashref
+#	on success and undef on failure.
 sub store ( $self, $url, $path )
 {
 	my @stat = stat $path;
@@ -87,8 +88,8 @@ sub clear ($self)
 }
 
 # $self->warm($cache):
-#	Pre-warm the metadata cache by scanning all cached files
-#	Takes a FuguVM::Proxy::Cache object
+#	Warm the metadata cache with a scan of all cached files. The
+#	method takes a FuguVM::Proxy::Cache object.
 sub warm ( $self, $cache )
 {
 	my $cache_dir = $cache->{cache_dir};
@@ -104,7 +105,7 @@ sub warm ( $self, $cache )
 }
 
 # $self->_guess_content_type($path):
-#	Guess content type from file extension
+#	Guess the content type from the file extension
 sub _guess_content_type ( $self, $path )
 {
 	return 'application/x-gzip'       if $path =~ /\.tgz$/;
@@ -118,7 +119,7 @@ sub _guess_content_type ( $self, $path )
 }
 
 # $self->_generate_etag($mtime, $size):
-#	Generate an ETag from file modification time and size
+#	Generate an ETag from the file modification time and size
 #	Format: "mtime-size" in hex
 sub _generate_etag ( $self, $mtime, $size )
 {
@@ -126,8 +127,9 @@ sub _generate_etag ( $self, $mtime, $size )
 }
 
 # $self->_walk_cache_dir($dir, $cache_dir, $callback):
-#	Recursively walk cache directory and invoke callback for each file
-#	Reconstructs URLs from filesystem paths
+#	Walk the cache directory recursively. Call the callback for
+#	each file. The method reconstructs the URLs from the filesystem
+#	paths.
 sub _walk_cache_dir ( $self, $dir, $cache_dir, $callback )
 {
 	opendir my $dh, $dir or return;
@@ -143,7 +145,7 @@ sub _walk_cache_dir ( $self, $dir, $cache_dir, $callback )
 		}
 		elsif ( -f $path ) {
 
-			# Reconstruct URL from path
+			# Reconstruct the URL from the path
 			# Path format: $cache_dir/proxy/$host/$path
 			my $url = $self->_path_to_url( $path, $cache_dir );
 			$callback->( $url, $path ) if defined $url;
@@ -152,13 +154,13 @@ sub _walk_cache_dir ( $self, $dir, $cache_dir, $callback )
 }
 
 # $self->_path_to_url($path, $cache_dir):
-#	Convert cache filesystem path back to URL
+#	Convert the cache filesystem path back to the URL
 sub _path_to_url ( $self, $path, $cache_dir )
 {
 	my $proxy_dir = "$cache_dir/proxy";
 	return unless $path =~ s{^\Q$proxy_dir\E/}{};
 
-	# Split into host and path
+	# Split the string into the host and the path
 	my ( $host, @parts ) = split m{/}, $path;
 	return unless defined $host && @parts;
 

--- a/lib/FuguVM/QGA.pm
+++ b/lib/FuguVM/QGA.pm
@@ -19,8 +19,9 @@ use v5.36;
 
 # FuguVM::QGA - QEMU Guest Agent client
 #
-# Provides communication with QEMU Guest Agent running inside the VM.
-# Used for reliable filesystem operations (freeze/thaw/sync) before shutdown.
+# The module talks to the QEMU Guest Agent that runs inside the VM.
+# FuguVM uses it for reliable filesystem operations before shutdown.
+# These operations are freeze, thaw, and sync.
 
 package FuguVM::QGA;
 
@@ -85,7 +86,7 @@ sub is_available ($self)
 }
 
 # $self->run_command($command, $arguments):
-#	Execute a QGA command and return the result
+#	Run a QGA command. The method returns the result.
 sub run_command ( $self, $command, $arguments = undef )
 {
 	return if !$self->{sock};
@@ -117,15 +118,17 @@ sub _read_response ($self)
 }
 
 # $self->_read_line($timeout):
-#	One line without its terminator, or undef on timeout, EOF or read
-#	error. Bounded with IO::Select against a wall-clock deadline:
-#	IO::Socket's timeout() governs only its own connect and accept, so a
-#	bare readline here blocks forever whenever nothing answers - and
-#	nothing answers whenever the guest runs no agent, which leaves the
-#	socket open and silent because QEMU, not the guest, serves it.
+#	Read one line without its terminator. The method returns undef
+#	on timeout, EOF, or read error. IO::Select bounds the read
+#	against a wall-clock deadline. The timeout() of IO::Socket
+#	governs only its own connect and accept. Thus a bare readline
+#	here blocks forever when nothing answers. Nothing answers when
+#	the guest runs no agent. The socket then stays open and silent,
+#	because QEMU, not the guest, serves it.
 #
-#	Bytes past the newline stay buffered for the next call, so a reply
-#	that arrives in the same segment as the following one is not lost.
+#	Bytes after the newline stay in the buffer for the next call.
+#	Thus the method does not lose a reply that arrives in the same
+#	segment as the next one.
 sub _read_line ( $self, $timeout )
 {
 	my $sock = $self->{sock};
@@ -157,18 +160,19 @@ sub _read_line ( $self, $timeout )
 # High-level commands
 
 # $self->sync:
-#	Sync guest filesystems (flush all buffers to disk)
-#	Returns true on success
+#	Sync the guest filesystems. The operation flushes all buffers
+#	to the disk. The method returns true on success.
 sub sync ($self)
 {
-	# guest-sync is used to synchronize the protocol, not filesystems
-	# We use guest-exec to run sync command for actual filesystem sync
+	# The guest-sync command synchronizes the protocol, not the
+	# filesystems. The module uses guest-exec to run the sync
+	# command for the real filesystem sync.
 	return $self->_exec_sync_command;
 }
 
 sub _exec_sync_command ($self)
 {
-	# Execute 'sync' command in guest
+	# Run the 'sync' command in the guest
 	my $result = $self->run_command(
 		'guest-exec',
 		{
@@ -181,7 +185,7 @@ sub _exec_sync_command ($self)
 	my $pid = $result->{return}{pid};
 	return 0 if !defined $pid;
 
-	# Wait for completion
+	# Wait until the command completes
 	my $start = time;
 	while ( time - $start < 10 ) {
 		my $status =
@@ -198,8 +202,9 @@ sub _exec_sync_command ($self)
 }
 
 # $self->freeze_filesystems:
-#	Freeze all mounted filesystems (quiesce for snapshot)
-#	Returns number of frozen filesystems on success, undef on failure
+#	Freeze all mounted filesystems. This makes them quiescent for a
+#	snapshot. The method returns the number of frozen filesystems
+#	on success and undef on failure.
 sub freeze_filesystems ($self)
 {
 	my $result = $self->run_command('guest-fsfreeze-freeze');
@@ -208,8 +213,8 @@ sub freeze_filesystems ($self)
 }
 
 # $self->thaw_filesystems:
-#	Thaw all frozen filesystems
-#	Returns number of thawed filesystems on success, undef on failure
+#	Thaw all frozen filesystems. The method returns the number of
+#	thawed filesystems on success and undef on failure.
 sub thaw_filesystems ($self)
 {
 	my $result = $self->run_command('guest-fsfreeze-thaw');
@@ -218,8 +223,8 @@ sub thaw_filesystems ($self)
 }
 
 # $self->fsfreeze_status:
-#	Get current filesystem freeze status
-#	Returns 'thawed', 'frozen', or undef on error
+#	Get the current filesystem freeze status. The method returns
+#	'thawed', 'frozen', or undef on error.
 sub fsfreeze_status ($self)
 {
 	my $result = $self->run_command('guest-fsfreeze-status');
@@ -228,7 +233,7 @@ sub fsfreeze_status ($self)
 }
 
 # $self->ping:
-#	Check if guest agent is responsive
+#	Check if the guest agent responds
 sub ping ($self)
 {
 	my $result = $self->run_command('guest-ping');
@@ -236,14 +241,14 @@ sub ping ($self)
 }
 
 # $self->shutdown($mode):
-#	Request guest to shutdown
+#	Ask the guest to shut down
 #	$mode: 'powerdown' (default), 'halt', or 'reboot'
 sub shutdown ( $self, $mode = 'powerdown' )
 {
 	my $result = $self->run_command( 'guest-shutdown', { mode => $mode } );
 
-	# guest-shutdown doesn't return a response on success
-	# (the guest shuts down immediately)
+	# The guest-shutdown command returns no response on success.
+	# The guest shuts down immediately.
 	return 1;
 }
 

--- a/lib/FuguVM/QMP.pm
+++ b/lib/FuguVM/QMP.pm
@@ -19,8 +19,9 @@ use v5.36;
 
 # FuguVM::QMP - QEMU Machine Protocol client
 #
-# Provides programmatic control over QEMU via the QMP JSON protocol.
-# Connects to QEMU's QMP socket for reliable VM lifecycle management.
+# The module gives programmatic control over QEMU through the QMP
+# JSON protocol. It connects to the QMP socket of QEMU for reliable
+# VM lifecycle management.
 
 package FuguVM::QMP;
 
@@ -59,14 +60,14 @@ sub open_connection ($self)
 
 	$self->{sock} = $sock;
 
-	# Read greeting
+	# Read the greeting
 	my $greeting = $self->_read_response;
 	if ( !defined $greeting || !exists $greeting->{QMP} ) {
 		$self->disconnect;
 		return 0;
 	}
 
-	# Send qmp_capabilities to enter command mode
+	# Send qmp_capabilities to enter the command mode
 	my $result = $self->run_command('qmp_capabilities');
 	if ( !defined $result ) {
 		$self->disconnect;
@@ -89,7 +90,7 @@ sub disconnect ($self)
 }
 
 # $self->run_command($command, $arguments):
-#	Execute a QMP command and return the result
+#	Run a QMP command. The method returns the result.
 sub run_command ( $self, $command, $arguments = undef )
 {
 	return if !$self->{sock};
@@ -121,14 +122,16 @@ sub _read_response ($self)
 }
 
 # $self->_read_line($timeout):
-#	One line without its terminator, or undef on timeout, EOF or read
-#	error. Bounded with IO::Select against a wall-clock deadline:
-#	IO::Socket's timeout() governs only its own connect and accept, so a
-#	bare readline here blocks forever whenever QEMU stops answering on
-#	an otherwise open socket.
+#	Read one line without its terminator. The method returns undef
+#	on timeout, EOF, or read error. IO::Select bounds the read
+#	against a wall-clock deadline. The timeout() of IO::Socket
+#	governs only its own connect and accept. Thus a bare readline
+#	here blocks forever when QEMU stops answering on an otherwise
+#	open socket.
 #
-#	Bytes past the newline stay buffered for the next call, so a reply
-#	that arrives in the same segment as the following one is not lost.
+#	Bytes after the newline stay in the buffer for the next call.
+#	Thus the method does not lose a reply that arrives in the same
+#	segment as the next one.
 sub _read_line ( $self, $timeout )
 {
 	my $sock = $self->{sock};
@@ -160,8 +163,8 @@ sub _read_line ( $self, $timeout )
 # High-level commands
 
 # $self->query_status:
-#	Query VM running status
-#	Returns hashref with 'running' and 'status' keys
+#	Query the VM running status. The method returns a hashref with
+#	the 'running' and 'status' keys.
 sub query_status ($self)
 {
 	my $result = $self->run_command('query-status');
@@ -170,7 +173,7 @@ sub query_status ($self)
 }
 
 # $self->is_running:
-#	Check if VM is currently running
+#	Check if the VM runs now
 sub is_running ($self)
 {
 	my $status = $self->query_status;
@@ -179,7 +182,7 @@ sub is_running ($self)
 }
 
 # $self->powerdown:
-#	Request graceful guest shutdown via ACPI
+#	Ask the guest for a controlled shutdown through ACPI
 sub powerdown ($self)
 {
 	my $result = $self->run_command('system_powerdown');
@@ -187,7 +190,7 @@ sub powerdown ($self)
 }
 
 # $self->quit:
-#	Immediately terminate QEMU process
+#	Stop the QEMU process immediately
 sub quit ($self)
 {
 	my $result = $self->run_command('quit');

--- a/lib/FuguVM/SSH.pm
+++ b/lib/FuguVM/SSH.pm
@@ -44,8 +44,9 @@ sub new ( $class, %args )
 }
 
 # $self->_connect:
-#	Establish SSH connection and authenticate using SSH agent
-#	or password fallback. Returns Net::SSH2 object on success.
+#	Open the SSH connection. Authenticate with the SSH agent first,
+#	then with the password as a fallback. The method returns a
+#	Net::SSH2 object on success.
 sub _connect ($self)
 {
 	my $ssh2 = Net::SSH2->new;
@@ -55,14 +56,15 @@ sub _connect ($self)
 		return;
 	}
 
-	# Try SSH agent authentication first if SSH_AUTH_SOCK is set
+	# Try the SSH agent authentication first when SSH_AUTH_SOCK is set
 	if ( defined $ENV{SSH_AUTH_SOCK} ) {
 		if ( $ssh2->auth_agent( $self->{user} ) ) {
 			return $ssh2;
 		}
 	}
 
-	# Fallback to password authentication if provided
+	# Fall back to the password authentication when a password is
+	# available
 	if ( defined $self->{password} ) {
 		if ( $ssh2->auth_password( $self->{user}, $self->{password} ) )
 		{
@@ -80,7 +82,8 @@ sub wait_available ( $self, $timeout = 120, $sig = undef )
 
 	while ( time - $start < $timeout ) {
 
-		# Check for interrupt if signal handler provided
+		# Check for an interrupt if the caller gave a signal
+		# handler
 		if ( defined $sig && FuguLib::Signal::check_interrupted() ) {
 			return 0;
 		}
@@ -154,8 +157,9 @@ sub run_command ( $self, $command )
 
 sub interactive ($self)
 {
-	# For interactive sessions, fall back to system ssh command
-	# Net::SSH2 doesn't provide proper TTY handling for interactive use
+	# For interactive sessions, fall back to the system ssh command.
+	# Net::SSH2 does not give correct TTY control for interactive
+	# use.
 	my @cmd = (
 		'ssh',
 		'-o',
@@ -169,18 +173,20 @@ sub interactive ($self)
 		"$self->{user}\@$self->{host}",
 	);
 
-	# Return the child's exit code, not the raw wait status: callers
-	# (and ultimately the fuguvm exit status) expect a 0-255 code. A
-	# raw status of, say, 256 for a remote exit code of 1 would become
-	# exit(256) -> 0, silently turning a failed remote command (e.g. a
-	# failing `prove` run driven over stdin) into success.
+	# Return the child's exit code, not the raw wait status. The
+	# callers, and finally the fuguvm exit status, expect a 0-255
+	# code. A raw status of 256 for a remote exit code of 1 would
+	# become exit(256) -> 0. That result silently turns a failed
+	# remote command into success, for example a failed `prove` run
+	# driven over stdin.
 	return _exit_code( system(@cmd) );
 }
 
 # _exit_code($status):
-#	Map a raw system()/$? wait status to a 0-255 exit code: the low
-#	byte encodes the terminating signal, the high byte the exit code.
-#	system() returns -1 when the child could not be run at all.
+#	Map a raw system()/$? wait status to a 0-255 exit code. The low
+#	byte encodes the terminating signal. The high byte encodes the
+#	exit code. system() returns -1 when it cannot start the child
+#	at all.
 sub _exit_code ($status)
 {
 	return EXIT_ERROR               if $status == -1;
@@ -189,7 +195,7 @@ sub _exit_code ($status)
 }
 
 # $self->write_file($remote_path, $content, $mode):
-#	Write content directly to a remote file via SFTP
+#	Write the content directly to a remote file with SFTP
 sub write_file ( $self, $remote_path, $content, $mode = 0644 )
 {
 	my $ssh2 = $self->_connect;
@@ -212,7 +218,7 @@ sub write_file ( $self, $remote_path, $content, $mode = 0644 )
 	}
 
 	$remote_fh->write($content);
-	undef $remote_fh;    # Close file handle
+	undef $remote_fh;    # Close the file handle
 	$ssh2->disconnect;
 
 	return EXIT_SUCCESS;

--- a/lib/FuguVM/State.pm
+++ b/lib/FuguVM/State.pm
@@ -26,7 +26,7 @@ use constant { MAX_VM_NAME_LENGTH => 255, };
 
 sub new ( $class, $state_dir, $vm_name, %opts )
 {
-	# Validate VM name length
+	# Validate the VM name length
 	if ( length($vm_name) > MAX_VM_NAME_LENGTH ) {
 		warn "VM name too long (max "
 		    . MAX_VM_NAME_LENGTH
@@ -34,7 +34,8 @@ sub new ( $class, $state_dir, $vm_name, %opts )
 		return;
 	}
 
-	# Validate VM name characters (no path separators or null bytes)
+	# Validate the VM name characters. Path separators and null
+	# bytes are not permitted.
 	if ( $vm_name =~ m{[/\x00]} ) {
 		warn "VM name contains invalid characters\n";
 		return;
@@ -64,13 +65,13 @@ sub _ensure_dir ($self)
 {
 	my $dir = $self->{vm_state_dir};
 
-	# Check for symlinks (refuse to follow for security)
+	# Check for symlinks. For security, refuse to follow them.
 	if ( -l $dir ) {
 		warn "State directory is a symlink: $dir\n";
 		return 0;
 	}
 
-	# Check if path exists but is not a directory
+	# Check if the path exists but is not a directory
 	if ( -e $dir && !-d $dir ) {
 		warn "State path exists but is not a directory: $dir\n";
 		return 0;
@@ -159,7 +160,7 @@ sub is_vm_running ($self)
 	my $pid = $self->get_vm_pid;
 	return 0 if !defined $pid;
 
-	# Check if process is alive
+	# Check if the process is alive
 	return kill( 0, $pid ) ? 1 : 0;
 }
 
@@ -198,7 +199,7 @@ sub is_proxy_running ($self)
 	my $pid = $self->get_proxy_pid;
 	return 0 if !defined $pid;
 
-	# Check if process is alive
+	# Check if the process is alive
 	return kill( 0, $pid ) ? 1 : 0;
 }
 
@@ -224,15 +225,15 @@ sub clear_proxy_port ($self)
 
 # Proxy lifecycle management
 # $self->ensure_proxy($cache_dir):
-#	Start proxy if not running, return Proxy object
-#	Returns undef if proxy cannot be started
+#	Start the proxy if it does not run. Return the Proxy object.
+#	Return undef if the proxy cannot start.
 sub ensure_proxy ( $self, $cache_dir )
 {
 	require FuguVM::Proxy;
 
 	my $proxy = FuguVM::Proxy->new( $self, $cache_dir );
 
-	# Already running? Return existing proxy
+	# If the proxy already runs, return the existing object
 	if ( $proxy->is_running ) {
 		return $proxy;
 	}
@@ -245,7 +246,8 @@ sub ensure_proxy ( $self, $cache_dir )
 }
 
 # $self->get_proxy($cache_dir):
-#	Get Proxy object if running, undef if not
+#	Return the Proxy object if the proxy runs. Return undef if it
+#	does not.
 sub get_proxy ( $self, $cache_dir )
 {
 	require FuguVM::Proxy;
@@ -255,7 +257,7 @@ sub get_proxy ( $self, $cache_dir )
 }
 
 # $self->stop_proxy($cache_dir):
-#	Stop proxy if running
+#	Stop the proxy if it runs.
 sub stop_proxy ( $self, $cache_dir )
 {
 	require FuguVM::Proxy;
@@ -293,7 +295,8 @@ sub mark_installed ($self)
 	return $self;
 }
 
-# Root password management (stored securely in state for initial setup)
+# Root password management. The state stores the password securely
+# for the initial setup.
 sub set_root_password ( $self, $password )
 {
 	$self->{data}{root_password} = $password;
@@ -307,9 +310,9 @@ sub get_root_password ($self)
 }
 
 # SSH key installation state
-# Tracks both whether an SSH key has been installed and which specific key
-# was installed. This allows the system to detect when the configured SSH
-# key has changed and automatically reinstall the new key.
+# The state tracks whether an SSH key is installed, and also which
+# specific key. Thus the system can detect when the configured SSH key
+# changed. Then it automatically installs the new key.
 sub is_ssh_key_installed ($self)
 {
 	return $self->{data}{ssh_key_installed} ? 1 : 0;
@@ -349,7 +352,8 @@ sub data ($self)
 }
 
 # Shutdown state tracking
-# Tracks whether VM was shutdown cleanly to detect filesystem corruption risk
+# The state records whether the VM was shut down cleanly. This detects
+# the risk of filesystem corruption.
 
 sub mark_clean_shutdown ($self)
 {
@@ -380,14 +384,15 @@ sub mark_running ($self)
 
 sub was_unclean_shutdown ($self)
 {
-	# If explicitly marked as unclean
+	# The state explicitly marks the shutdown as unclean
 	if ( exists $self->{data}{shutdown_clean}
 		&& !$self->{data}{shutdown_clean} )
 	{
 		return 1;
 	}
 
-	# If marked running but VM process is dead = crashed/killed
+	# The state says running, but the VM process is dead. Thus the
+	# VM crashed or was killed.
 	if ( $self->{data}{running} && !$self->is_vm_running ) {
 		return 1;
 	}

--- a/lib/FuguVM/Util.pm
+++ b/lib/FuguVM/Util.pm
@@ -40,18 +40,20 @@ sub generate_random_bytes ( $, $length )
 }
 
 # $class->generate_password($length):
-#	Generate a strong random password of specified length using
-#	base64-encoded random bytes (URL-safe variant without padding)
+#	Generate a strong random password of the specified length. The
+#	password uses base64-encoded random bytes. The base64 variant
+#	is URL-safe and has no padding.
 sub generate_password ( $class, $length = PASSWORD_LENGTH )
 {
-	# Generate more bytes than needed since base64 expands
+	# Generate more bytes than the password needs. Base64 expands
+	# the data.
 	my $raw_bytes =
 	    $class->generate_random_bytes( ( $length * 3 / 4 ) + 3 );
 
-	# Use URL-safe base64 encoding (no + / = characters)
+	# Use the URL-safe base64 encoding. It has no + / = characters.
 	my $encoded = MIME::Base64::encode_base64url( $raw_bytes, '' );
 
-	# Trim to requested length
+	# Trim the password to the requested length
 	return substr( $encoded, 0, $length );
 }
 

--- a/lib/FuguVM/VM.pm
+++ b/lib/FuguVM/VM.pm
@@ -19,8 +19,8 @@ use v5.36;
 
 # FuguVM::VM - OpenBSD VM management for macOS/arm64
 #
-# Opinionated VM controller for running OpenBSD guests on Apple Silicon.
-# Uses QMP for reliable VM lifecycle management.
+# This module is an opinionated VM controller for OpenBSD guests on
+# Apple Silicon. It uses QMP for reliable VM lifecycle management.
 
 package FuguVM::VM;
 
@@ -51,7 +51,8 @@ use constant {
 	MEMORY_DEFAULT => '1G',
 	CPU_COUNT      => 2,
 
-	# Guest CPU model under TCG emulation (no host passthrough)
+	# The guest CPU model under TCG emulation. TCG does not use host
+	# passthrough.
 	TCG_CPU => 'cortex-a57',
 };
 
@@ -68,18 +69,19 @@ sub new ( $class, %args )
 	return $self;
 }
 
-# Idempotent: ensure VM is running
+# The operation is idempotent. It makes sure that the VM runs.
 sub up ($self)
 {
 	my $config = $self->{config};
 	my $state  = $self->{state};
 	my $log    = $self->{log};
 
-	# Check if already running
+	# Check if the VM already runs
 	if ( $self->_is_running ) {
 
-		# If VM is running but SSH key needs to be installed or updated
-		# (first boot failed, or key changed in config)
+		# The VM runs, but the SSH key is not installed or is not
+		# current. This occurs when the first boot failed, or when
+		# the key changed in the configuration.
 		if ( $state->is_installed && $self->_needs_ssh_key_update ) {
 			return $self->_complete_ssh_setup;
 		}
@@ -88,16 +90,16 @@ sub up ($self)
 		return EXIT_SUCCESS;
 	}
 
-	# Verify the disk's backing chain before anything else looks at the
-	# disk. A base image missing from the cache is not corruption, and
-	# the unclean-shutdown check below would report it as such and
-	# recommend 'fuguvm disk repair' - which cannot recreate a missing
-	# backing file.
+	# Verify the backing chain of the disk before other checks read
+	# the disk. A base image that is missing from the cache is not
+	# corruption. The unclean-shutdown check below would report it as
+	# corruption and recommend 'fuguvm disk repair'. That command
+	# cannot make a missing backing file again.
 	if ( $state->disk_exists && !$self->_verify_backing_chain ) {
 		return EXIT_ERROR;
 	}
 
-	# Check for unclean shutdown and verify disk integrity
+	# Check for an unclean shutdown. Then verify the disk integrity.
 	if ( $state->was_unclean_shutdown ) {
 		$log->warning("Detected unclean shutdown, checking disk...");
 		my $disk  = FuguVM::Disk->new( $state->{state_dir} );
@@ -112,10 +114,11 @@ sub up ($self)
 		$state->clear_shutdown_state;
 	}
 
-	# Derive the installed-image cache key exactly once, before the
-	# installer runs: key() hashes install.exp at call time, so a key
-	# re-derived after a tens-of-minutes install would publish the
-	# image the OLD installer produced under the NEW digest.
+	# Derive the installed-image cache key one time only, before the
+	# installer runs. key() hashes install.exp at call time. An
+	# install takes tens of minutes. A key derived again after the
+	# install would publish the image the OLD installer made under
+	# the NEW digest.
 	my $cache     = $self->_image_cache;
 	my $cache_key = defined $cache ? $cache->key($config) : undef;
 
@@ -124,11 +127,12 @@ sub up ($self)
 		$self->_cache_restore( $cache, $cache_key );
 	}
 
-	# Start caching proxy for VM installation (packages downloaded by VM)
-	# Also used for downloading the miniroot image on first run
+	# Start the caching proxy for the VM installation. The VM
+	# downloads its packages through the proxy. The first run also
+	# uses the proxy to download the miniroot image.
 	my $cache_dir = $self->_cache_dir;
 	my $proxy     = $state->ensure_proxy($cache_dir);
-	my $proxy_vm_url;    # For VM-side downloads (inside OpenBSD)
+	my $proxy_vm_url;    # For downloads inside the OpenBSD guest
 
 	if ( defined $proxy ) {
 		$proxy_vm_url = $proxy->guest_url;
@@ -139,10 +143,11 @@ sub up ($self)
 			"Proxy not available, VM downloads will not be cached");
 	}
 
-	# Ensure the miniroot is available (download via proxy if needed).
-	# Only the installer boots it: an installed system - freshly
-	# installed or restored from the image cache - boots its own disk,
-	# and must not fail here because the miniroot has been pruned.
+	# Make sure that the miniroot is available. Download it through
+	# the proxy if necessary. Only the installer boots the miniroot.
+	# An installed system boots its own disk, whether it was freshly
+	# installed or restored from the image cache. Such a system must
+	# not fail here because the miniroot was pruned.
 	my $image_path;
 
 	if ( !$state->is_installed ) {
@@ -163,7 +168,7 @@ sub up ($self)
 		$log->info("Using cached image: $image_path");
 	}
 
-	# Ensure disk exists
+	# Make sure that the disk exists
 	my $disk_path = $state->disk_path;
 
 	if ( !$state->disk_exists ) {
@@ -177,10 +182,10 @@ sub up ($self)
 		}
 	}
 
-	# Start VM
+	# Start the VM
 	$log->info("Starting VM...");
 
-	# Only attach install media if not already installed
+	# Attach the install media only when the system is not installed
 	my $boot_image = $state->is_installed ? undef : $image_path;
 	my $pid        = $self->_start_qemu($boot_image);
 	if ( !defined $pid ) {
@@ -190,11 +195,13 @@ sub up ($self)
 
 	$log->info("Started $config->{name} (PID: $pid)");
 
-	# Install if needed
+	# Install the system if necessary
 	if ( !$state->is_installed ) {
 
-      # Proxy is already running (started above for image download)
-      # Use VM-accessible URL for installation (VM connects to host via gateway)
+		# The proxy already runs. The code above started it for the
+		# image download. Use the VM-accessible URL for the
+		# installation. The VM connects to the host through the
+		# gateway.
 		my $install_proxy_url = $proxy_vm_url // 'none';
 
 		# Generate a strong random password for this installation
@@ -208,7 +215,7 @@ sub up ($self)
 			port => $config->{console_port},
 		);
 
-		# Use the generated password for installation
+		# Use the generated password for the installation
 		my $install_config = {
 			%$config,
 			root_password => $root_password,
@@ -223,10 +230,11 @@ sub up ($self)
 		$state->mark_installed;
 		$log->info("Installation complete");
 
-		# Stop VM via QMP (graceful). The image cache captures the
-		# disk at exactly this point - installed, pristine, before
-		# the per-checkout SSH key goes in - so the capture must
-		# know that QEMU is really gone, not assume it.
+		# Stop the VM gracefully through QMP. The image cache
+		# captures the disk at exactly this point: installed,
+		# pristine, and without the per-checkout SSH key. Thus the
+		# capture must know that QEMU is really gone. It must not
+		# assume it.
 		$log->info("Stopping installation VM...");
 		$self->_qmp_quit;
 		my $clean_exit = $self->_wait_exit(30);
@@ -241,8 +249,8 @@ sub up ($self)
 		$state->clear_vm_pid;
 
 		# Publish the installed disk as a cached base image. A VM
-		# that had to be killed may have left the disk mid-write,
-		# so that capture is skipped rather than published.
+		# that was force stopped can leave the disk mid-write. Thus
+		# the code skips that capture and does not publish it.
 		if ( defined $cache_key ) {
 			if ($clean_exit) {
 				$self->_cache_store( $cache, $cache_key,
@@ -255,7 +263,7 @@ sub up ($self)
 			}
 		}
 
-		# Restart VM without install media
+		# Restart the VM without the install media
 		$log->info("Restarting installed system...");
 		$pid = $self->_start_qemu;    # No boot image, no exit_on_halt
 		if ( !defined $pid ) {
@@ -264,14 +272,15 @@ sub up ($self)
 		}
 		$log->info("Started $config->{name} (PID: $pid)");
 
-		# Wait for SSH with password auth
+		# Wait for SSH with password authentication
 		$log->info("Waiting for SSH...");
 		if ( !$self->_wait_ssh_password( $root_password, 120 ) ) {
 			$log->error("Timeout waiting for SSH");
 			return EXIT_TIMEOUT;
 		}
 
-		# Install SSH authorized key for future key-based auth
+		# Install the SSH authorized key for future key-based
+		# authentication
 		if ( !$self->_install_ssh_key($root_password) ) {
 			$log->error("Failed to install SSH key");
 			return EXIT_ERROR;
@@ -282,15 +291,17 @@ sub up ($self)
 		return EXIT_SUCCESS;
 	}
 
-	# VM is installed - check if SSH key needs to be installed or updated
+	# The VM is installed. Check if the SSH key must be installed or
+	# updated.
 	if ( $self->_needs_ssh_key_update ) {
 
-		# SSH key not installed or changed in config
-		# Use password auth to wait for SSH and install the key
+		# The SSH key is not installed, or it changed in the
+		# configuration. Use password authentication to wait for
+		# SSH. Then install the key.
 		return $self->_complete_ssh_setup;
 	}
 
-	# Wait for SSH (key-based auth for already installed VMs)
+	# Wait for SSH. An installed VM uses key-based authentication.
 	$log->info("Waiting for SSH...");
 	if ( !$self->wait_ssh(120) ) {
 		$log->error("Timeout waiting for SSH");
@@ -302,11 +313,12 @@ sub up ($self)
 }
 
 # $self->_image_cache:
-#	Installed-image cache for this VM's configured cache_dir, or undef
-#	when caching is switched off - by 'up --no-cache' for a single
-#	invocation, or by 'image_cache no' in the configuration. Both
-#	suppress restore and save together: a half-cached run would leave
-#	an overlay whose base nothing published.
+#	Return the installed-image cache for this VM's configured
+#	cache_dir. Return undef when caching is off. 'up --no-cache'
+#	turns caching off for a single invocation. 'image_cache no'
+#	turns it off in the configuration. Both stop restore and save
+#	together. A half-cached run would leave an overlay with a base
+#	that nothing published.
 sub _image_cache ($self)
 {
 	return if $self->{no_cache};
@@ -318,11 +330,11 @@ sub _image_cache ($self)
 }
 
 # $self->_verify_backing_chain:
-#	Confirm that the working disk's backing image, if it has one, is
-#	present. Returns true when the chain resolves; on a break, logs
-#	the missing file and a remedy and returns false, so a pruned or
-#	evicted cache entry fails with an explanation rather than an
-#	opaque QEMU open error at boot.
+#	Make sure that the backing image of the working disk, if the
+#	disk has one, is present. Return true when the chain resolves.
+#	On a break, log the missing file and a remedy, and return
+#	false. Thus a pruned or evicted cache entry fails with an
+#	explanation, not with an opaque QEMU open error at boot.
 sub _verify_backing_chain ($self)
 {
 	my $config = $self->{config};
@@ -348,10 +360,10 @@ sub _verify_backing_chain ($self)
 }
 
 # $self->_cache_restore($cache, $key):
-#	Create the working disk as an overlay on a cached base image and
-#	seed the state the installation would have written. Returns true
-#	on a cache hit, false on a miss or any failure - both of which
-#	simply leave the caller to install from scratch.
+#	Create the working disk as an overlay on a cached base image.
+#	Seed the state that the installation would have written. Return
+#	true on a cache hit. Return false on a miss or on any failure.
+#	In both cases the caller then installs from scratch.
 sub _cache_restore ( $self, $cache, $key )
 {
 	my $config = $self->{config};
@@ -373,10 +385,10 @@ sub _cache_restore ( $self, $cache, $key )
 		return 0;
 	}
 
-	# The base was captured from an installed system, so the state
-	# the installer would have written comes from its metadata. The
-	# root password is what the later SSH key install authenticates
-	# with, and it is baked into the image.
+	# The base was captured from an installed system. Thus the state
+	# that the installer would have written comes from the metadata
+	# of the base. The later SSH key install authenticates with the
+	# root password. That password is baked into the image.
 	$state->mark_installed;
 	my $password = $hit->{meta}{root_password};
 	$state->set_root_password($password) if defined $password;
@@ -388,10 +400,11 @@ sub _cache_restore ( $self, $cache, $key )
 }
 
 # $self->_cache_store($cache, $key, $root_password):
-#	Publish the freshly installed disk as a cached base image and
-#	replace the working disk with an overlay on it. Best effort: any
-#	failure leaves the standalone disk in place and warns, because
-#	'up' must never fail because caching failed.
+#	Publish the freshly installed disk as a cached base image. Then
+#	replace the working disk with an overlay on that image. The
+#	operation is best effort. On any failure it keeps the
+#	standalone disk in place and warns. 'up' must never fail
+#	because caching failed.
 sub _cache_store ( $self, $cache, $key, $root_password )
 {
 	my $config = $self->{config};
@@ -425,8 +438,9 @@ sub _cache_store ( $self, $cache, $key, $root_password )
 
 # $self->_reparent_disk($base):
 #	Replace the working disk with a fresh overlay backed by $base.
-#	The old disk is moved aside rather than deleted, so a failure to
-#	create the overlay cannot leave the VM without a disk.
+#	The method moves the old disk aside and does not delete it.
+#	Thus a failure to create the overlay cannot leave the VM
+#	without a disk.
 sub _reparent_disk ( $self, $base )
 {
 	my $config = $self->{config};
@@ -442,8 +456,8 @@ sub _reparent_disk ( $self, $base )
 		return 0;
 	};
 
-	# Disk::create returns early on an existing path, so the rename
-	# above is what makes this actually create the overlay.
+	# Disk::create returns early on an existing path. Thus the
+	# rename above is what makes this call create the overlay.
 	my $disk = FuguVM::Disk->new( $state->{state_dir} );
 	my $path = $disk->create( $config->{name}, undef, $base, 'qcow2' );
 	if ( !defined $path ) {
@@ -462,7 +476,7 @@ sub down ($self)
 	my $log    = $self->{log};
 	my $config = $self->{config};
 
-	# Stop proxy if running
+	# Stop the proxy if it runs
 	my $cache_dir = $self->_cache_dir;
 	if ( $state->is_proxy_running ) {
 		$state->stop_proxy($cache_dir);
@@ -476,7 +490,7 @@ sub down ($self)
 
 	$log->info("Shutting down VM...");
 
-	# Try graceful shutdown with filesystem sync
+	# Try a graceful shutdown with a filesystem sync
 	if ( $self->_graceful_shutdown ) {
 		$state->mark_clean_shutdown;
 		$state->clear_vm_pid;
@@ -484,7 +498,7 @@ sub down ($self)
 		return EXIT_SUCCESS;
 	}
 
-	# Emergency force quit - filesystem may be corrupted
+	# Emergency force quit. The filesystem can be corrupt.
 	$log->warning(
 		"Graceful shutdown failed, force stopping (risk of corruption)"
 	);
@@ -502,19 +516,19 @@ sub destroy ($self)
 	my $log    = $self->{log};
 	my $config = $self->{config};
 
-	# Stop proxy if running
+	# Stop the proxy if it runs
 	my $cache_dir = $self->_cache_dir;
 	if ( $state->is_proxy_running ) {
 		$state->stop_proxy($cache_dir);
 		$log->info("Proxy stopped");
 	}
 
-	# Stop if running
+	# Stop the VM if it runs
 	if ( $self->_is_running ) {
 		$self->stop(1);
 	}
 
-	# Remove disk
+	# Remove the disk
 	my $disk_path = $state->disk_path;
 	if ( -f $disk_path ) {
 		$log->info("Removing disk image...");
@@ -524,11 +538,11 @@ sub destroy ($self)
 		};
 	}
 
-	# Remove QMP socket
+	# Remove the QMP socket
 	my $qmp_path = $self->_qmp_socket_path;
 	unlink $qmp_path if -S $qmp_path;
 
-	# Clear state
+	# Clear the state
 	$state->{data} = {};
 	$state->save;
 
@@ -583,7 +597,7 @@ sub stop ( $self, $force = 0 )
 		return EXIT_SUCCESS;
 	}
 
-	# Try graceful shutdown with filesystem sync
+	# Try a graceful shutdown with a filesystem sync
 	$log->info("Shutting down VM gracefully...");
 	if ( $self->_graceful_shutdown ) {
 		$state->mark_clean_shutdown;
@@ -592,7 +606,7 @@ sub stop ( $self, $force = 0 )
 		return EXIT_SUCCESS;
 	}
 
-	# If graceful shutdown times out, force stop
+	# If the graceful shutdown times out, force stop the VM
 	$log->warning(
 "Graceful shutdown timed out, force stopping (risk of corruption)"
 	);
@@ -611,7 +625,7 @@ sub status ($self)
 	my $running = $self->_is_running;
 	my $pid     = $state->get_vm_pid;
 
-	# Query QEMU status via QMP if running
+	# Query the QEMU status through QMP if the VM runs
 	my $qemu_status;
 	if ($running) {
 		my $qmp = $self->_qmp_connect;
@@ -658,7 +672,7 @@ sub wait_ssh ( $self, $timeout = 120, $sig = undef )
 {
 	my $config = $self->{config};
 
-	# Uses SSH agent for authentication
+	# The connection uses the SSH agent for authentication
 	my $ssh = FuguVM::SSH->new(
 		host => '127.0.0.1',
 		port => $config->{ssh_port},
@@ -669,8 +683,9 @@ sub wait_ssh ( $self, $timeout = 120, $sig = undef )
 }
 
 # $self->_wait_ssh_password($password, $timeout):
-#	Wait for SSH to become available using password authentication
-#	Used during initial installation before SSH key is installed
+#	Wait for SSH to become available with password authentication.
+#	The initial installation uses this method before the SSH key
+#	goes in.
 sub _wait_ssh_password ( $self, $password, $timeout = 120 )
 {
 	my $config = $self->{config};
@@ -686,8 +701,8 @@ sub _wait_ssh_password ( $self, $password, $timeout = 120 )
 }
 
 # $self->_needs_ssh_key_update:
-#	Check if SSH key needs to be installed or updated.
-#	Returns true if no key is installed, or if the configured key
+#	Check if the SSH key must be installed or updated. Return true
+#	if no key is installed. Also return true if the configured key
 #	differs from the installed key.
 sub _needs_ssh_key_update ($self)
 {
@@ -697,13 +712,13 @@ sub _needs_ssh_key_update ($self)
 	my $configured_key = $config->{ssh_pubkey};
 	my $installed_key  = $state->get_installed_ssh_pubkey;
 
-	# No key configured - nothing to install
+	# No key is configured. There is nothing to install.
 	return 0 if !defined $configured_key || $configured_key eq '';
 
-	# No key installed yet
+	# No key is installed yet
 	return 1 if !defined $installed_key;
 
-	# Compare keys (normalize whitespace for comparison)
+	# Compare the keys. Normalize the whitespace for the comparison.
 	my $configured_normalized = $configured_key =~ s/\s+/ /gr;
 	my $installed_normalized  = $installed_key  =~ s/\s+/ /gr;
 
@@ -711,10 +726,10 @@ sub _needs_ssh_key_update ($self)
 }
 
 # $self->_complete_ssh_setup():
-#	Install or update the SSH key on the VM.
-#	Uses the stored root password to authenticate.
-#	Called when recovering from a failed first boot or when the
-#	configured SSH key has changed.
+#	Install or update the SSH key on the VM. The method
+#	authenticates with the stored root password. It runs to recover
+#	from a failed first boot, or when the configured SSH key
+#	changed.
 sub _complete_ssh_setup ($self)
 {
 	my $state  = $self->{state};
@@ -730,14 +745,14 @@ sub _complete_ssh_setup ($self)
 
 	$log->info("Updating SSH key...");
 
-	# Wait for SSH with password auth
+	# Wait for SSH with password authentication
 	$log->info("Waiting for SSH...");
 	if ( !$self->_wait_ssh_password( $root_password, 120 ) ) {
 		$log->error("Timeout waiting for SSH");
 		return EXIT_TIMEOUT;
 	}
 
-	# Install SSH authorized key
+	# Install the SSH authorized key
 	if ( !$self->_install_ssh_key($root_password) ) {
 		$log->error("Failed to install SSH key");
 		return EXIT_ERROR;
@@ -749,22 +764,23 @@ sub _complete_ssh_setup ($self)
 }
 
 # $self->_install_ssh_key($password):
-#	Install the SSH public key from config into authorized_keys
-#	Uses password authentication since key is not yet installed
+#	Install the SSH public key from the configuration into
+#	authorized_keys. The method uses password authentication,
+#	because the key is not yet installed.
 sub _install_ssh_key ( $self, $password )
 {
 	my $config = $self->{config};
 	my $state  = $self->{state};
 	my $log    = $self->{log};
 
-	# Get SSH public key from config
+	# Get the SSH public key from the configuration
 	my $ssh_pubkey = $config->{ssh_pubkey};
 	if ( !defined $ssh_pubkey || $ssh_pubkey eq '' ) {
 		$log->error("No ssh_pubkey configured in ~/.fuguvmrc");
 		return 0;
 	}
 
-	# Connect with password
+	# Connect with the password
 	my $ssh = FuguVM::SSH->new(
 		host     => '127.0.0.1',
 		port     => $config->{ssh_port},
@@ -772,14 +788,14 @@ sub _install_ssh_key ( $self, $password )
 		password => $password,
 	);
 
-	# Create .ssh directory
+	# Create the .ssh directory
 	my $result =
 	    $ssh->run_command('mkdir -p /root/.ssh && chmod 700 /root/.ssh');
 	if ( $result->{exit_code} != 0 ) {
 		return 0;
 	}
 
-	# Write authorized_keys file
+	# Write the authorized_keys file
 	my $authkeys_content = $ssh_pubkey . "\n";
 	if (
 		$ssh->write_file(
@@ -791,13 +807,13 @@ sub _install_ssh_key ( $self, $password )
 		return 0;
 	}
 
-	# Store which pubkey was installed for future comparison
+	# Store the installed pubkey for a future comparison
 	$state->mark_ssh_key_installed($ssh_pubkey);
 	return 1;
 }
 
 # P1: Graceful shutdown with filesystem sync
-# Tries multiple methods in order of reliability:
+# The method tries these procedures in order of reliability:
 # 1. SSH sync + ACPI powerdown (sync via SSH, powerdown via QMP)
 # 2. QGA guest-shutdown (if available)
 # 3. Direct ACPI powerdown
@@ -806,12 +822,13 @@ sub _graceful_shutdown ($self)
 	my $config = $self->{config};
 	my $log    = $self->{log};
 
-	# Best-effort filesystem sync over SSH before pulling the power.
-	# Hard-bounded: a wedged guest must never stall shutdown, and
-	# libssh2 does not reliably honor its own timeout on the connect
-	# and handshake. A failure or timeout here is fine - the ACPI
-	# powerdown below runs the guest's own orderly shutdown (which
-	# syncs), and a force stop is the ultimate fallback.
+	# Do a best-effort filesystem sync over SSH before the code
+	# pulls the power. The sync has a hard time bound. A wedged
+	# guest must never stall the shutdown. Also, libssh2 does not
+	# reliably obey its own timeout on the connect and handshake. A
+	# failure or a timeout here is acceptable. The ACPI powerdown
+	# below runs the orderly shutdown of the guest, which syncs. A
+	# force stop is the ultimate fallback.
 	$self->_bounded(
 		FuguVM::SSH::DEFAULT_TIMEOUT + 5,
 		sub {
@@ -823,13 +840,14 @@ sub _graceful_shutdown ($self)
 			return $ssh->run_command('sync; sync; sync');
 		} );
 
-	# Ask the guest to power off via the ACPI power button, then wait.
+	# Ask the guest to power off through the ACPI power button. Then
+	# wait.
 	if ( $self->_qmp_powerdown && $self->_wait_exit(60) ) {
 		$log->info("Shutdown via ACPI powerdown");
 		return 1;
 	}
 
-	# Guest-agent shutdown, if the agent is available.
+	# Do a guest-agent shutdown if the agent is available.
 	my $qga = $self->_qga_connect;
 	if ($qga) {
 		$qga->sync;
@@ -846,10 +864,10 @@ sub _graceful_shutdown ($self)
 }
 
 # $self->_bounded($seconds, $code):
-#	Run $code under a hard wall-clock deadline so a blocking guest
-#	interaction cannot stall the caller. Returns $code's return value,
-#	or undef if the deadline elapsed. Mirrors the alarm guard used for
-#	the MQTT connect in OpenHAP::MQTT.
+#	Run $code under a hard wall-clock deadline. Thus a blocked
+#	guest interaction cannot stall the caller. Return the return
+#	value of $code, or undef if the deadline elapsed. The guard
+#	mirrors the alarm guard for the MQTT connect in OpenHAP::MQTT.
 sub _bounded ( $self, $seconds, $code )
 {
 	my $result;
@@ -868,10 +886,11 @@ sub _bounded ( $self, $seconds, $code )
 }
 
 # $self->_force_stop:
-#	Terminate the QEMU process deterministically: SIGTERM (QEMU exits
-#	and flushes its disk caches), escalating to SIGKILL if it lingers.
-#	Unlike a QMP 'quit', this cannot hang on an unresponsive monitor
-#	socket, so it is a safe last resort.
+#	Stop the QEMU process deterministically. Send SIGTERM first:
+#	QEMU exits and flushes its disk caches. Escalate to SIGKILL if
+#	the process stays. Unlike a QMP 'quit', this method cannot hang
+#	on an unresponsive monitor socket. Thus it is a safe last
+#	resort.
 sub _force_stop ($self)
 {
 	my $pid = $self->{state}->get_vm_pid;
@@ -923,10 +942,10 @@ sub _is_running ($self)
 	my $pid = $self->{state}->get_vm_pid;
 	return 0 if !defined $pid;
 
-	# Check if process is alive
+	# Check if the process is alive
 	return 0 if !kill( 0, $pid );
 
-	# Optionally verify via QMP (more reliable)
+	# Verify through QMP when possible. QMP is more reliable.
 	my $qmp = $self->_qmp_connect;
 	if ($qmp) {
 		my $running = $qmp->is_running;
@@ -934,7 +953,7 @@ sub _is_running ($self)
 		return $running;
 	}
 
-	# Fall back to process check
+	# Fall back to the process check
 	return 1;
 }
 
@@ -957,7 +976,8 @@ sub _start_qemu ( $self, $boot_image = undef )
 
 	my @cmd = (QEMU_BINARY);
 
-	# Machine type for arm64, acceleration by host capability
+	# Set the machine type for arm64. Select the accelerator by the
+	# host capability.
 	push @cmd, '-M', 'virt,highmem=off';
 	push @cmd, $self->_accel_args;
 
@@ -971,7 +991,8 @@ sub _start_qemu ( $self, $boot_image = undef )
 		push @cmd, '-bios', $bios;
 	}
 
-	# Main disk with safe cache mode (writethrough syncs on each write)
+	# The main disk with the safe cache mode. The writethrough mode
+	# syncs on each write.
 	my $disk_path = $state->disk_path;
 	push @cmd, '-drive',
 	    "file=$disk_path,format=qcow2,if=virtio,cache=writethrough";
@@ -1011,19 +1032,19 @@ sub _start_qemu ( $self, $boot_image = undef )
 	# No graphics display (headless)
 	push @cmd, '-display', 'none';
 
-	# Spawn QEMU using FuguLib::Process
+	# Use FuguLib::Process to spawn QEMU
 	my $log_file = "$state->{vm_state_dir}/qemu.log";
 	my $result   = FuguLib::Process->spawn_command(
 		cmd         => \@cmd,
 		daemonize   => 1,
 		stdout      => $log_file,
 		stderr      => $log_file,
-		check_alive => 0,    # Don't check, QEMU writes its own PID file
+		check_alive => 0,   # Do not check. QEMU writes its own PID file
 	);
 
 	return unless $result->{success};
 
-	# Wait for QEMU to write PID file
+	# Wait until QEMU writes the PID file
 	my $start = time;
 	my $pid;
 	while ( time - $start < 5 ) {
@@ -1037,7 +1058,7 @@ sub _start_qemu ( $self, $boot_image = undef )
 		usleep(100_000);    # 0.1 seconds
 	}
 
-	# Fallback: use forked PID from FuguLib::Process
+	# Fallback: use the forked PID from FuguLib::Process
 	unless ( defined $pid ) {
 		my $forked = $result->{pid};
 		if ( kill( 0, $forked ) ) {
@@ -1052,11 +1073,11 @@ sub _start_qemu ( $self, $boot_image = undef )
 		return;
 	}
 
-	# Confirm QEMU is actually accepting console connections before the
-	# installer tries to attach. A QEMU that exited at startup (bad
-	# accelerator, missing firmware) leaves the port closed; catching
-	# that here fails fast with the QEMU log instead of a long telnet
-	# timeout later.
+	# Make sure that QEMU accepts console connections before the
+	# installer tries to attach. A QEMU that exited at startup, for
+	# example with a bad accelerator or missing firmware, leaves the
+	# port closed. This check fails fast with the QEMU log, not with
+	# a long telnet timeout later.
 	unless ( $self->_wait_console_ready( $config->{console_port}, 30 ) ) {
 		$self->{log}
 		    ->error( 'QEMU console port %d not listening after start',
@@ -1069,10 +1090,10 @@ sub _start_qemu ( $self, $boot_image = undef )
 }
 
 # $self->_wait_console_ready($port, $timeout):
-#	Poll the console TCP port until it accepts a connection, so the
-#	installer's telnet attaches to a live console. The bind happens
-#	at QEMU startup (before guest boot), so this is quick when QEMU
-#	is healthy and bounded when it is not.
+#	Poll the console TCP port until it accepts a connection. Thus
+#	the telnet of the installer attaches to a live console. QEMU
+#	binds the port at startup, before the guest boots. Thus the
+#	poll is quick when QEMU is healthy, and bounded when it is not.
 sub _wait_console_ready ( $self, $port, $timeout )
 {
 	require IO::Socket::INET;
@@ -1090,7 +1111,7 @@ sub _wait_console_ready ( $self, $port, $timeout )
 			return 1;
 		}
 
-		# Give up early if QEMU has already exited
+		# Stop the wait early if QEMU already exited
 		my $qemu_pid = $self->{state}->get_vm_pid;
 		return 0 if defined $qemu_pid && !kill( 0, $qemu_pid );
 
@@ -1101,8 +1122,9 @@ sub _wait_console_ready ( $self, $port, $timeout )
 }
 
 # $self->_dump_qemu_log($log_file):
-#	Emit the tail of the QEMU log so a startup failure is visible in
-#	CI output instead of requiring shell access to the runner.
+#	Show the tail of the QEMU log. Thus a startup failure is
+#	visible in the CI output, and shell access to the runner is not
+#	necessary.
 sub _dump_qemu_log ( $self, $log_file )
 {
 	open my $fh, '<', $log_file or return;
@@ -1117,10 +1139,11 @@ sub _dump_qemu_log ( $self, $log_file )
 }
 
 # $self->_accel_args():
-#	Pick the QEMU accelerator for the host: HVF on macOS, KVM on
-#	aarch64 Linux hosts with /dev/kvm, TCG software emulation
-#	otherwise or when --emulate was given. Host CPU passthrough is
-#	only valid with hardware acceleration; TCG needs a named model.
+#	Pick the QEMU accelerator for the host. Use HVF on macOS. Use
+#	KVM on aarch64 Linux hosts with /dev/kvm. Use TCG software
+#	emulation in the other cases, or when --emulate was given. Host
+#	CPU passthrough is only valid with hardware acceleration. TCG
+#	needs a named model.
 sub _accel_args ($self)
 {
 	my $accel;
@@ -1144,7 +1167,7 @@ sub _accel_args ($self)
 }
 
 # _host_arch():
-#	Host machine architecture from uname
+#	Return the host machine architecture from uname.
 sub _host_arch ()
 {
 	require POSIX;
@@ -1166,7 +1189,7 @@ sub _find_efi_firmware ($self)
 		return $path if -f $path;
 	}
 
-	# Try glob for versioned Homebrew paths
+	# Try a glob for the versioned Homebrew paths
 	my @glob_paths =
 	    glob('/opt/homebrew/Cellar/qemu/*/share/qemu/edk2-aarch64-code.fd');
 	return $glob_paths[0] if @glob_paths;
@@ -1175,9 +1198,9 @@ sub _find_efi_firmware ($self)
 }
 
 # $self->_cache_dir:
-#	Configured cache directory, injected into the per-VM config by
-#	FuguVM::Config::load_vm. The fallback only serves VM objects
-#	built without a configuration.
+#	Return the configured cache directory. FuguVM::Config::load_vm
+#	injects it into the per-VM config. The fallback only serves VM
+#	objects built without a configuration.
 sub _cache_dir ($self)
 {
 	my $configured = $self->{config}{cache_dir};

--- a/lib/FuguVM/VM.pm
+++ b/lib/FuguVM/VM.pm
@@ -99,7 +99,7 @@ sub up ($self)
 		return EXIT_ERROR;
 	}
 
-	# Check for an unclean shutdown. Then verify the disk integrity.
+	# Check for an unclean shutdown. Then check the disk integrity.
 	if ( $state->was_unclean_shutdown ) {
 		$log->warning("Detected unclean shutdown, checking disk...");
 		my $disk  = FuguVM::Disk->new( $state->{state_dir} );
@@ -814,7 +814,7 @@ sub _install_ssh_key ( $self, $password )
 
 # P1: Graceful shutdown with filesystem sync
 # The method tries these procedures in order of reliability:
-# 1. SSH sync + ACPI powerdown (sync via SSH, powerdown via QMP)
+# 1. SSH sync + ACPI powerdown (sync through SSH, powerdown through QMP)
 # 2. QGA guest-shutdown (if available)
 # 3. Direct ACPI powerdown
 sub _graceful_shutdown ($self)
@@ -945,7 +945,7 @@ sub _is_running ($self)
 	# Check if the process is alive
 	return 0 if !kill( 0, $pid );
 
-	# Verify through QMP when possible. QMP is more reliable.
+	# Check through QMP when possible. QMP is more reliable.
 	my $qmp = $self->_qmp_connect;
 	if ($qmp) {
 		my $running = $qmp->is_running;

--- a/lib/OpenHAP/Accessory.pm
+++ b/lib/OpenHAP/Accessory.pm
@@ -15,7 +15,7 @@ sub new ( $class, %args )
 		event_callbacks   => [],
 	}, $class;
 
-	# Add required Accessory Information service
+	# Add the required Accessory Information service
 	$self->_add_accessory_info_service();
 
 	return $self;
@@ -101,7 +101,7 @@ sub get_services ($self)
 
 sub get_service ( $self, $type )
 {
-	# Look up the full UUID if a short name is given
+	# Look up the full UUID when the caller gives a short name
 	require OpenHAP::Service;
 	my $target_uuid = $OpenHAP::Service::SERVICE_TYPES{$type} // $type;
 
@@ -137,8 +137,8 @@ sub to_json ($self)
 
 sub identify ($self)
 {
-	# Override in subclasses to implement identify functionality
-	# (e.g., blink LED, beep, etc.)
+	# Subclasses override this method to add the identify function.
+	# For example, blink an LED or sound a beep.
 }
 
 sub add_event_callback ( $self, $callback )
@@ -148,7 +148,7 @@ sub add_event_callback ( $self, $callback )
 
 sub notify_change ( $self, $iid )
 {
-	# Notify all registered callbacks about characteristic change
+	# Tell all registered callbacks about the characteristic change
 	for my $callback ( @{ $self->{event_callbacks} } ) {
 		$callback->( $self->{aid}, $iid );
 	}

--- a/lib/OpenHAP/Bridge.pm
+++ b/lib/OpenHAP/Bridge.pm
@@ -8,7 +8,7 @@ our @ISA = qw(OpenHAP::Accessory);
 sub new ( $class, %args )
 {
 	my $self = $class->SUPER::new(
-		aid               => 1,    # Bridge is always accessory 1
+		aid               => 1,    # The bridge is always accessory 1
 		name              => $args{name}         // 'OpenHAP Bridge',
 		manufacturer      => $args{manufacturer} // 'OpenBSD',
 		model             => $args{model}        // 'OpenHAP',
@@ -18,8 +18,9 @@ sub new ( $class, %args )
 
 	$self->{bridged_accessories} = [];
 
-	# ProtocolInformation is required on the bridge accessory object
-	# itself; bridged accessories do not carry it (HAP-Services.md §3)
+	# The bridge accessory object itself must have the
+	# ProtocolInformation service. Bridged accessories do not
+	# carry it (HAP-Services.md §3).
 	$self->_add_protocol_info_service;
 
 	return $self;
@@ -53,7 +54,7 @@ sub add_bridged_accessory ( $self, $accessory )
 		$accessory->{aid}, $accessory->{name} );
 	push @{ $self->{bridged_accessories} }, $accessory;
 
-	# Forward event callbacks, preserving the device aid
+	# Forward the event callbacks. Keep the device aid unchanged.
 	$accessory->add_event_callback(
 		sub ( $aid, $iid ) {
 			for my $callback ( @{ $self->{event_callbacks} } ) {
@@ -87,10 +88,10 @@ sub to_json ($self)
 {
 	my @accessories;
 
-	# Add bridge itself
+	# Add the bridge itself
 	push @accessories, $self->SUPER::to_json();
 
-	# Add bridged accessories
+	# Add the bridged accessories
 	for my $acc ( @{ $self->{bridged_accessories} } ) {
 		push @accessories, $acc->to_json;
 	}

--- a/lib/OpenHAP/Characteristic.pm
+++ b/lib/OpenHAP/Characteristic.pm
@@ -42,8 +42,9 @@ our %CHAR_TYPES = (
 	'Version' => '00000037-0000-1000-8000-0026BB765291',
 );
 
-# _uuid_to_short($uuid) - Convert full UUID to short form for JSON
-# Returns short hex string for Apple UUIDs, full UUID for custom ones
+# _uuid_to_short($uuid) - Convert the full UUID to the short form
+# for JSON. The function returns a short hex string for Apple
+# UUIDs. It returns the full UUID for custom UUIDs.
 sub _uuid_to_short ($uuid)
 {
 	my $base = HAP_BASE_UUID;
@@ -90,7 +91,7 @@ sub new ( $class, %args )
 		format => $args{format} // 'string',
 		perms  => $args{perms}  // ['pr'],
 
-		# Value (can be scalar ref for mutable values)
+		# Value: a scalar reference makes the value mutable
 		value => $args{value},
 
 		# Optional metadata
@@ -114,12 +115,12 @@ sub new ( $class, %args )
 sub get_value ($self)
 {
 
-	# If there's a custom getter, use it
+	# Use the custom getter if the characteristic has one
 	if ( $self->{on_get} ) {
 		return $self->{on_get}->();
 	}
 
-	# If value is a reference, dereference it
+	# If the value is a reference, dereference it
 	if ( ref $self->{value} eq 'SCALAR' ) {
 		return ${ $self->{value} };
 	}
@@ -132,12 +133,12 @@ sub set_value ( $self, $value )
 	$OpenHAP::logger->debug( 'Setting characteristic IID=%d to value: %s',
 		$self->{iid}, defined $value ? $value : 'undef' );
 
-	# If there's a custom setter, use it
+	# Use the custom setter if the characteristic has one
 	if ( $self->{on_set} ) {
 		$self->{on_set}->($value);
 	}
 
-	# Update value
+	# Update the value
 	if ( ref $self->{value} eq 'SCALAR' ) {
 		${ $self->{value} } = $value;
 	}
@@ -170,14 +171,15 @@ sub to_json ( $self, $include_value = 1 )
 		perms  => $self->{perms},
 	};
 
-	# Add optional metadata
+	# Add the optional metadata
 	$json->{unit}     = $self->{unit}   if defined $self->{unit};
 	$json->{minValue} = $self->{min}    if defined $self->{min};
 	$json->{maxValue} = $self->{max}    if defined $self->{max};
 	$json->{minStep}  = $self->{step}   if defined $self->{step};
 	$json->{maxLen}   = $self->{maxLen} if defined $self->{maxLen};
 
-	# Add value if requested and readable
+	# Add the value if the caller requests it and the
+	# characteristic is readable
 	if ( $include_value && grep { $_ eq 'pr' } @{ $self->{perms} } ) {
 		$json->{value} = $self->json_value;
 	}
@@ -185,8 +187,8 @@ sub to_json ( $self, $include_value = 1 )
 	return $json;
 }
 
-# json_value() - Current value converted to its JSON type per the
-# characteristic format (HAP-HTTP.md §15.1)
+# json_value() - Convert the current value to its JSON type. The
+# characteristic format selects the type (HAP-HTTP.md §15.1).
 sub json_value ($self)
 {
 	my $value = $self->get_value();

--- a/lib/OpenHAP/Config.pm
+++ b/lib/OpenHAP/Config.pm
@@ -55,7 +55,8 @@ m/\A \s* device \s+ (\w+) \s+ (\w+) \s+ (\w+) \s* [{] /xms
 			$current_device = undef;
 		}
 
-		# Device properties (must check BEFORE top-level config)
+		# Device properties. This check must come BEFORE the
+		# top-level config check.
 		elsif (    $current_device
 			&& $line =~ m/\A \s* (\w+) \s* = \s* (.+?) \s* \z/xms )
 		{
@@ -69,7 +70,8 @@ m/\A \s* device \s+ (\w+) \s+ (\w+) \s+ (\w+) \s* [{] /xms
 		elsif ( $line =~ m/\A \s* (\w+) \s* = \s* (.+?) \s* \z/xms ) {
 			my ( $key, $value ) = ( $1, $2 );
 
-			# Remove surrounding quotes if present
+			# Remove the quotes around the value if they
+			# are present
 			$value =~ s/\A "//xms;
 			$value =~ s/" \z//xms;
 			$self->{config}{$key} = $value;

--- a/lib/OpenHAP/Daemon.pm
+++ b/lib/OpenHAP/Daemon.pm
@@ -25,9 +25,9 @@ use FuguLib::Daemon;
 use FuguLib::State;
 
 # $class->daemonize($logfile):
-#	Fork into background, detach from terminal, and redirect
-#	standard file descriptors. Returns in child process only.
-#	Parent process exits successfully.
+#	Fork into the background. Detach from the terminal. Redirect
+#	the standard file descriptors. The method returns in the
+#	child process only. The parent process exits successfully.
 sub daemonize ( $class, $logfile = '/var/log/openhapd.log' )
 {
 	FuguLib::Daemon->daemonize( logfile => $logfile );
@@ -37,7 +37,8 @@ sub daemonize ( $class, $logfile = '/var/log/openhapd.log' )
 }
 
 # $class->write_pidfile($path):
-#	Write current PID to file. Returns true on success.
+#	Write the current PID to the file. The method returns true
+#	on success.
 sub write_pidfile ( $class, $path )
 {
 	my $state = FuguLib::State->new($path);
@@ -52,8 +53,8 @@ sub write_pidfile ( $class, $path )
 }
 
 # $class->read_pidfile($path):
-#	Read PID from file. Returns PID or undef if file doesn't exist
-#	or cannot be read.
+#	Read the PID from the file. The method returns the PID. It
+#	returns undef if the file does not exist or is not readable.
 sub read_pidfile ( $class, $path )
 {
 	my $state = FuguLib::State->new($path);
@@ -62,8 +63,9 @@ sub read_pidfile ( $class, $path )
 }
 
 # $class->check_running($pidfile):
-#	Check if daemon is running based on PID file.
-#	Returns PID if running, undef otherwise.
+#	Check if the daemon runs. The check uses the PID file.
+#	The method returns the PID if the daemon runs. Otherwise,
+#	it returns undef.
 sub check_running ( $class, $pidfile )
 {
 	my $state = FuguLib::State->new($pidfile);
@@ -78,18 +80,21 @@ sub check_running ( $class, $pidfile )
 #				it is a source checkout
 #	perl_dirs   => \@dirs	override the perl library directories
 #				(tests only)
-#	The daemon's unveil(2) inventory: an ordered list of
-#	[$path, $perms] pairs with per-path dispositions, for
-#	FuguLib::Sandbox->unveil. Pure assembly - nothing here touches
-#	the filesystem view - so it is unit-testable on any platform.
+#	The method returns the unveil(2) inventory of the daemon.
+#	The inventory is an ordered list of [$path, $perms] pairs
+#	for FuguLib::Sandbox->unveil. Each path has its own
+#	disposition. The method only assembles data. Nothing here
+#	touches the filesystem view. Thus unit tests can run on
+#	all platforms.
 #
-#	Every entry is required (absent means a broken install and
-#	startup must fail naming the path) or optional (legitimately
-#	absent on a working system: a fresh install has no config
-#	file, -f mode never creates the log file, mdnsd may not run,
-#	and the resolver files matter only when mqtt_host is a name).
-#	Getting a disposition wrong turns a configuration that starts
-#	today into a startup failure.
+#	Each entry is required or optional. If a required entry is
+#	absent, the install is broken. Then startup must fail and
+#	name the path. An optional entry can be legitimately absent
+#	on a working system. A fresh install has no config file.
+#	The -f mode never creates the log file. The mdnsd daemon
+#	does not always run. The resolver files matter only when
+#	mqtt_host is a name. A wrong disposition turns a
+#	configuration that starts today into a startup failure.
 sub unveil_paths ( $class, %args )
 {
 	my $db_path     = $args{db_path} or die 'db_path parameter required';
@@ -98,21 +103,24 @@ sub unveil_paths ( $class, %args )
 
 	my @paths = ( [ $db_path, 'rwc' ], [ '/dev/urandom', 'r' ], );
 
-	# The perl library tree, read-only, for the lazy require on the
-	# MQTT reconnect path. An enumerated list, never live @INC:
-	# bin/openhapd prepends $RealBin/../lib, which on an installed
-	# layout is /usr/local/lib - every third-party library on the
-	# system, not a perl tree - and OpenHAP::MQTT unshifts a
-	# directory onto @INC at connect time, so a derived set would
-	# depend on whether the startup connect has run. Unveiling the
-	# tree read-only is the deliberate trade: proving no module
-	# ever loads late is a claim no test can hold over time, while
-	# these few read-only lines cannot regress the MQTT reconnect.
+	# Unveil the perl library tree read-only for the lazy require
+	# on the MQTT reconnect path. Use an enumerated list, never
+	# the live @INC. Two reasons apply. First, bin/openhapd
+	# prepends $RealBin/../lib. On an installed layout, that is
+	# /usr/local/lib. That directory holds every third-party
+	# library on the system, not a perl tree. Second,
+	# OpenHAP::MQTT unshifts a directory onto @INC at connect
+	# time. Thus a derived set would depend on whether the
+	# startup connect has run. The read-only unveil of the tree
+	# is a deliberate trade. No test can prove over time that no
+	# module loads late. But these few read-only lines cannot
+	# regress the MQTT reconnect.
 	my @perl_dirs =
 	    $args{perl_dirs} ? @{ $args{perl_dirs} } : _perl_lib_dirs();
 
-	# The checkout's own lib, only when it really is one: the
-	# installed layout must not pick up /usr/local/lib here
+	# Add the checkout's own lib directory, but only when it
+	# really is a checkout. The installed layout must not pick
+	# up /usr/local/lib here.
 	my $script_lib = $args{script_lib};
 	push @perl_dirs, $script_lib
 	    if defined $script_lib && -d "$script_lib/OpenHAP";
@@ -135,11 +143,11 @@ sub unveil_paths ( $class, %args )
 }
 
 # _perl_lib_dirs():
-#	The perl library directories as the interpreter was built with
-#	them - stable facts from %Config, not runtime @INC. The
-#	literal site_perl entry is the directory OpenHAP::MQTT
-#	unshifts onto @INC at connect time; on OpenBSD it equals
-#	sitelibexp and dedupes away.
+#	Return the perl library directories from the interpreter
+#	build. These are stable facts from %Config, not the runtime
+#	@INC. The literal site_perl entry is the directory that
+#	OpenHAP::MQTT unshifts onto @INC at connect time. On
+#	OpenBSD, it equals sitelibexp and the dedupe removes it.
 sub _perl_lib_dirs ()
 {
 	my @dirs;

--- a/lib/OpenHAP/DeviceLoader.pm
+++ b/lib/OpenHAP/DeviceLoader.pm
@@ -25,7 +25,7 @@ use OpenHAP::Tasmota::Sensor;
 use OpenHAP::Tasmota::Lightbulb;
 
 # $class->new():
-#	Create new device loader instance.
+#	Create a new device loader instance.
 sub new ($class)
 {
 	bless {
@@ -35,8 +35,8 @@ sub new ($class)
 }
 
 # $self->load_devices($config, $hap, $mqtt):
-#	Load devices from configuration and add them to HAP bridge.
-#	Returns number of successfully loaded devices.
+#	Load the devices from the configuration. Add them to the
+#	HAP bridge. The method returns the number of loaded devices.
 sub load_devices ( $self, $config, $hap, $mqtt )
 {
 	my @devices = $config->get_devices();
@@ -68,15 +68,15 @@ sub load_devices ( $self, $config, $hap, $mqtt )
 }
 
 # $self->get_devices():
-#	Return list of loaded device accessory objects.
+#	Return the list of loaded device accessory objects.
 sub get_devices ($self)
 {
 	return @{ $self->{devices} };
 }
 
 # $self->_create_device($device, $mqtt, $mqtt_connected):
-#	Create accessory from device configuration.
-#	Returns accessory object or undef on error.
+#	Create an accessory from the device configuration.
+#	The method returns the accessory object, or undef on error.
 sub _create_device ( $self, $device, $mqtt, $mqtt_connected )
 {
 	my $dev_type    = $device->{type}    // 'unknown';
@@ -86,7 +86,7 @@ sub _create_device ( $self, $device, $mqtt, $mqtt_connected )
 		'Processing device: type=%s, subtype=%s, name=%s',
 		$dev_type, $dev_subtype, $device->{name} // '<unnamed>' );
 
-	# Validate device type
+	# Validate the device type
 	unless ( $self->_is_supported_device( $dev_type, $dev_subtype ) ) {
 		$OpenHAP::logger->debug(
 			'Skipping unsupported device type: %s/%s',
@@ -94,10 +94,10 @@ sub _create_device ( $self, $device, $mqtt, $mqtt_connected )
 		return;
 	}
 
-	# Validate required fields
+	# Validate the required fields
 	return unless $self->_validate_device($device);
 
-	# Create device with error handling
+	# Create the device and catch errors
 	my $accessory;
 	eval {
 		$accessory =
@@ -113,7 +113,7 @@ sub _create_device ( $self, $device, $mqtt, $mqtt_connected )
 		return;
 	}
 
-	# Subscribe to MQTT if connected
+	# Subscribe to MQTT if the client is connected
 	if ($mqtt_connected) {
 		$self->_subscribe_mqtt( $accessory, $device );
 	}
@@ -127,7 +127,7 @@ sub _create_device ( $self, $device, $mqtt, $mqtt_connected )
 }
 
 # $self->_is_supported_device($type, $subtype):
-#	Check if device type is supported.
+#	Check if the loader supports the device type.
 sub _is_supported_device ( $self, $type, $subtype )
 {
 	return 1 if $type eq 'tasmota' && $subtype eq 'thermostat';
@@ -142,7 +142,8 @@ sub _is_supported_device ( $self, $type, $subtype )
 }
 
 # $self->_validate_device($device):
-#	Validate required device fields. Returns true if valid.
+#	Validate the required device fields. The method returns true
+#	if the device is valid.
 sub _validate_device ( $self, $device )
 {
 	unless ( defined $device->{name} && $device->{name} ne '' ) {
@@ -168,7 +169,7 @@ sub _validate_device ( $self, $device )
 }
 
 # $self->_instantiate_device($device, $mqtt, $type, $subtype):
-#	Instantiate device object based on type.
+#	Create the device object for the given type.
 sub _instantiate_device ( $self, $device, $mqtt, $type, $subtype )
 {
 	my %common_args = (
@@ -227,7 +228,7 @@ sub _instantiate_device ( $self, $device, $mqtt, $type, $subtype )
 }
 
 # $self->_subscribe_mqtt($accessory, $device):
-#	Subscribe device to MQTT topics.
+#	Subscribe the device to its MQTT topics.
 sub _subscribe_mqtt ( $self, $accessory, $device )
 {
 	eval { $accessory->subscribe_mqtt(); };
@@ -243,7 +244,7 @@ sub _subscribe_mqtt ( $self, $accessory, $device )
 }
 
 # $self->_device_type_name($device):
-#	Return human-readable device type name.
+#	Return the human-readable device type name.
 sub _device_type_name ( $self, $device )
 {
 	my $type    = $device->{type}    // 'unknown';

--- a/lib/OpenHAP/HAP.pm
+++ b/lib/OpenHAP/HAP.pm
@@ -328,7 +328,7 @@ sub _dispatch ( $self, $request, $session )
 	my $path   = $request->{path};
 	my $method = $request->{method};
 
-	# Pairing endpoints. These need no verification.
+	# Pairing endpoints. These need no verified session.
 	if ( $path eq '/pair-setup' && $method eq 'POST' ) {
 		return $self->_handle_pair_setup( $request, $session );
 	}
@@ -342,7 +342,7 @@ sub _dispatch ( $self, $request, $session )
 		return $self->_handle_identify( $request, $session );
 	}
 
-	# All other endpoints need verification
+	# All other endpoints need a verified session
 	unless ( $session->is_verified() ) {
 		return OpenHAP::HTTP::build_response(
 			status  => 470,    # Connection Authorization Required
@@ -711,7 +711,7 @@ sub _handle_add_pairing ( $self, $tlv, $session )
 	$OpenHAP::logger->debug( 'Add pairing request for: %s',
 		$identifier // 'unknown' );
 
-	# Verify the admin permissions. Only admins can add pairings.
+	# Check the admin permissions. Only admins can add pairings.
 	my $pairings           = $self->{storage}->load_pairings();
 	my $current_controller = $session->controller_id();
 	my $current_pairing    = $pairings->{$current_controller};
@@ -773,7 +773,7 @@ sub _handle_remove_pairing ( $self, $tlv, $session )
 	$OpenHAP::logger->debug( 'Remove pairing request for: %s',
 		$identifier // 'unknown' );
 
-	# Verify the admin permissions
+	# Check the admin permissions
 	my $pairings           = $self->{storage}->load_pairings();
 	my $current_controller = $session->controller_id();
 	my $current_pairing    = $pairings->{$current_controller};
@@ -826,7 +826,7 @@ sub _handle_list_pairings ( $self, $tlv, $session )
 {
 	$OpenHAP::logger->debug('List pairings request');
 
-	# Verify the admin permissions
+	# Check the admin permissions
 	my $pairings           = $self->{storage}->load_pairings();
 	my $current_controller = $session->controller_id();
 	my $current_pairing    = $pairings->{$current_controller};

--- a/lib/OpenHAP/HAP.pm
+++ b/lib/OpenHAP/HAP.pm
@@ -50,11 +50,11 @@ sub new ( $class, %args )
 
 sub _initialize ($self)
 {
-	# Initialize storage
+	# Initialize the storage
 	$self->{storage} =
 	    OpenHAP::Storage->new( db_path => $self->{storage_path} );
 
-	# Load or generate accessory keys
+	# Load or generate the accessory keys
 	my ( $ltsk, $ltpk ) = $self->{storage}->load_accessory_keys();
 	unless ( $ltsk && $ltpk ) {
 		( $ltsk, $ltpk ) = OpenHAP::Crypto::generate_keypair_ed25519();
@@ -64,7 +64,7 @@ sub _initialize ($self)
 	$self->{accessory_ltsk} = $ltsk;
 	$self->{accessory_ltpk} = $ltpk;
 
-	# Initialize pairing handler
+	# Initialize the pairing handler
 	$self->{pairing} = OpenHAP::Pairing->new(
 		pin            => $self->{pin},
 		storage        => $self->{storage},
@@ -72,12 +72,12 @@ sub _initialize ($self)
 		accessory_ltpk => $self->{accessory_ltpk},
 	);
 
-	# Initialize bridge
+	# Initialize the bridge
 	$self->{bridge} = OpenHAP::Bridge->new( name => $self->{name}, );
 
-	# Deliver device-side changes as EVENT/1.0 notifications: the
-	# bridge forwards each bridged accessory's notify_change with
-	# the device aid preserved (HAP-HTTP.md §14)
+	# Deliver device-side changes as EVENT/1.0 notifications.
+	# The bridge forwards the notify_change of each bridged
+	# accessory and keeps the device aid (HAP-HTTP.md §14).
 	$self->{bridge}->add_event_callback(
 		sub ( $aid, $iid ) {
 			$self->_queue_change_event( $aid, $iid );
@@ -85,7 +85,7 @@ sub _initialize ($self)
 }
 
 # $self->_queue_change_event($aid, $iid):
-#	Queue an event carrying the characteristic's current value
+#	Queue an event with the current value of the characteristic
 sub _queue_change_event ( $self, $aid, $iid )
 {
 	my $accessory = $self->{bridge}->get_accessory($aid);
@@ -105,7 +105,7 @@ sub add_accessory ( $self, $accessory )
 }
 
 # $self->_mqtt_resubscribe_accessories():
-#	resubscribe all accessories to their MQTT topics
+#	Resubscribe all accessories to their MQTT topics
 sub _mqtt_resubscribe_accessories ($self)
 {
 	my @accessories = $self->{bridge}->get_bridged_accessories();
@@ -120,15 +120,16 @@ sub _mqtt_resubscribe_accessories ($self)
 }
 
 # $self->set_mqtt_client($mqtt):
-#	set the MQTT client for event loop integration
+#	Set the MQTT client for event loop integration
 sub set_mqtt_client ( $self, $mqtt )
 {
 	$self->{mqtt_client} = $mqtt;
 }
 
 # $self->set_mdns($mdns):
-#	set the mDNS registration handle so the TXT record can be
-#	re-advertised when the pairing state changes (HAP-mDNS.md §8)
+#	Set the mDNS registration handle. The server re-advertises
+#	the TXT record when the pairing state changes
+#	(HAP-mDNS.md §8).
 sub set_mdns ( $self, $mdns )
 {
 	$self->{mdns}              = $mdns;
@@ -136,7 +137,7 @@ sub set_mdns ( $self, $mdns )
 }
 
 # $self->_refresh_mdns():
-#	re-advertise the TXT record if the pairing state changed
+#	Re-advertise the TXT record when the pairing state changes
 sub _refresh_mdns ($self)
 {
 	return unless defined $self->{mdns};
@@ -146,10 +147,10 @@ sub _refresh_mdns ($self)
 
 	$self->{last_paired_state} = $paired;
 
-	# Never drive an update onto an unpublished handle: the daemon
-	# may have started with mdnsd down, and this runs on the
-	# pairing path, where a write to a dead socket must not be
-	# reachable
+	# Never send an update to an unpublished handle. The daemon
+	# can start while mdnsd is down. This code runs on the
+	# pairing path. A write to a dead socket must not be
+	# reachable there.
 	return unless $self->{mdns}->is_published;
 
 	if ( $self->{mdns}->update_txt( txt => $self->get_mdns_txt_string ) ) {
@@ -191,19 +192,20 @@ sub run ($self)
 
 	# Use a short timeout to allow MQTT polling
 	my $select_timeout          = $self->{mqtt_tick_interval};
-	my $mqtt_reconnect_interval = 30;    # Try reconnect every 30 seconds
+	my $mqtt_reconnect_interval = 30;    # Reconnect attempt interval
 	my $last_mqtt_reconnect     = 0;
 
 	while (1) {
 		my @ready = $select->can_read($select_timeout);
 
-		# Process MQTT messages if client is configured
+		# Process MQTT messages if the server has a client
 		if ( $self->{mqtt_client} ) {
 			if ( $self->{mqtt_client}->is_connected ) {
 				$self->{mqtt_client}->tick(0);
 			}
 			else {
-				# Try to reconnect periodically if disconnected
+				# Try to reconnect at intervals when the
+				# client is not connected
 				my $now = time;
 				if ( $now - $last_mqtt_reconnect >=
 					$mqtt_reconnect_interval )
@@ -215,7 +217,7 @@ sub run ($self)
 'Reconnected to MQTT broker'
 						);
 
-						# Resubscribe devices
+						# Resubscribe the devices
 						$self
 						    ->_mqtt_resubscribe_accessories
 						    ();
@@ -239,12 +241,12 @@ sub run ($self)
 			}
 			else {
 
-				# Handle client data
+				# Process the client data
 				$self->_handle_client( $sock, $select );
 			}
 		}
 
-		# Flush coalesced events if delay has passed
+		# Flush the coalesced events after the coalesce delay
 		$self->flush_events();
 	}
 }
@@ -264,9 +266,9 @@ sub _handle_client ( $self, $sock, $select )
 
 	if ( !$bytes ) {
 
-		# Connection closed: release the pairing lock if this
-		# session held it, so an aborted pair-setup cannot lock
-		# out pairing until restart
+		# The connection is closed. Release the pairing lock
+		# if this session holds it. Thus an aborted pair-setup
+		# cannot block pairing until a restart.
 		OpenHAP::Pairing->clear_pairing_state($session);
 		$self->_purge_event_subscriptions($session);
 		$OpenHAP::logger->info( 'Client disconnected from %s',
@@ -277,9 +279,10 @@ sub _handle_client ( $self, $sock, $select )
 		return;
 	}
 
-	# Decrypt if session is encrypted. Remember the state: pair-verify
-	# M4 enables encryption during dispatch, but the M4 response itself
-	# is still sent in the clear; only subsequent traffic is encrypted.
+	# Decrypt the data if the session is encrypted. Keep a
+	# record of the state. Pair-verify M4 enables encryption
+	# during dispatch. But the server sends the M4 response in
+	# the clear. Encryption applies only to subsequent traffic.
 	my $was_encrypted = $session->is_encrypted();
 	if ($was_encrypted) {
 		$data = $session->decrypt($data);
@@ -295,25 +298,25 @@ sub _handle_client ( $self, $sock, $select )
 		}
 	}
 
-	# Parse HTTP request
+	# Parse the HTTP request
 	my $request = OpenHAP::HTTP::parse($data);
 
-	# Log HTTP request with client info
+	# Log the HTTP request with the client information
 	$OpenHAP::logger->info(
 		'HTTP %s %s from %s', $request->{method},
 		$request->{path},     $sock->peerhost
 	);
 
-	# Dispatch request
+	# Dispatch the request
 	my $response = $self->_dispatch( $request, $session );
 
-	# Encrypt only if the session was already encrypted when the
-	# request arrived (see note above)
+	# Encrypt the response only if the session was encrypted
+	# when the request arrived. See the note above.
 	if ($was_encrypted) {
 		$response = $session->encrypt($response);
 	}
 
-	# Send response
+	# Send the response
 	$sock->syswrite($response);
 
 	# Re-advertise mDNS if this request changed the pairing state
@@ -325,7 +328,7 @@ sub _dispatch ( $self, $request, $session )
 	my $path   = $request->{path};
 	my $method = $request->{method};
 
-	# Pairing endpoints (no verification required)
+	# Pairing endpoints. These need no verification.
 	if ( $path eq '/pair-setup' && $method eq 'POST' ) {
 		return $self->_handle_pair_setup( $request, $session );
 	}
@@ -334,12 +337,12 @@ sub _dispatch ( $self, $request, $session )
 		return $self->_handle_pair_verify( $request, $session );
 	}
 
-	# Identify endpoint (only for unpaired accessories)
+	# Identify endpoint. It is for unpaired accessories only.
 	if ( $path eq '/identify' && $method eq 'POST' ) {
 		return $self->_handle_identify( $request, $session );
 	}
 
-	# All other endpoints require verification
+	# All other endpoints need verification
 	unless ( $session->is_verified() ) {
 		return OpenHAP::HTTP::build_response(
 			status  => 470,    # Connection Authorization Required
@@ -357,7 +360,7 @@ sub _dispatch ( $self, $request, $session )
 		return $self->_handle_accessories( $request, $session );
 	}
 
-	# Strip query string for path matching
+	# Remove the query string for path matching
 	my $base_path = $path;
 	$base_path =~ s/\?.*//;
 
@@ -369,8 +372,9 @@ sub _dispatch ( $self, $request, $session )
 		return $self->_handle_characteristics_put( $request, $session );
 	}
 
-	# Timed write preparation (accept both POST and PUT for compatibility)
-	# Spec shows POST in table but later text uses PUT; accept both
+	# Timed write preparation. The spec shows POST in the
+	# table, but the later text uses PUT. Accept both methods
+	# for compatibility.
 	if ( $path eq '/prepare' && ( $method eq 'PUT' || $method eq 'POST' ) )
 	{
 		return $self->_handle_prepare( $request, $session );
@@ -423,7 +427,7 @@ sub _handle_accessories ( $self, $request, $session )
 
 sub _handle_characteristics_get ( $self, $request, $session )
 {
-	# Parse query string: ?id=1.11,1.13&meta=1&perms=1&type=1&ev=1
+	# Parse the query string: ?id=1.11,1.13&meta=1&perms=1&type=1&ev=1
 	my $query = $request->{path};
 	$query =~ s/^.*\?//;
 	$OpenHAP::logger->debug( 'Reading characteristics: %s', $query );
@@ -476,7 +480,7 @@ sub _handle_characteristics_get ( $self, $request, $session )
 			value => $char->json_value,
 		};
 
-		# Add optional metadata if requested
+		# Add the optional metadata if the controller requests it
 		if ($include_meta) {
 			$result->{format} = $char->{format};
 			$result->{unit}   = $char->{unit}
@@ -489,17 +493,17 @@ sub _handle_characteristics_get ( $self, $request, $session )
 			    if defined $char->{step};
 		}
 
-		# Add permissions if requested
+		# Add the permissions if the controller requests them
 		if ($include_perms) {
 			$result->{perms} = $char->{perms};
 		}
 
-		# Add type if requested
+		# Add the type if the controller requests it
 		if ($include_type) {
 			$result->{type} = $char->{type};
 		}
 
-		# Add event status if requested
+		# Add the event status if the controller requests it
 		if ($include_ev) {
 			$result->{ev} = $char->events_enabled() ? \1 : \0;
 		}
@@ -554,7 +558,7 @@ sub _handle_characteristics_put ( $self, $request, $session )
 			next;
 		}
 
-		# Check if characteristic is writable
+		# Check if the characteristic is writable
 		my $is_writable = grep { $_ eq 'pw' } @{ $char->{perms} // [] };
 		if ( defined $value && !$is_writable ) {
 			push @results,
@@ -567,7 +571,7 @@ sub _handle_characteristics_put ( $self, $request, $session )
 			next;
 		}
 
-		# Set value if provided
+		# Set the value if the request contains one
 		if ( defined $value ) {
 			eval { $char->set_value($value) };
 			if ($@) {
@@ -581,13 +585,14 @@ sub _handle_characteristics_put ( $self, $request, $session )
 				next;
 			}
 
-			# Notify subscribers on other connections; the
-			# originating session is excluded (HAP-HTTP.md §14)
+			# Notify the subscribers on other connections.
+			# Exclude the originating session
+			# (HAP-HTTP.md §14).
 			$self->queue_event( $aid, $iid, $char->json_value,
 				$session );
 		}
 
-		# Enable/disable events
+		# Enable or disable events
 		if ( exists $item->{ev} ) {
 			my $has_ev =
 			    grep { $_ eq 'ev' } @{ $char->{perms} // [] };
@@ -603,7 +608,7 @@ sub _handle_characteristics_put ( $self, $request, $session )
 			}
 			$char->enable_events( $item->{ev} );
 
-			# Track session for event delivery
+			# Record the session for event delivery
 			if ( $item->{ev} ) {
 				$self->_register_event_subscription( $session,
 					$aid, $iid );
@@ -619,11 +624,11 @@ sub _handle_characteristics_put ( $self, $request, $session )
 		    { aid => $aid + 0, iid => $iid + 0, status => 0 };
 	}
 
-	# If all succeeded, return 204 No Content
+	# Return 204 No Content when all writes succeed
 	return OpenHAP::HTTP::build_response( status => 204 )
 	    unless $has_errors;
 
-	# If any failed, return 207 Multi-Status with details
+	# Return 207 Multi-Status with details if some writes fail
 	my $json = encode_json( { characteristics => \@results } );
 	return OpenHAP::HTTP::build_response(
 		status  => 207,
@@ -634,7 +639,7 @@ sub _handle_characteristics_put ( $self, $request, $session )
 
 sub _handle_identify ( $self, $request, $session )
 {
-	# Identify is only allowed for unpaired accessories
+	# Identify is only for unpaired accessories
 	if ( $self->is_paired() ) {
 		return OpenHAP::HTTP::build_response(
 			status  => 400,
@@ -645,7 +650,7 @@ sub _handle_identify ( $self, $request, $session )
 
 	$OpenHAP::logger->info('Identify request received (unpaired)');
 
-	# Trigger identification on the bridge
+	# Start identification on the bridge
 	my $bridge = $self->{bridge};
 	if ($bridge) {
 		my $info_service = $bridge->get_service('AccessoryInformation');
@@ -706,7 +711,7 @@ sub _handle_add_pairing ( $self, $tlv, $session )
 	$OpenHAP::logger->debug( 'Add pairing request for: %s',
 		$identifier // 'unknown' );
 
-	# Verify admin permissions (only admins can add pairings)
+	# Verify the admin permissions. Only admins can add pairings.
 	my $pairings           = $self->{storage}->load_pairings();
 	my $current_controller = $session->controller_id();
 	my $current_pairing    = $pairings->{$current_controller};
@@ -726,9 +731,9 @@ sub _handle_add_pairing ( $self, $tlv, $session )
 		);
 	}
 
-	# An existing identifier with a different LTPK is an error;
-	# with a matching LTPK only the permissions are updated
-	# (HAP-Pairing.md §7.4)
+	# An existing identifier with a different LTPK is an error.
+	# With a matching LTPK, the server updates only the
+	# permissions (HAP-Pairing.md §7.4).
 	my $existing = $pairings->{$identifier};
 	if ( $existing && $existing->{ltpk} ne $ltpk ) {
 		my $error = OpenHAP::TLV::encode(
@@ -768,7 +773,7 @@ sub _handle_remove_pairing ( $self, $tlv, $session )
 	$OpenHAP::logger->debug( 'Remove pairing request for: %s',
 		$identifier // 'unknown' );
 
-	# Verify admin permissions
+	# Verify the admin permissions
 	my $pairings           = $self->{storage}->load_pairings();
 	my $current_controller = $session->controller_id();
 	my $current_pairing    = $pairings->{$current_controller};
@@ -793,8 +798,9 @@ sub _handle_remove_pairing ( $self, $tlv, $session )
 	$OpenHAP::logger->info( 'Removed pairing for controller: %s',
 		$identifier );
 
-	# Check if any admins remain (HAP-Pairing.md §7.2)
-	# When last admin is removed, clear all pairings and regenerate identity
+	# Check if any admins remain (HAP-Pairing.md §7.2). If no
+	# admin remains, remove all pairings and regenerate the
+	# identity.
 	my $remaining = $self->{storage}->load_pairings();
 	my $has_admin = grep { $_->{permissions} } values %$remaining;
 	unless ( $has_admin || keys %$remaining == 0 ) {
@@ -820,7 +826,7 @@ sub _handle_list_pairings ( $self, $tlv, $session )
 {
 	$OpenHAP::logger->debug('List pairings request');
 
-	# Verify admin permissions
+	# Verify the admin permissions
 	my $pairings           = $self->{storage}->load_pairings();
 	my $current_controller = $session->controller_id();
 	my $current_pairing    = $pairings->{$current_controller};
@@ -840,7 +846,8 @@ sub _handle_list_pairings ( $self, $tlv, $session )
 		);
 	}
 
-	# Build response with all pairings, separated by 0xFF
+	# Build the response with all pairings. Separate them with
+	# 0xFF.
 	my @response_items =
 	    ( OpenHAP::Pairing::kTLVType_State(), pack( 'C', 2 ) );
 
@@ -848,7 +855,7 @@ sub _handle_list_pairings ( $self, $tlv, $session )
 	for my $id ( sort keys %$pairings ) {
 		my $pairing = $pairings->{$id};
 
-		# Add separator between pairings
+		# Add a separator between pairings
 		unless ($first) {
 			push @response_items,
 			    OpenHAP::Pairing::kTLVType_Separator(), '';
@@ -890,7 +897,7 @@ sub _handle_prepare ( $self, $request, $session )
 		);
 	}
 
-	# Store timed write context in session
+	# Store the timed write context in the session
 	$session->{timed_write} = {
 		ttl       => $ttl,
 		pid       => $pid,
@@ -923,8 +930,8 @@ sub _unregister_event_subscription ( $self, $session, $aid, $iid )
 }
 
 # $self->_purge_event_subscriptions($session):
-#	Drop every subscription held by a disconnecting session -
-#	subscriptions are per-connection (HAP-HTTP.md §14)
+#	Remove every subscription that a disconnecting session
+#	holds. Subscriptions are per-connection (HAP-HTTP.md §14).
 sub _purge_event_subscriptions ( $self, $session )
 {
 	for my $subs ( values %{ $self->{event_subscriptions} } ) {
@@ -947,10 +954,10 @@ use constant IMMEDIATE_EVENT_TYPES => {
 # Event coalescing delay in seconds (HAP-HTTP.md §14)
 use constant EVENT_COALESCE_DELAY => 0.250;
 
-# Queue an event for delivery, with coalescing for all but the
-# immediate-delivery characteristic types. The optional $originator is
-# the session whose request caused the change; it never receives the
-# event (HAP-HTTP.md §14)
+# Queue an event for delivery. Coalesce all events except the
+# immediate-delivery characteristic types. The optional
+# $originator is the session whose request caused the change.
+# That session never receives the event (HAP-HTTP.md §14).
 sub queue_event ( $self, $aid, $iid, $value, $originator = undef )
 {
 	my $accessory = $self->{bridge}->get_accessory($aid);
@@ -959,7 +966,7 @@ sub queue_event ( $self, $aid, $iid, $value, $originator = undef )
 	my $char = $accessory->get_characteristic($iid);
 	return unless $char;
 
-	# Immediate types bypass coalescing
+	# The immediate types bypass coalescing
 	my $char_type =
 	    OpenHAP::Characteristic::_uuid_to_short( $char->{type} // '' );
 	if ( IMMEDIATE_EVENT_TYPES->{$char_type} ) {
@@ -967,7 +974,7 @@ sub queue_event ( $self, $aid, $iid, $value, $originator = undef )
 		return;
 	}
 
-	# Queue event for coalescing
+	# Queue the event for coalescing
 	my $key = "$aid.$iid";
 	$self->{event_queue}{$key} = {
 		aid        => $aid,
@@ -977,11 +984,11 @@ sub queue_event ( $self, $aid, $iid, $value, $originator = undef )
 		timestamp  => Time::HiRes::time(),
 	};
 
-	# Schedule flush if not already scheduled
+	# Schedule a flush if no flush is pending
 	$self->{event_flush_scheduled} //= Time::HiRes::time();
 }
 
-# Flush queued events (called from event loop)
+# Flush the queued events. The event loop calls this function.
 sub flush_events ($self)
 {
 	return unless $self->{event_flush_scheduled};
@@ -989,23 +996,24 @@ sub flush_events ($self)
 	my $now    = Time::HiRes::time();
 	my $oldest = $self->{event_flush_scheduled};
 
-	# Wait until coalesce delay has passed
+	# Wait until the end of the coalesce delay
 	return if ( $now - $oldest ) < EVENT_COALESCE_DELAY;
 
-	# Send all queued events
+	# Send all the queued events
 	for my $event ( values %{ $self->{event_queue} } ) {
 		$self->send_event(
 			$event->{aid},   $event->{iid},
 			$event->{value}, $event->{originator} );
 	}
 
-	# Clear queue
+	# Clear the queue
 	$self->{event_queue}           = {};
 	$self->{event_flush_scheduled} = undef;
 }
 
-# Send EVENT/1.0 notification to subscribed sessions, excluding the
-# originating session if one is given (HAP-HTTP.md §14)
+# Send an EVENT/1.0 notification to the subscribed sessions. Do
+# not send it to the originating session when the caller gives
+# one (HAP-HTTP.md §14).
 sub send_event ( $self, $aid, $iid, $value, $originator = undef )
 {
 	my $key  = "$aid.$iid";
@@ -1052,9 +1060,10 @@ sub get_config_number ($self)
 }
 
 # $self->update_config_number():
-#	Increment c# when the accessory database changed since the last
-#	run (HAP-mDNS.md §3.1). Called after device loading; compares a
-#	digest of the accessory structure against the stored one.
+#	Increment c# when the accessory database changed since the
+#	last run (HAP-mDNS.md §3.1). The server calls this after
+#	device loading. It compares a digest of the accessory
+#	structure against the stored one.
 sub update_config_number ($self)
 {
 	my @parts;
@@ -1076,7 +1085,8 @@ sub update_config_number ($self)
 	my $stored = $self->{storage}->get_config_digest;
 	if ( !defined $stored ) {
 
-		# First run: record the digest, c# stays at its initial 1
+		# On the first run, record the digest. c# stays at
+		# its initial value of 1.
 		$self->{storage}->save_config_digest($digest);
 	}
 	elsif ( $stored ne $digest ) {
@@ -1092,15 +1102,16 @@ sub update_config_number ($self)
 
 sub get_device_id ($self)
 {
-	# Generate a device ID from the public key (uppercase MAC format)
+	# Generate a device ID from the public key in uppercase MAC format
 	my $id = uc( unpack( 'H*', substr( $self->{accessory_ltpk}, 0, 6 ) ) );
 	return join( ':', $id =~ /../g );
 }
 
 sub get_mdns_txt_records ($self)
 {
-	# Note: pv=1 instead of 1.1 because mdnsd uses '.' as TXT record
-	# delimiter and doesn't support escaping. HomeKit accepts pv=1.
+	# Note: pv=1, not 1.1. mdnsd uses '.' as the TXT record
+	# delimiter and does not support escaping. HomeKit accepts
+	# pv=1.
 	my $records = {
 		'c#' => $self->get_config_number(),
 		'ff' => 0,
@@ -1112,7 +1123,7 @@ sub get_mdns_txt_records ($self)
 		'ci' => 2,
 	};
 
-	# Add setup hash if setup_id is configured
+	# Add the setup hash if setup_id is set
 	if ( defined $self->{setup_id} && length( $self->{setup_id} ) == 4 ) {
 		$records->{sh} = $self->_get_setup_hash();
 	}
@@ -1121,10 +1132,11 @@ sub get_mdns_txt_records ($self)
 }
 
 # $self->get_mdns_txt_string():
-#	the TXT records formatted for the advertisement: key=value
-#	pairs joined with '.' in sorted key order. mdnsd's TXT
-#	delimiter makes the ordering observable on the wire
-#	(MDNS-Control.md §5), so it is kept deterministic
+#	Return the TXT records in the advertisement format. The
+#	string joins key=value pairs with '.' in sorted key order.
+#	The TXT delimiter of mdnsd makes the order visible on the
+#	wire (MDNS-Control.md §5). Thus the function keeps the
+#	order deterministic.
 sub get_mdns_txt_string ($self)
 {
 	my $records = $self->get_mdns_txt_records;
@@ -1132,8 +1144,9 @@ sub get_mdns_txt_string ($self)
 	return join '.', map { "$_=$records->{$_}" } sort keys %$records;
 }
 
-# _get_setup_hash() - Calculate setup hash for mDNS
-# Hash is Base64 of first 4 bytes of SHA-512(setupID + deviceID.toUpperCase())
+# _get_setup_hash() - Calculate the setup hash for mDNS
+# The hash is the Base64 of the first 4 bytes of
+# SHA-512(setupID + deviceID.toUpperCase())
 sub _get_setup_hash ($self)
 {
 	my $setup_id  = $self->{setup_id};
@@ -1142,13 +1155,14 @@ sub _get_setup_hash ($self)
 	my $hash      = sha512( $setup_id . $device_id );
 	my $truncated = substr( $hash, 0, 4 );
 
-	# Base64 encode without newlines
+	# Encode the truncated hash in Base64 without newlines
 	my $encoded = encode_base64( $truncated, '' );
 	return $encoded;
 }
 
-# _regenerate_identity() - Generate new accessory keys after factory reset
-# Called when last admin pairing is removed (HAP-Pairing.md §7.2)
+# _regenerate_identity() - Generate new accessory keys after a
+# factory reset. The server calls this after removal of the
+# last admin pairing (HAP-Pairing.md §7.2).
 sub _regenerate_identity ($self)
 {
 	my ( $ltsk, $ltpk ) = OpenHAP::Crypto::generate_keypair_ed25519();
@@ -1156,7 +1170,7 @@ sub _regenerate_identity ($self)
 	$self->{accessory_ltsk} = $ltsk;
 	$self->{accessory_ltpk} = $ltpk;
 
-	# Reinitialize pairing handler with new keys
+	# Reinitialize the pairing handler with the new keys
 	$self->{pairing} = OpenHAP::Pairing->new(
 		pin            => $self->{pin},
 		storage        => $self->{storage},
@@ -1164,7 +1178,7 @@ sub _regenerate_identity ($self)
 		accessory_ltpk => $self->{accessory_ltpk},
 	);
 
-	# Reset authentication attempt counter
+	# Reset the authentication attempt counter
 	OpenHAP::Pairing->reset_auth_attempts();
 
 	$OpenHAP::logger->info('Accessory identity regenerated');

--- a/lib/OpenHAP/HTTP.pm
+++ b/lib/OpenHAP/HTTP.pm
@@ -2,7 +2,7 @@ use v5.36;
 
 package OpenHAP::HTTP;
 
-# Simple HTTP/1.1 parser for HAP protocol
+# A simple HTTP/1.1 parser for the HAP protocol
 # HAP uses a variant of HTTP/1.1 with some differences
 
 sub parse ($data)
@@ -15,16 +15,16 @@ sub parse ($data)
 		body    => '',
 	};
 
-	# Split headers and body
+	# Split the headers and the body
 	my ( $headers_part, $body ) = split( /\r?\n\r?\n/, $data, 2 );
 	$request->{body} = $body // '';
 
-	# Parse request line and headers
+	# Parse the request line and headers
 	my @lines = split( /\r?\n/, $headers_part );
 
 	if ( @lines > 0 ) {
 
-		# Parse request line (GET /path HTTP/1.1)
+		# Parse the request line (GET /path HTTP/1.1)
 		my $request_line = shift @lines;
 		if ( $request_line =~ m{^(\S+)\s+(\S+)\s+HTTP/(\S+)$} ) {
 			$request->{method}  = $1;
@@ -33,7 +33,7 @@ sub parse ($data)
 		}
 	}
 
-	# Parse headers
+	# Parse the headers
 	for my $line (@lines) {
 		if ( $line =~ /^([^:]+):\s*(.*)$/ ) {
 			my ( $name, $value ) = ( $1, $2 );
@@ -53,7 +53,7 @@ sub build_response (%args)
 
 	my $response = "HTTP/1.1 $status $status_text\r\n";
 
-	# Add Content-Length if not specified
+	# Add Content-Length if the headers do not include it
 	unless ( exists $headers->{'Content-Length'} ) {
 		$headers->{'Content-Length'} = length($body);
 	}
@@ -63,7 +63,7 @@ sub build_response (%args)
 		$headers->{'Connection'} = 'keep-alive';
 	}
 
-	# Add headers
+	# Add the headers
 	for my $name ( keys %$headers ) {
 		$response .= "$name: $headers->{$name}\r\n";
 	}

--- a/lib/OpenHAP/MQTT.pm
+++ b/lib/OpenHAP/MQTT.pm
@@ -3,7 +3,7 @@ use v5.36;
 package OpenHAP::MQTT;
 
 # MQTT client wrapper for OpenHAP
-# Integrates with IO::Select for event-driven message handling
+# The module works with IO::Select for event-driven message handling
 
 sub new ( $class, %args )
 {
@@ -28,10 +28,10 @@ sub mqtt_connect ( $self, $timeout = 10 )
 		'Connecting to MQTT broker at %s:%d (timeout: %ds)',
 		$self->{host}, $self->{port}, $timeout );
 
-	# Try to load Net::MQTT::Simple if available
+	# Try to load Net::MQTT::Simple if it is available
 	local $@;
 
-	# Capture warnings from Net::MQTT::Simple
+	# Capture the warnings from Net::MQTT::Simple
 	my @warnings;
 	local $SIG{__WARN__} = sub {
 		push @warnings, shift;
@@ -39,7 +39,7 @@ sub mqtt_connect ( $self, $timeout = 10 )
 
 	my $success = eval {
 
-		# Ensure site_perl is in @INC
+		# Make sure that site_perl is in @INC
 		unshift @INC, '/usr/local/libdata/perl5/site_perl'
 		    unless grep { $_ eq '/usr/local/libdata/perl5/site_perl' }
 		    @INC;
@@ -56,13 +56,14 @@ sub mqtt_connect ( $self, $timeout = 10 )
 
 		my $mqtt = Net::MQTT::Simple->new($server);
 
-		# Set login credentials if provided
+		# Set the login credentials if the configuration
+		# has a username
 		if ( defined $self->{username} ) {
 			$mqtt->login( $self->{username},
 				$self->{password} // '' );
 		}
 
-		alarm(0);    # Clear alarm
+		alarm(0);    # Clear the alarm
 
 		$self->{client}    = $mqtt;
 		$self->{connected} = 1;
@@ -70,13 +71,14 @@ sub mqtt_connect ( $self, $timeout = 10 )
 			'Successfully connected to MQTT broker');
 		return 1;
 	};
-	alarm(0);    # Ensure alarm is cleared on error path
+	alarm(0);    # Also clear the alarm on the error path
 
-	# Log captured warnings through our logging system
+	# Send the captured warnings to the logger
 	for my $warning (@warnings) {
 		chomp $warning;
 
-	     # Strip program name if present (e.g., "/usr/local/bin/openhapd: ")
+		# Remove the program name if it is present, for
+		# example "/usr/local/bin/openhapd: "
 		$warning =~ s{^(?:.*/)?[^/]+:\s+}{};
 		$OpenHAP::logger->debug( 'MQTT connection warning: %s',
 			$warning );
@@ -92,8 +94,8 @@ sub mqtt_connect ( $self, $timeout = 10 )
 }
 
 # $self->subscribe($topic, $callback):
-#	subscribe to an MQTT topic with a callback for messages
-#	$callback receives ($topic, $payload)
+#	Subscribe to an MQTT topic with a callback for messages.
+#	$callback receives ($topic, $payload).
 sub subscribe ( $self, $topic, $callback )
 {
 	$OpenHAP::logger->debug( 'Subscribing to MQTT topic: %s', $topic );
@@ -101,10 +103,10 @@ sub subscribe ( $self, $topic, $callback )
 
 	return unless $self->{connected} && $self->{client};
 
-	# Net::MQTT::Simple uses a different subscription model
-	# We register topics and poll for messages in tick().
-	# Since 1.33 it passes a retain flag as a third argument;
-	# accept and ignore any extra arguments.
+	# Net::MQTT::Simple uses a different subscription model.
+	# The module registers the topics and polls for messages in
+	# tick(). Since 1.33, Net::MQTT::Simple passes a retain flag
+	# as a third argument. Accept and ignore all extra arguments.
 	eval {
 		$self->{client}->subscribe(
 			$topic,
@@ -121,7 +123,7 @@ sub subscribe ( $self, $topic, $callback )
 }
 
 # $self->unsubscribe($topic):
-#	unsubscribe from an MQTT topic
+#	Unsubscribe from an MQTT topic.
 sub unsubscribe ( $self, $topic )
 {
 	delete $self->{subscriptions}{$topic};
@@ -157,17 +159,18 @@ sub publish ( $self, $topic, $payload, $retain = 0 )
 }
 
 # $self->tick($timeout):
-#	process pending MQTT messages, call from main event loop
-#	$timeout is maximum seconds to wait (default 0 = non-blocking)
-#	returns number of messages processed
+#	Process the pending MQTT messages. Call this method from the
+#	main event loop. $timeout is the maximum wait in seconds. The
+#	default is 0, which does not block. The method returns the
+#	number of processed messages.
 sub tick ( $self, $timeout = 0 )
 {
 	return 0 unless $self->{connected} && $self->{client};
 
 	my $processed = 0;
 
-	# Process any incoming messages with timeout
-	# Capture warnings from Net::MQTT::Simple's connection attempts
+	# Process the incoming messages with the timeout.
+	# Capture the warnings from Net::MQTT::Simple connection attempts.
 	my @warnings;
 	local $SIG{__WARN__} = sub {
 		push @warnings, shift;
@@ -175,18 +178,19 @@ sub tick ( $self, $timeout = 0 )
 
 	eval { $self->{client}->tick($timeout); };
 
-	# Log captured warnings through our logging system
+	# Send the captured warnings to the logger
 	for my $warning (@warnings) {
 		chomp $warning;
 
-	     # Strip program name if present (e.g., "/usr/local/bin/openhapd: ")
+		# Remove the program name if it is present, for
+		# example "/usr/local/bin/openhapd: "
 		$warning =~ s{^(?:.*/)?[^/]+:\s+}{};
 		$OpenHAP::logger->debug( 'MQTT: %s', $warning );
 	}
 
 	if ($@) {
 
-		# Connection may have been lost
+		# The connection is possibly lost
 		if ( $@ =~ /connection|socket|closed/i ) {
 			$self->{connected} = 0;
 			$OpenHAP::logger->warning( 'MQTT connection lost: %s',
@@ -196,7 +200,7 @@ sub tick ( $self, $timeout = 0 )
 		$OpenHAP::logger->error( 'MQTT tick error: %s', $@ );
 	}
 
-	# Process pending messages through callbacks
+	# Process the pending messages through the callbacks
 	while ( @{ $self->{pending_messages} } > 0 ) {
 		my $msg = shift @{ $self->{pending_messages} };
 		my ( $topic_received, $payload ) = @$msg;
@@ -210,8 +214,9 @@ sub tick ( $self, $timeout = 0 )
 }
 
 # $self->_dispatch_message($topic, $payload):
-#	dispatch a message to matching subscription callbacks
-#	$callback receives ($topic, $payload) - topic is the actual received topic
+#	Send the message to the subscription callbacks that match.
+#	$callback receives ($topic, $payload). The topic is the
+#	actual received topic.
 sub _dispatch_message ( $self, $topic, $payload )
 {
 	my $dispatched = 0;
@@ -233,14 +238,15 @@ sub _dispatch_message ( $self, $topic, $payload )
 }
 
 # $self->_topic_matches($pattern, $topic):
-#	check if a topic matches a subscription pattern
-#	supports + (single level) and # (multi level) wildcards
+#	Check if a topic matches a subscription pattern.
+#	The pattern supports the + (single level) and # (multi level)
+#	wildcards.
 sub _topic_matches ( $self, $pattern, $topic )
 {
 	# Exact match
 	return 1 if $pattern eq $topic;
 
-	# No wildcards, must be exact
+	# The pattern has no wildcards, so the match must be exact
 	return 0 unless $pattern =~ m{[+#]};
 
 	my @pattern_parts = split m{/}, $pattern;
@@ -249,25 +255,26 @@ sub _topic_matches ( $self, $pattern, $topic )
 	for my $i ( 0 .. $#pattern_parts ) {
 		my $p = $pattern_parts[$i];
 
-		# Multi-level wildcard matches everything remaining
+		# The multi-level wildcard matches all remaining levels
 		return 1 if $p eq '#';
 
-		# Topic is shorter than pattern (without #)
+		# The topic is shorter than the pattern (without #)
 		return 0 if $i > $#topic_parts;
 
-		# Single-level wildcard matches any single level
+		# The single-level wildcard matches any single level
 		next if $p eq '+';
 
-		# Exact level match required
+		# The level must match exactly
 		return 0 if $p ne $topic_parts[$i];
 	}
 
-	# Pattern exhausted, topic must also be exhausted
+	# The loop matched all pattern levels. The topic must not
+	# have more levels.
 	return @topic_parts == @pattern_parts;
 }
 
 # $self->resubscribe():
-#	resubscribe to all topics after reconnection
+#	Subscribe to all topics again after a reconnection.
 sub resubscribe ($self)
 {
 	return unless $self->{connected} && $self->{client};
@@ -291,8 +298,8 @@ sub resubscribe ($self)
 }
 
 # $self->reconnect():
-#	attempt to reconnect to the broker
-#	returns 1 on success, 0 on failure
+#	Try to connect to the broker again.
+#	The method returns 1 on success and 0 on failure.
 sub reconnect ($self)
 {
 	$OpenHAP::logger->debug('Attempting MQTT reconnection');
@@ -323,7 +330,7 @@ sub is_connected ($self)
 }
 
 # $self->subscriptions():
-#	return list of subscribed topics
+#	Return the list of subscribed topics.
 sub subscriptions ($self)
 {
 	return keys %{ $self->{subscriptions} };

--- a/lib/OpenHAP/PIN.pm
+++ b/lib/OpenHAP/PIN.pm
@@ -22,7 +22,7 @@ use Exporter qw(import);
 our @EXPORT_OK = qw(normalize_pin validate_pin);
 
 # Invalid PINs per HAP specification
-# These are sequential or trivial patterns that should not be used
+# These are sequential or trivial patterns. Do not use them.
 use constant INVALID_PINS => qw(
     00000000 11111111 22222222 33333333 44444444
     55555555 66666666 77777777 88888888 99999999
@@ -30,31 +30,32 @@ use constant INVALID_PINS => qw(
 );
 
 # normalize_pin($pin):
-#	Strip dashes and spaces from PIN for internal use
-#	Returns: 8-digit numeric string or undef if invalid format
+#	Remove dashes and spaces from the PIN for internal use
+#	Returns: an 8-digit numeric string, or undef if the format
+#	is invalid
 sub normalize_pin ($pin)
 {
 	return unless defined $pin;
 
-	# Strip dashes and spaces
+	# Remove the dashes and spaces
 	$pin =~ s/[-\s]//g;
 
-	# Verify it's exactly 8 digits
+	# Make sure the PIN is exactly 8 digits
 	return unless $pin =~ /^\d{8}$/;
 
 	return $pin;
 }
 
 # validate_pin($pin):
-#	Validate PIN meets HAP requirements
-#	Returns: 1 if valid, undef if invalid
+#	Validate that the PIN meets the HAP requirements
+#	Returns: 1 if the PIN is valid, undef if it is invalid
 sub validate_pin ($pin)
 {
-	# Normalize first
+	# Normalize the PIN first
 	my $normalized = normalize_pin($pin);
 	return unless defined $normalized;
 
-	# Check against invalid PINs list
+	# Check the PIN against the list of invalid PINs
 	my %invalid = map { $_ => 1 } INVALID_PINS;
 	return if exists $invalid{$normalized};
 

--- a/lib/OpenHAP/Pairing.pm
+++ b/lib/OpenHAP/Pairing.pm
@@ -67,11 +67,13 @@ sub new ( $class, %args )
 	return $self;
 }
 
-# clear_pairing_state() - Reset global pairing state
-# Called after successful pairing or on connection close
+# clear_pairing_state() - Reset the global pairing state
+# The server calls this after successful pairing or on
+# connection close.
 sub clear_pairing_state ( $class_or_self, $session = undef )
 {
-	# Only clear if this session owns the lock or no session specified
+	# Clear the state only if this session owns the lock or
+	# the caller gives no session
 	if (       !defined $session
 		|| !defined $pairing_session_id
 		|| $pairing_session_id == $session )
@@ -81,8 +83,9 @@ sub clear_pairing_state ( $class_or_self, $session = undef )
 	}
 }
 
-# reset_auth_attempts() - Reset failed authentication counter
-# Called after successful SRP proof verification or administratively
+# reset_auth_attempts() - Reset the failed authentication counter
+# The server calls this after successful SRP proof verification.
+# Administrative actions also call it.
 sub reset_auth_attempts ($class_or_self)
 {
 	$failed_auth_attempts = 0;
@@ -98,13 +101,15 @@ sub _record_failed_attempt ($self)
 	    if $self->{storage};
 }
 
-# get_failed_attempts() - Get current failed attempt count (for testing)
+# get_failed_attempts() - Get the current failed attempt count
+# (for testing)
 sub get_failed_attempts ($class_or_self)
 {
 	return $failed_auth_attempts;
 }
 
-# _get_accessory_pairing_id() - Generate MAC-like pairing ID from public key
+# _get_accessory_pairing_id() - Generate a MAC-like pairing ID
+# from the public key
 sub _get_accessory_pairing_id ($self)
 {
 	my $id = uc( unpack( 'H*', substr( $self->{accessory_ltpk}, 0, 6 ) ) );
@@ -116,7 +121,7 @@ sub handle_pair_setup ( $self, $body, $session )
 
 	my %request = OpenHAP::TLV::decode($body);
 
-	# Reject malformed TLV or missing State ([HAP-TLV8 §10])
+	# Reject a malformed TLV or a missing State ([HAP-TLV8 §10])
 	unless ( defined $request{ kTLVType_State() } ) {
 		$OpenHAP::logger->warning(
 			'Pair-setup rejected: malformed TLV request');
@@ -128,7 +133,7 @@ sub handle_pair_setup ( $self, $body, $session )
 	$OpenHAP::logger->debug( 'Pair-setup M%d received (method=%d)',
 		$state, $method );
 
-	# Validate method (0x00 = PairSetup, 0x01 = PairSetupWithAuth)
+	# Validate the method (0x00 = PairSetup, 0x01 = PairSetupWithAuth)
 	if ( $method != 0 && $method != 1 ) {
 		return $self->_error_response( kTLVError_Unknown, 2 );
 	}
@@ -148,15 +153,18 @@ sub handle_pair_setup ( $self, $body, $session )
 
 sub _pair_setup_m1_m2 ( $self, $session, $method = 0 )
 {
-	# Check if max authentication attempts exceeded (HAP-Pairing.md §8)
+	# Check if the failed attempts exceed the maximum
+	# (HAP-Pairing.md §8)
 	if ( $failed_auth_attempts >= MAX_AUTH_ATTEMPTS ) {
 		$OpenHAP::logger->warning(
 			'Pair-setup rejected: max attempts exceeded');
 		return $self->_error_response( kTLVError_MaxTries, 2 );
 	}
 
-	# Check if already paired (HAP-Pairing.md §2.4)
-	# PairSetupWithAuth (method=1) allows pairing even when already paired
+	# Check if the accessory is already paired
+	# (HAP-Pairing.md §2.4). PairSetupWithAuth (method=1)
+	# permits pairing even when the accessory is already
+	# paired.
 	if ( $method == 0 ) {
 		my $pairings = $self->{storage}->load_pairings();
 		if ( keys %$pairings > 0 ) {
@@ -167,14 +175,14 @@ sub _pair_setup_m1_m2 ( $self, $session, $method = 0 )
 		}
 	}
 
-	# Check for concurrent pairing attempt (HAP-Pairing.md §2.4)
+	# Check for a concurrent pairing attempt (HAP-Pairing.md §2.4)
 	if ( $pairing_in_progress && $pairing_session_id != $session ) {
 		$OpenHAP::logger->debug(
 			'Pair-setup rejected: another pairing in progress');
 		return $self->_error_response( kTLVError_Busy, 2 );
 	}
 
-	# Mark pairing as in progress
+	# Mark the pairing as in progress
 	$pairing_in_progress = 1;
 	$pairing_session_id  = $session;
 
@@ -184,13 +192,13 @@ sub _pair_setup_m1_m2 ( $self, $session, $method = 0 )
 	$srp->compute_verifier( $salt, $self->{pin} );
 	my $B = $srp->generate_server_public();
 
-	# Store SRP session
+	# Store the SRP session
 	$session->{pairing_state}{srp} = $srp;
 
-	# M2: Send salt and public key
+	# M2: Send the salt and the public key
 	my $B_hex = $B->as_hex();
-	$B_hex =~ s/^0x//;                              # Strip 0x prefix
-	$B_hex = '0' . $B_hex if length($B_hex) % 2;    # Ensure even length
+	$B_hex =~ s/^0x//;                              # Remove the 0x prefix
+	$B_hex = '0' . $B_hex if length($B_hex) % 2;    # Make the length even
 	my $response = OpenHAP::TLV::encode(
 		kTLVType_State,     pack( 'C',  2 ),
 		kTLVType_PublicKey, pack( 'H*', $B_hex ),
@@ -209,7 +217,7 @@ sub _pair_setup_m3_m4 ( $self, $request, $session )
 	my $A  = $request->{ kTLVType_PublicKey() };
 	my $M1 = $request->{ kTLVType_Proof() };
 
-	# Compute session key (returns undef if A mod N == 0)
+	# Compute the session key. It returns undef if A mod N == 0.
 	my $K = $srp->compute_session_key($A);
 	unless ( defined $K ) {
 		$self->_record_failed_attempt;
@@ -236,11 +244,11 @@ sub _pair_setup_m3_m4 ( $self, $request, $session )
 	# Successful SRP proof resets the attempt counter (§8)
 	$self->reset_auth_attempts;
 
-	# Generate server proof
+	# Generate the server proof
 	my $M2 = $srp->generate_server_proof();
 	$OpenHAP::logger->debug('Pair-setup M3 verified, sending M4');
 
-	# M4: Send proof
+	# M4: Send the proof
 	my $response = OpenHAP::TLV::encode( kTLVType_State, pack( 'C', 4 ),
 		kTLVType_Proof, $M2, );
 
@@ -255,12 +263,12 @@ sub _pair_setup_m5_m6 ( $self, $request, $session )
 
 	my $encrypted_data = $request->{ kTLVType_EncryptedData() };
 
-	# Derive encryption key from SRP session key
+	# Derive the encryption key from the SRP session key
 	my $session_key = $srp->get_session_key();
 	my $encrypt_key = OpenHAP::Crypto::hkdf_sha512( $session_key,
 		'Pair-Setup-Encrypt-Salt', 'Pair-Setup-Encrypt-Info', 32 );
 
-	# Decrypt data
+	# Decrypt the data
 	my $nonce    = pack('x[4]') . 'PS-Msg05';
 	my $auth_tag = substr( $encrypted_data, -16, 16, '' );
 	my $decrypted =
@@ -270,13 +278,13 @@ sub _pair_setup_m5_m6 ( $self, $request, $session )
 	return $self->_error_response( kTLVError_Authentication, 6 )
 	    unless defined $decrypted;
 
-	# Parse decrypted TLV
+	# Parse the decrypted TLV
 	my %inner                 = OpenHAP::TLV::decode($decrypted);
 	my $ios_device_pairing_id = $inner{ kTLVType_Identifier() };
 	my $ios_device_ltpk       = $inner{ kTLVType_PublicKey() };
 	my $ios_device_signature  = $inner{ kTLVType_Signature() };
 
-	# Verify signature
+	# Verify the signature
 	my $ios_device_x = OpenHAP::Crypto::hkdf_sha512(
 		$session_key,
 		'Pair-Setup-Controller-Sign-Salt',
@@ -294,18 +302,19 @@ sub _pair_setup_m5_m6 ( $self, $request, $session )
 		return $self->_error_response( kTLVError_Authentication, 6 );
 	}
 
-	# Save pairing
+	# Save the pairing
 	$self->{storage}
 	    ->save_pairing( $ios_device_pairing_id, $ios_device_ltpk, 1 );
 	$OpenHAP::logger->debug( 'Pair-setup M5 verified, pairing saved for %s',
 		$ios_device_pairing_id );
 
-	# Pairing successful - reset attempt counter and clear pairing lock
+	# The pairing is successful. Reset the attempt counter.
+	# Clear the pairing lock.
 	$self->reset_auth_attempts;
 	$pairing_in_progress = 0;
 	$pairing_session_id  = undef;
 
-	# Generate accessory signature
+	# Generate the accessory signature
 	my $accessory_x = OpenHAP::Crypto::hkdf_sha512(
 		$session_key,
 		'Pair-Setup-Accessory-Sign-Salt',
@@ -319,20 +328,20 @@ sub _pair_setup_m5_m6 ( $self, $request, $session )
 		$self->{accessory_ltsk},
 		$self->{accessory_ltpk} );
 
-	# Build response TLV
+	# Build the response TLV
 	my $response_tlv = OpenHAP::TLV::encode(
 		kTLVType_Identifier, $accessory_pairing_id,
 		kTLVType_PublicKey,  $self->{accessory_ltpk},
 		kTLVType_Signature,  $accessory_signature,
 	);
 
-	# Encrypt response
+	# Encrypt the response
 	my $response_nonce = pack('x[4]') . 'PS-Msg06';
 	my ( $response_encrypted, $response_tag ) =
 	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $encrypt_key,
 		$response_nonce, $response_tlv );
 
-	# M6: Send encrypted data
+	# M6: Send the encrypted data
 	my $response = OpenHAP::TLV::encode(
 		kTLVType_State,         pack( 'C', 6 ),
 		kTLVType_EncryptedData, $response_encrypted . $response_tag,
@@ -346,7 +355,7 @@ sub handle_pair_verify ( $self, $body, $session )
 
 	my %request = OpenHAP::TLV::decode($body);
 
-	# Reject malformed TLV or missing State ([HAP-TLV8 §10])
+	# Reject a malformed TLV or a missing State ([HAP-TLV8 §10])
 	unless ( defined $request{ kTLVType_State() } ) {
 		$OpenHAP::logger->warning(
 			'Pair-verify rejected: malformed TLV request');
@@ -372,22 +381,22 @@ sub _pair_verify_m1_m2 ( $self, $request, $session )
 	my $ios_public_key = $request->{ kTLVType_PublicKey() };
 	$OpenHAP::logger->debug('Pair-verify M1: generating ephemeral keypair');
 
-	# Generate accessory ephemeral keypair
+	# Generate the accessory ephemeral keypair
 	my ( $accessory_secret, $accessory_public ) =
 	    OpenHAP::Crypto::generate_keypair_x25519();
 
-	# Compute shared secret
+	# Compute the shared secret
 	my $shared_secret =
 	    OpenHAP::Crypto::derive_shared_secret( $accessory_secret,
 		$ios_public_key );
 
-	# Store for next step
+	# Store the state for the next step
 	$session->{pairing_state}{accessory_secret} = $accessory_secret;
 	$session->{pairing_state}{accessory_public} = $accessory_public;
 	$session->{pairing_state}{ios_public_key}   = $ios_public_key;
 	$session->{pairing_state}{shared_secret}    = $shared_secret;
 
-	# Generate accessory info and signature
+	# Generate the accessory info and signature
 	my $accessory_pairing_id = $self->_get_accessory_pairing_id();
 	my $accessory_info =
 	    $accessory_public . $accessory_pairing_id . $ios_public_key;
@@ -396,13 +405,13 @@ sub _pair_verify_m1_m2 ( $self, $request, $session )
 		$self->{accessory_ltsk},
 		$self->{accessory_ltpk} );
 
-	# Build sub-TLV
+	# Build the sub-TLV
 	my $sub_tlv = OpenHAP::TLV::encode(
 		kTLVType_Identifier, $accessory_pairing_id,
 		kTLVType_Signature,  $accessory_signature,
 	);
 
-	# Derive session key and encrypt
+	# Derive the session key and encrypt
 	my $session_key = OpenHAP::Crypto::hkdf_sha512( $shared_secret,
 		'Pair-Verify-Encrypt-Salt', 'Pair-Verify-Encrypt-Info', 32 );
 
@@ -411,7 +420,7 @@ sub _pair_verify_m1_m2 ( $self, $request, $session )
 	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $session_key, $nonce,
 		$sub_tlv );
 
-	# M2: Send public key and encrypted data
+	# M2: Send the public key and the encrypted data
 	my $response = OpenHAP::TLV::encode(
 		kTLVType_State,         pack( 'C', 2 ),
 		kTLVType_PublicKey,     $accessory_public,
@@ -434,7 +443,7 @@ sub _pair_verify_m3_m4 ( $self, $request, $session )
 	return $self->_error_response( kTLVError_Unknown, 4 )
 	    unless defined $shared_secret;
 
-	# Derive session key
+	# Derive the session key
 	my $session_key = OpenHAP::Crypto::hkdf_sha512( $shared_secret,
 		'Pair-Verify-Encrypt-Salt', 'Pair-Verify-Encrypt-Info', 32 );
 
@@ -448,19 +457,19 @@ sub _pair_verify_m3_m4 ( $self, $request, $session )
 	return $self->_error_response( kTLVError_Authentication, 4 )
 	    unless defined $decrypted;
 
-	# Parse inner TLV
+	# Parse the inner TLV
 	my %inner          = OpenHAP::TLV::decode($decrypted);
 	my $ios_pairing_id = $inner{ kTLVType_Identifier() };
 	my $ios_signature  = $inner{ kTLVType_Signature() };
 
-	# Load pairing
+	# Load the pairing
 	my $pairings = $self->{storage}->load_pairings();
 	my $pairing  = $pairings->{$ios_pairing_id};
 
 	return $self->_error_response( kTLVError_Authentication, 4 )
 	    unless $pairing;
 
-	# Verify signature
+	# Verify the signature
 	my $ios_info = $ios_public_key . $ios_pairing_id . $accessory_public;
 	unless (
 		OpenHAP::Crypto::verify_ed25519(
@@ -469,10 +478,12 @@ sub _pair_verify_m3_m4 ( $self, $request, $session )
 		return $self->_error_response( kTLVError_Authentication, 4 );
 	}
 
-	# Derive session encryption keys
-	# From controller's perspective:
-	# - Control-Read-Encryption-Key: controller reads (accessory encrypts)
-	# - Control-Write-Encryption-Key: controller writes (accessory decrypts)
+	# Derive the session encryption keys. The names are from
+	# the controller's point of view:
+	# - Control-Read-Encryption-Key: the controller reads,
+	#   the accessory encrypts
+	# - Control-Write-Encryption-Key: the controller writes,
+	#   the accessory decrypts
 	my $encrypt_key =
 	    OpenHAP::Crypto::hkdf_sha512( $shared_secret, 'Control-Salt',
 		'Control-Read-Encryption-Key', 32 );
@@ -480,7 +491,7 @@ sub _pair_verify_m3_m4 ( $self, $request, $session )
 	    OpenHAP::Crypto::hkdf_sha512( $shared_secret, 'Control-Salt',
 		'Control-Write-Encryption-Key', 32 );
 
-	# Set up encrypted session
+	# Set up the encrypted session
 	$session->set_encryption( $encrypt_key, $decrypt_key );
 	$session->set_verified($ios_pairing_id);
 	$OpenHAP::logger->debug(

--- a/lib/OpenHAP/Pairing.pm
+++ b/lib/OpenHAP/Pairing.pm
@@ -84,7 +84,7 @@ sub clear_pairing_state ( $class_or_self, $session = undef )
 }
 
 # reset_auth_attempts() - Reset the failed authentication counter
-# The server calls this after successful SRP proof verification.
+# The server calls this after the SRP proof verification succeeds.
 # Administrative actions also call it.
 sub reset_auth_attempts ($class_or_self)
 {

--- a/lib/OpenHAP/SRP.pm
+++ b/lib/OpenHAP/SRP.pm
@@ -2,34 +2,36 @@ use v5.36;
 
 package OpenHAP::SRP;
 
-# Prefer the GMP backend: SRP's 3072-bit modular exponentiation is
-# impractically slow in the pure-Perl Calc backend (seconds per op,
-# far worse under emulation). 'try' falls back to Calc silently when
-# Math::BigInt::GMP is not installed, so this stays correct everywhere.
+# Prefer the GMP backend. The 3072-bit modular exponentiation of
+# SRP is impractically slow in the pure-Perl Calc backend. It
+# takes seconds per operation, and far more under emulation.
+# 'try' falls back to Calc silently when Math::BigInt::GMP is
+# not installed. Thus the module stays correct everywhere.
 use Math::BigInt try => 'GMP';
 use Digest::SHA qw(sha512);
 use OpenHAP::Crypto;
 use OpenHAP::PIN qw(normalize_pin);
 
 # SRP-6a implementation for HAP
-# Uses 3072-bit group from RFC 5054
+# The module uses the 3072-bit group from RFC 5054.
 
 # N_len: Length of N in bytes (3072 bits / 8 = 384 bytes)
 use constant N_LEN => 384;
 
 # _bigint_to_bytes($bigint, $length = undef) - Convert BigInt to bytes
-# Strips '0x' prefix from as_hex() and optionally pads to fixed length
+# The function removes the '0x' prefix from as_hex(). It pads
+# the bytes to a fixed length if the caller gives $length.
 sub _bigint_to_bytes ( $bigint, $length = undef )
 {
 	my $hex = $bigint->as_hex();
-	$hex =~ s/^0x//;    # Strip 0x prefix
+	$hex =~ s/^0x//;    # Remove the 0x prefix
 
-	# Ensure even number of hex digits
+	# Make the number of hex digits even
 	$hex = '0' . $hex if length($hex) % 2;
 
 	my $bytes = pack( 'H*', $hex );
 
-	# Left-pad with zeros if length specified
+	# Pad with zeros on the left if the caller gives a length
 	if ( defined $length && length($bytes) < $length ) {
 		$bytes = ( "\x00" x ( $length - length($bytes) ) ) . $bytes;
 	}
@@ -82,7 +84,7 @@ sub compute_verifier ( $self, $salt = undef, $password = undef )
 	my $x       = Math::BigInt->from_hex( unpack( 'H*', $x_bytes ) );
 
 	# v = g^x mod N
-	# bmodpow mutates its invocant, so work on a copy of g
+	# bmodpow mutates its invocant. Thus work on a copy of g.
 	my $v = $self->{g}->copy->bmodpow( $x, $self->{N} );
 
 	$self->{v} = $v;
@@ -92,12 +94,12 @@ sub compute_verifier ( $self, $salt = undef, $password = undef )
 sub generate_server_public ($self)
 {
 
-	# Generate random b (256 bits)
+	# Generate a random b (256 bits)
 	my $b_bytes = OpenHAP::Crypto::generate_random_bytes(32);
 	$self->{b} = Math::BigInt->from_hex( unpack( 'H*', $b_bytes ) );
 
 	# k = H(N | PAD(g))
-	# PAD(g) must be padded to the same length as N (384 bytes for 3072-bit)
+	# PAD(g) pads g to the same length as N (384 bytes for 3072-bit)
 	my $N_bytes  = _bigint_to_bytes( $self->{N} );
 	my $N_len    = length($N_bytes);
 	my $g_padded = _bigint_to_bytes( $self->{g}, $N_len );
@@ -105,7 +107,7 @@ sub generate_server_public ($self)
 	my $k        = Math::BigInt->from_hex( unpack( 'H*', $k_bytes ) );
 
 	# B = (k*v + g^b) mod N
-	# bmodpow mutates its invocant, so work on a copy of g
+	# bmodpow mutates its invocant. Thus work on a copy of g.
 	my $B =
 	    ( $k * $self->{v} +
 		    $self->{g}->copy->bmodpow( $self->{b}, $self->{N} ) )
@@ -119,23 +121,26 @@ sub compute_session_key ( $self, $A_bytes )
 {
 	my $A = Math::BigInt->from_hex( unpack( 'H*', $A_bytes ) );
 
-    # Security: Verify A mod N != 0 (SRP-6a requirement per HAP-Pairing.md §2.6)
-    # A malicious controller could send A = 0, N, or 2N to make the shared
-    # secret predictable, bypassing authentication.
+	# Security: verify A mod N != 0. This is an SRP-6a
+	# requirement per HAP-Pairing.md §2.6. A malicious
+	# controller can send A = 0, N, or 2N to make the shared
+	# secret predictable and thus bypass authentication.
 	return if ( $A % $self->{N} )->is_zero();
 
 	$self->{A} = $A;
 
-	# u = H(PAD(A) | PAD(B)) - Both A and B must be padded to N_LEN
-	# per HAP-Pairing.md §2.6 and SRP-6a spec
+	# u = H(PAD(A) | PAD(B))
+	# Pad both A and B to N_LEN per HAP-Pairing.md §2.6 and the
+	# SRP-6a spec.
 	my $A_padded = _bigint_to_bytes( $self->{A}, N_LEN );
 	my $B_padded = _bigint_to_bytes( $self->{B}, N_LEN );
 	my $u_bytes  = sha512( $A_padded . $B_padded );
 	my $u        = Math::BigInt->from_hex( unpack( 'H*', $u_bytes ) );
 
 	# S = (A * v^u)^b mod N
-	# bmodpow mutates its invocant, so work on a copy of v; the
-	# multiplication result is a fresh object, safe to mutate
+	# bmodpow mutates its invocant. Thus work on a copy of v.
+	# The multiplication result is a fresh object. It is safe
+	# to mutate.
 	my $S =
 	    ( $self->{A} * $self->{v}->copy->bmodpow( $u, $self->{N} ) )
 	    ->bmodpow( $self->{b}, $self->{N} );
@@ -153,8 +158,8 @@ sub verify_client_proof ( $self, $M1_client )
 {
 
 	# M1 = H(H(N) XOR H(g) | H(username) | salt | A | B | K)
-	# use the string xor operator: v5.36 enables the 'bitwise'
-	# feature, under which plain ^ is numeric-only
+	# Use the string xor operator. v5.36 enables the 'bitwise'
+	# feature. Under that feature, plain ^ is numeric-only.
 	my $N_hash = sha512( _bigint_to_bytes( $self->{N} ) );
 	my $g_hash = sha512( _bigint_to_bytes( $self->{g} ) );
 	my $xor    = $N_hash ^. $g_hash;
@@ -162,7 +167,7 @@ sub verify_client_proof ( $self, $M1_client )
 	my $user_hash = sha512( $self->{username} );
 
 	# M1 = H(H(N) XOR H(g) | H(I) | s | PAD(A) | PAD(B) | K)
-	# A and B must be padded to N_LEN per HAP-Pairing.md §2.5
+	# Pad A and B to N_LEN per HAP-Pairing.md §2.5.
 	my $A_bytes = _bigint_to_bytes( $self->{A}, N_LEN );
 	my $B_bytes = _bigint_to_bytes( $self->{B}, N_LEN );
 
@@ -186,7 +191,8 @@ sub generate_server_proof ($self)
 	die "SRP: K not set (compute_session_key not called)"
 	    if !defined $self->{K};
 
-   # M2 = H(PAD(A) | M1 | K) - A must be padded to N_LEN per HAP-Pairing.md §2.6
+	# M2 = H(PAD(A) | M1 | K)
+	# Pad A to N_LEN per HAP-Pairing.md §2.6.
 	my $A_bytes = _bigint_to_bytes( $self->{A}, N_LEN );
 	my $M2      = sha512( $A_bytes . $self->{M1} . $self->{K} );
 

--- a/lib/OpenHAP/SRP.pm
+++ b/lib/OpenHAP/SRP.pm
@@ -121,7 +121,7 @@ sub compute_session_key ( $self, $A_bytes )
 {
 	my $A = Math::BigInt->from_hex( unpack( 'H*', $A_bytes ) );
 
-	# Security: verify A mod N != 0. This is an SRP-6a
+	# Security: make sure that A mod N != 0. This is an SRP-6a
 	# requirement per HAP-Pairing.md §2.6. A malicious
 	# controller can send A = 0, N, or 2N to make the shared
 	# secret predictable and thus bypass authentication.

--- a/lib/OpenHAP/Service.pm
+++ b/lib/OpenHAP/Service.pm
@@ -17,8 +17,9 @@ our %SERVICE_TYPES = (
 	'Lightbulb'            => '00000043-0000-1000-8000-0026BB765291',
 );
 
-# _uuid_to_short($uuid) - Convert full UUID to short form for JSON
-# Returns short hex string for Apple UUIDs, full UUID for custom ones
+# _uuid_to_short($uuid) - Convert the full UUID to the short form
+# for JSON. The function returns a short hex string for Apple
+# UUIDs. It returns the full UUID for custom UUIDs.
 sub _uuid_to_short ($uuid)
 {
 	my $base = HAP_BASE_UUID;

--- a/lib/OpenHAP/Session.pm
+++ b/lib/OpenHAP/Session.pm
@@ -12,7 +12,7 @@ sub new ( $class, %args )
 		verified      => 0,
 		controller_id => undef,
 
-		# Session keys (set after pair-verify)
+		# Session keys. Pair-verify sets them.
 		encrypt_key => undef,
 		decrypt_key => undef,
 
@@ -45,15 +45,16 @@ sub encrypt ( $self, $data )
 
 	my $encrypted = '';
 
-	# HAP encrypts data in chunks with AAD containing length
+	# HAP encrypts data in chunks. The AAD contains the length.
 	while ( length($data) > 0 ) {
 		my $chunk  = substr( $data, 0, 1024, '' );
 		my $length = length($chunk);
 
-		# AAD is 2-byte length in little-endian
+		# The AAD is the 2-byte length in little-endian
 		my $aad = pack( 'v', $length );
 
-		# Nonce is 4 bytes zero + 8 bytes counter (little-endian)
+		# The nonce is 4 bytes zero + 8 bytes counter
+		# (little-endian)
 		my $nonce = pack( 'x[4]Q<', $self->{encrypt_count}++ );
 
 		my ( $ciphertext, $tag ) =
@@ -76,12 +77,12 @@ sub decrypt ( $self, $data )
 	my $decrypted = '';
 	my $pos       = 0;
 
-	# HAP decrypts data in frames; a truncated frame or a frame
-	# claiming more than 1024 bytes of plaintext is an error
-	# (HAP-Encryption.md §9)
+	# HAP decrypts data in frames. A truncated frame is an
+	# error. A frame that claims more than 1024 bytes of
+	# plaintext is also an error (HAP-Encryption.md §9).
 	while ( $pos < length($data) ) {
 
-		# Read frame header (2-byte length)
+		# Read the frame header (2-byte length)
 		return if $pos + 2 > length($data);
 		my $length = unpack( 'v', substr( $data, $pos, 2 ) );
 		my $aad    = substr( $data, $pos, 2 );
@@ -89,14 +90,15 @@ sub decrypt ( $self, $data )
 
 		return if $length > 1024;
 
-		# Read ciphertext + tag
+		# Read the ciphertext and the tag
 		return if $pos + $length + 16 > length($data);
 		my $ciphertext = substr( $data, $pos, $length );
 		$pos += $length;
 		my $tag = substr( $data, $pos, 16 );
 		$pos += 16;
 
-		# Nonce is 4 bytes zero + 8 bytes counter (little-endian)
+		# The nonce is 4 bytes zero + 8 bytes counter
+		# (little-endian)
 		my $nonce = pack( 'x[4]Q<', $self->{decrypt_count}++ );
 
 		my $plaintext =

--- a/lib/OpenHAP/Storage.pm
+++ b/lib/OpenHAP/Storage.pm
@@ -10,7 +10,7 @@ sub new ( $class, %args )
 {
 	my $db_path = $args{db_path} // '/var/db/openhapd';
 
-	# Create directory if it doesn't exist
+	# Create the directory if it does not exist
 	make_path($db_path) unless -d $db_path;
 
 	my $self = bless {
@@ -114,8 +114,9 @@ sub remove_pairing ( $self, $controller_id )
 	return;
 }
 
-# remove_all_pairings() - Remove all pairings (factory reset)
-# Called when last admin pairing is removed (HAP-Pairing.md §7.2)
+# remove_all_pairings() - Remove all pairings. This is a factory
+# reset. The daemon calls this method when it removes the last
+# admin pairing (HAP-Pairing.md §7.2).
 sub remove_all_pairings ($self)
 {
 	$OpenHAP::logger->debug('Removing all pairings');

--- a/lib/OpenHAP/TLV.pm
+++ b/lib/OpenHAP/TLV.pm
@@ -2,15 +2,17 @@ use v5.36;
 
 package OpenHAP::TLV;
 
-# TLV8 encoding/decoding for HomeKit Accessory Protocol
-# Type-Length-Value with 8-bit type and length fields
-# Values > 255 bytes are split into multiple chunks with same type
+# TLV8 encoding and decoding for the HomeKit Accessory Protocol
+# The format is Type-Length-Value with 8-bit type and length
+# fields. The codec splits values of more than 255 bytes into
+# multiple chunks with the same type.
 
-# TLV Type for separator (used in List Pairings responses)
+# TLV type for the separator. List Pairings responses use it.
 use constant kTLVType_Separator => 0xFF;
 
 # encode(@items) - Encode type-value pairs in order
-# Takes a list of type, value pairs preserving insertion order
+# The function takes a list of type, value pairs. It keeps the
+# insertion order.
 # Example: encode(0x06, $state, 0x03, $pubkey)
 sub encode (@items)
 {
@@ -20,16 +22,16 @@ sub encode (@items)
 		my $type  = shift @items;
 		my $value = shift @items;
 
-		# Handle undefined values as empty
+		# Use the empty string for an undefined value
 		$value //= '';
 
-		# Handle empty values (e.g., separator 0xFF)
+		# Encode empty values, for example the separator 0xFF
 		if ( length($value) == 0 ) {
 			$out .= pack( 'CC', $type, 0 );
 			next;
 		}
 
-		# Split values > 255 bytes into chunks
+		# Split values of more than 255 bytes into chunks
 		while ( length($value) > 0 ) {
 			my $chunk = substr( $value, 0, 255, '' );
 			$out .= pack( 'CC', $type, length($chunk) ) . $chunk;
@@ -45,10 +47,11 @@ sub encode_separator()
 	return pack( 'CC', kTLVType_Separator, 0 );
 }
 
-# decode($data) - Decode TLV8 buffer into a type => value hash
-# Consecutive records with the same type are concatenated (fragmentation).
-# Returns the empty list if the buffer is malformed: a truncated record
-# header or a length field pointing past the end of the buffer.
+# decode($data) - Decode a TLV8 buffer into a type => value hash
+# The function concatenates consecutive records with the same
+# type (fragmentation). It returns the empty list if the buffer
+# is malformed. A malformed buffer has a truncated record header
+# or a length field that points past the end of the buffer.
 sub decode ($data)
 {
 	my %items;
@@ -61,12 +64,12 @@ sub decode ($data)
 		my ( $type, $len ) = unpack( 'CC', substr( $data, $pos, 2 ) );
 		$pos += 2;
 
-		# Reject a length running past the end of the buffer
+		# Reject a length that runs past the end of the buffer
 		return if $pos + $len > length($data);
 		my $value = substr( $data, $pos, $len );
 		$pos += $len;
 
-		# Concatenate chunks with same type
+		# Concatenate chunks with the same type
 		$items{$type} = ( $items{$type} // '' ) . $value;
 	}
 

--- a/lib/OpenHAP/Tasmota/Base.pm
+++ b/lib/OpenHAP/Tasmota/Base.pm
@@ -404,7 +404,7 @@ sub blink ( $self, $on = 1 )
 
 # $self->query_status($type):
 #	Query the device status.
-#	$type: 0 = all, 8 = sensors, 11 = full state, etc.
+#	$type: 0 = all, 8 = sensors, 11 = full state, and other STATUS codes
 sub query_status ( $self, $type = 11 )
 {
 	$self->{mqtt_client}

--- a/lib/OpenHAP/Tasmota/Base.pm
+++ b/lib/OpenHAP/Tasmota/Base.pm
@@ -42,10 +42,10 @@ sub new ( $class, %args )
 	$self->{temp_unit}    = 'C';                        # Default to Celsius
 	$self->{last_state}   = {};    # Cache of last known state
 
-	# FullTopic pattern (H2) - default: %prefix%/%topic%/
+	# FullTopic pattern (H2). The default is %prefix%/%topic%/
 	$self->{fulltopic} = $args{fulltopic} // '%prefix%/%topic%/';
 
-	# SetOption26: use indexed POWER1 for single-relay devices (M1)
+	# SetOption26: use the indexed POWER1 for single-relay devices (M1)
 	$self->{setoption26} = $args{setoption26} // 0;
 
 	return $self;
@@ -53,7 +53,7 @@ sub new ( $class, %args )
 
 # $self->subscribe_mqtt():
 #	Subscribe to all standard Tasmota topics.
-#	Subclasses should call SUPER::subscribe_mqtt() first.
+#	Subclasses must call SUPER::subscribe_mqtt() first.
 sub subscribe_mqtt ($self)
 {
 	my $topic = $self->{mqtt_topic};
@@ -100,8 +100,9 @@ sub subscribe_mqtt ($self)
 }
 
 # $self->query_initial_state():
-#	Query device for current state after connect or LWT Online.
-#	Uses Status 11 for full state reconciliation (C1/H1).
+#	Query the device for the current state after a connect or
+#	an LWT Online. The method uses Status 11 for full state
+#	reconciliation (C1/H1).
 sub query_initial_state ($self)
 {
 	return unless $self->{mqtt_client}->is_connected();
@@ -109,27 +110,28 @@ sub query_initial_state ($self)
 	$OpenHAP::logger->debug( 'Querying initial state for %s',
 		$self->{name} );
 
-	# Request full status (Status 11) - recommended per spec §6.1
+	# Request the full status (Status 11). Spec §6.1 recommends
+	# this query.
 	$self->{mqtt_client}
 	    ->publish( $self->_build_topic( 'cmnd', 'Status' ), '11' );
 }
 
 # $self->is_online():
-#	Check if device is online.
+#	Check if the device is online.
 sub is_online ($self)
 {
 	return $self->{availability} == AVAILABILITY_ONLINE;
 }
 
 # $self->get_availability():
-#	Get device availability state.
+#	Get the device availability state.
 sub get_availability ($self)
 {
 	return $self->{availability};
 }
 
 # $self->_handle_lwt($payload):
-#	Handle LWT (Last Will and Testament) message (C1).
+#	Process the LWT (Last Will and Testament) message (C1).
 sub _handle_lwt ( $self, $payload )
 {
 	my $prev = $self->{availability};
@@ -138,7 +140,7 @@ sub _handle_lwt ( $self, $payload )
 		$self->{availability} = AVAILABILITY_ONLINE;
 		$OpenHAP::logger->info( 'Device %s is online', $self->{name} );
 
-		# Query initial state when device comes online (H3)
+		# Query the initial state when the device comes online (H3)
 		$self->query_initial_state();
 	}
 	elsif ( $payload eq 'Offline' ) {
@@ -151,14 +153,14 @@ sub _handle_lwt ( $self, $payload )
 			$self->{name}, $payload );
 	}
 
-	# Notify if availability changed
+	# Notify the subclass if the availability changed
 	if ( $prev != $self->{availability} ) {
 		$self->_on_availability_changed( $prev, $self->{availability} );
 	}
 }
 
 # $self->_handle_state($payload):
-#	Handle periodic STATE message from tele/ topic (C2).
+#	Process the periodic STATE message from the tele/ topic (C2).
 sub _handle_state ( $self, $payload )
 {
 	eval {
@@ -173,7 +175,7 @@ sub _handle_state ( $self, $payload )
 }
 
 # $self->_handle_result($payload):
-#	Handle RESULT message from stat/ topic (C3).
+#	Process the RESULT message from the stat/ topic (C3).
 sub _handle_result ( $self, $payload )
 {
 	eval {
@@ -188,13 +190,13 @@ sub _handle_result ( $self, $payload )
 }
 
 # $self->_handle_sensor($payload):
-#	Handle SENSOR message from tele/ topic.
+#	Process the SENSOR message from the tele/ topic.
 sub _handle_sensor ( $self, $payload )
 {
 	eval {
 		my $data = decode_json($payload);
 
-		# Extract temperature unit if present (H4)
+		# Extract the temperature unit if it is present (H4)
 		if ( exists $data->{TempUnit} ) {
 			$self->{temp_unit} = $data->{TempUnit};
 		}
@@ -209,24 +211,25 @@ sub _handle_sensor ( $self, $payload )
 }
 
 # $self->_handle_status11($payload):
-#	Handle STATUS11 response for state reconciliation (C1/H1).
+#	Process the STATUS11 response for state reconciliation (C1/H1).
 sub _handle_status11 ( $self, $payload )
 {
 	eval {
 		my $data = decode_json($payload);
 
-		# STATUS11 wraps data in StatusSTS (same as periodic STATE)
+		# STATUS11 wraps the data in StatusSTS. The format is
+		# the same as the periodic STATE.
 		if ( exists $data->{StatusSTS} ) {
 			my $sts = $data->{StatusSTS};
 
 			$OpenHAP::logger->debug( 'STATUS11 received for %s',
 				$self->{name} );
 
-			# Cache state data
+			# Cache the state data
 			$self->{last_state} =
 			    { %{ $self->{last_state} }, %$sts };
 
-			# Process as state data
+			# Process the data as state data
 			$self->_process_state_data($sts);
 		}
 	};
@@ -238,33 +241,38 @@ sub _handle_status11 ( $self, $payload )
 }
 
 # $self->_process_state_data($data):
-#	Process parsed STATE data. Override in subclasses.
+#	Process the parsed STATE data. Subclasses can override
+#	this method.
 sub _process_state_data ( $self, $data )
 {
-	# Cache state data
+	# Cache the state data
 	$self->{last_state} = { %{ $self->{last_state} }, %$data };
 
-	# Default implementation: check for POWER state
+	# The default implementation checks for the POWER state
 	$self->_extract_power_state($data);
 }
 
 # $self->_process_result_data($data):
-#	Process parsed RESULT data. Override in subclasses.
+#	Process the parsed RESULT data. Subclasses can override
+#	this method.
 sub _process_result_data ( $self, $data )
 {
-	# Default implementation: check for POWER state
+	# The default implementation checks for the POWER state
 	$self->_extract_power_state($data);
 }
 
 # $self->_process_sensor_data($data):
-#	Process parsed SENSOR data. Override in subclasses.
+#	Process the parsed SENSOR data. Subclasses can override
+#	this method.
 sub _process_sensor_data ( $self, $data )
 {
-	# Default: no-op, subclasses should override
+	# The default does nothing. Subclasses can override this
+	# method.
 }
 
 # $self->_extract_power_state($data):
-#	Extract power state from JSON data, handling multi-relay (H1).
+#	Extract the power state from the JSON data. The method
+#	supports multi-relay devices (H1).
 sub _extract_power_state ( $self, $data )
 {
 	my $power_key = $self->_get_power_key();
@@ -277,14 +285,15 @@ sub _extract_power_state ( $self, $data )
 
 # $self->_get_power_key():
 #	Get the power key name for this device.
-#	Handles multi-relay (H1) and SetOption26 (M1) support.
+#	The method supports multi-relay (H1) and SetOption26 (M1).
 sub _get_power_key ($self)
 {
 	if ( $self->{relay_index} && $self->{relay_index} > 0 ) {
 		return 'POWER' . $self->{relay_index};
 	}
 
-	# M1: SetOption26 uses indexed format even for single-relay
+	# M1: SetOption26 uses the indexed format even for
+	# single-relay devices
 	if ( $self->{setoption26} ) {
 		return 'POWER1';
 	}
@@ -301,7 +310,8 @@ sub _get_power_topic ($self)
 			'Power' . $self->{relay_index} );
 	}
 
-	# M1: SetOption26 uses indexed format even for single-relay
+	# M1: SetOption26 uses the indexed format even for
+	# single-relay devices
 	if ( $self->{setoption26} ) {
 		return $self->_build_topic( 'cmnd', 'Power1' );
 	}
@@ -310,7 +320,7 @@ sub _get_power_topic ($self)
 }
 
 # $self->_build_topic($prefix, $command):
-#	Build a topic using the FullTopic pattern (H2).
+#	Build a topic with the FullTopic pattern (H2).
 #	$prefix: 'cmnd', 'stat', or 'tele'
 #	$command: The command/topic suffix
 sub _build_topic ( $self, $prefix, $command )
@@ -318,32 +328,34 @@ sub _build_topic ( $self, $prefix, $command )
 	my $fulltopic = $self->{fulltopic};
 	my $topic     = $self->{mqtt_topic};
 
-	# Substitute tokens
+	# Replace the tokens
 	$fulltopic =~ s/%prefix%/$prefix/g;
 	$fulltopic =~ s/%topic%/$topic/g;
 
-	# Remove trailing slash and append command
+	# Remove the trailing slash. Then append the command.
 	$fulltopic =~ s{/$}{};
 
 	return "$fulltopic/$command";
 }
 
 # $self->_on_power_update($state):
-#	Called when power state updates. Override in subclasses.
+#	The base class calls this method when the power state
+#	updates. Subclasses can override it.
 sub _on_power_update ( $self, $state )
 {
 	# Default: no-op
 }
 
 # $self->_on_availability_changed($old, $new):
-#	Called when device availability changes. Override in subclasses.
+#	The base class calls this method when the device
+#	availability changes. Subclasses can override it.
 sub _on_availability_changed ( $self, $old, $new )
 {
 	# Default: no-op
 }
 
 # $self->convert_temperature($temp):
-#	Convert temperature to Celsius if needed (H4).
+#	Convert the temperature to Celsius if necessary (H4).
 sub convert_temperature ( $self, $temp )
 {
 	return $temp unless defined $temp;
@@ -358,7 +370,7 @@ sub convert_temperature ( $self, $temp )
 }
 
 # $self->set_power($state):
-#	Set power state (0=OFF, 1=ON).
+#	Set the power state (0=OFF, 1=ON).
 sub set_power ( $self, $state )
 {
 	my $command = $state ? 'ON' : 'OFF';
@@ -370,7 +382,7 @@ sub set_power ( $self, $state )
 }
 
 # $self->toggle_power():
-#	Toggle power state (L1).
+#	Toggle the power state (L1).
 sub toggle_power ($self)
 {
 	my $topic = $self->_get_power_topic();
@@ -391,7 +403,7 @@ sub blink ( $self, $on = 1 )
 }
 
 # $self->query_status($type):
-#	Query device status.
+#	Query the device status.
 #	$type: 0 = all, 8 = sensors, 11 = full state, etc.
 sub query_status ( $self, $type = 11 )
 {
@@ -400,8 +412,8 @@ sub query_status ( $self, $type = 11 )
 }
 
 # $self->force_telemetry():
-#	Force immediate telemetry update (L1).
-#	Triggers STATE and SENSOR messages from the device.
+#	Force an immediate telemetry update (L1).
+#	The device then sends STATE and SENSOR messages.
 sub force_telemetry ($self)
 {
 	$OpenHAP::logger->debug( 'Forcing telemetry for %s', $self->{name} );

--- a/lib/OpenHAP/Tasmota/Heater.pm
+++ b/lib/OpenHAP/Tasmota/Heater.pm
@@ -23,7 +23,7 @@ sub new ( $class, %args )
 
 	$self->{power_state} = 0;
 
-	# Add Switch/Outlet service
+	# Add the Switch/Outlet service
 	my $switch = OpenHAP::Service->new(
 		type    => 'Switch',
 		iid     => 10,
@@ -47,7 +47,8 @@ sub new ( $class, %args )
 
 sub subscribe_mqtt ($self)
 {
-	# Call base class to set up standard subscriptions (C1, C2, C3)
+	# Call the base class to set up the standard subscriptions
+	# (C1, C2, C3)
 	$self->SUPER::subscribe_mqtt();
 
 	return unless $self->{mqtt_client}->is_connected();
@@ -56,7 +57,8 @@ sub subscribe_mqtt ($self)
 		'Heater %s subscribing to additional MQTT topics',
 		$self->{name} );
 
-	# M2: Subscribe to plain-text POWER response (SetOption4 support)
+	# M2: Subscribe to the plain-text POWER response
+	# (SetOption4 support)
 	$self->{mqtt_client}->subscribe(
 		$self->_build_topic( 'stat', $self->_get_power_key() ),
 		sub ( $recv_topic, $payload ) {
@@ -67,7 +69,7 @@ sub subscribe_mqtt ($self)
 		} );
 }
 
-# Override _on_power_update to update our power state
+# Override _on_power_update to update the power state
 sub _on_power_update ( $self, $state )
 {
 	if ( $self->{power_state} != $state ) {

--- a/lib/OpenHAP/Tasmota/Lightbulb.pm
+++ b/lib/OpenHAP/Tasmota/Lightbulb.pm
@@ -63,7 +63,7 @@ sub new ( $class, %args )
 	$self->{has_ct} =
 	    ( $self->{capabilities} & CAP_CT ) ? 1 : 0;
 
-	# Add Lightbulb service
+	# Add the Lightbulb service
 	my $lightbulb = OpenHAP::Service->new(
 		type    => 'Lightbulb',
 		iid     => 10,
@@ -152,7 +152,8 @@ sub new ( $class, %args )
 
 sub subscribe_mqtt ($self)
 {
-	# Call base class to set up standard subscriptions (C1, C2, C3)
+	# Call the base class to set up the standard subscriptions
+	# (C1, C2, C3)
 	$self->SUPER::subscribe_mqtt();
 
 	return unless $self->{mqtt_client}->is_connected();
@@ -161,7 +162,8 @@ sub subscribe_mqtt ($self)
 		'Lightbulb %s subscribing to additional MQTT topics',
 		$self->{name} );
 
-	# M2: Subscribe to plain-text POWER response (SetOption4 support)
+	# M2: Subscribe to the plain-text POWER response
+	# (SetOption4 support)
 	$self->{mqtt_client}->subscribe(
 		$self->_build_topic( 'stat', $self->_get_power_key() ),
 		sub ( $recv_topic, $payload ) {
@@ -171,7 +173,7 @@ sub subscribe_mqtt ($self)
 			$self->notify_change(11);
 		} );
 
-	# M2: Subscribe to DIMMER topic for SetOption4 devices
+	# M2: Subscribe to the DIMMER topic for SetOption4 devices
 	if ( $self->{has_dimmer} ) {
 		$self->{mqtt_client}->subscribe(
 			$self->_build_topic( 'stat', 'DIMMER' ),
@@ -186,7 +188,7 @@ sub subscribe_mqtt ($self)
 			} );
 	}
 
-	# M2: Subscribe to HSBCOLOR topic for SetOption4 devices
+	# M2: Subscribe to the HSBCOLOR topic for SetOption4 devices
 	if ( $self->{has_color} ) {
 		$self->{mqtt_client}->subscribe(
 			$self->_build_topic( 'stat', 'HSBCOLOR' ),
@@ -195,7 +197,7 @@ sub subscribe_mqtt ($self)
 			} );
 	}
 
-	# M2: Subscribe to CT topic for SetOption4 devices
+	# M2: Subscribe to the CT topic for SetOption4 devices
 	if ( $self->{has_ct} ) {
 		$self->{mqtt_client}->subscribe(
 			$self->_build_topic( 'stat', 'CT' ),
@@ -214,25 +216,26 @@ sub subscribe_mqtt ($self)
 	}
 }
 
-# Override to process state data from periodic STATE messages
+# Override the base method to process the state data from
+# periodic STATE messages
 sub _process_state_data ( $self, $data )
 {
 	$self->SUPER::_process_state_data($data);
 
-	# Extract light-specific state
+	# Extract the light-specific state
 	$self->_extract_light_state($data);
 }
 
-# Override to process command results
+# Override the base method to process the command results
 sub _process_result_data ( $self, $data )
 {
 	$self->SUPER::_process_result_data($data);
 
-	# Extract light-specific state
+	# Extract the light-specific state
 	$self->_extract_light_state($data);
 }
 
-# Override _on_power_update to update our power state
+# Override _on_power_update to update the power state
 sub _on_power_update ( $self, $state )
 {
 	if ( $self->{power_state} != $state ) {
@@ -244,7 +247,7 @@ sub _on_power_update ( $self, $state )
 }
 
 # $self->_extract_light_state($data):
-#	Extract light state from JSON data.
+#	Extract the light state from the JSON data.
 sub _extract_light_state ( $self, $data )
 {
 	my $changed = 0;
@@ -261,12 +264,12 @@ sub _extract_light_state ( $self, $data )
 		}
 	}
 
-	# HSB Color (HSBColor in Tasmota is "h,s,b" string)
+	# HSB Color. The Tasmota HSBColor value is a "h,s,b" string.
 	if ( exists $data->{HSBColor} && $self->{has_color} ) {
 		$self->_parse_hsbcolor( $data->{HSBColor} );
 	}
 
-	# M3: Handle Color field for SetOption17 decimal format
+	# M3: Process the Color field for the SetOption17 decimal format
 	if ( exists $data->{Color} && $self->{has_color} ) {
 		$self->_parse_color( $data->{Color} );
 	}
@@ -275,7 +278,7 @@ sub _extract_light_state ( $self, $data )
 	if ( exists $data->{CT} && $self->{has_ct} ) {
 		my $ct = $data->{CT};
 
-		# Clamp to Tasmota/HomeKit range (153-500)
+		# Clamp to the Tasmota/HomeKit range (153-500)
 		$ct = 153 if $ct < 153;
 		$ct = 500 if $ct > 500;
 
@@ -289,7 +292,7 @@ sub _extract_light_state ( $self, $data )
 }
 
 # $self->_set_brightness($value):
-#	Set brightness level (0-100).
+#	Set the brightness level (0-100).
 sub _set_brightness ( $self, $value )
 {
 	$OpenHAP::logger->debug( 'Lightbulb %s brightness set to %d%%',
@@ -300,10 +303,10 @@ sub _set_brightness ( $self, $value )
 }
 
 # $self->_set_hue($value):
-#	Set hue (0-360).
+#	Set the hue (0-360).
 sub _set_hue ( $self, $value )
 {
-	# Tasmota accepts 0-360 for hue (360 wraps to 0)
+	# Tasmota accepts 0-360 for the hue. The value 360 wraps to 0.
 	$value = int($value) % 360;
 
 	$OpenHAP::logger->debug( 'Lightbulb %s hue set to %d',
@@ -314,7 +317,7 @@ sub _set_hue ( $self, $value )
 }
 
 # $self->_set_saturation($value):
-#	Set saturation (0-100).
+#	Set the saturation (0-100).
 sub _set_saturation ( $self, $value )
 {
 	$OpenHAP::logger->debug( 'Lightbulb %s saturation set to %d%%',
@@ -325,10 +328,10 @@ sub _set_saturation ( $self, $value )
 }
 
 # $self->_set_ct($value):
-#	Set color temperature in mireds (153-500).
+#	Set the color temperature in mireds (153-500).
 sub _set_ct ( $self, $value )
 {
-	# Tasmota CT range is 153-500, clamp to that
+	# The Tasmota CT range is 153-500. Clamp the value to it.
 	$value = 153 if $value < 153;
 	$value = 500 if $value > 500;
 
@@ -340,7 +343,7 @@ sub _set_ct ( $self, $value )
 }
 
 # $self->set_color($hue, $saturation, $brightness):
-#	Set color using HSB values.
+#	Set the color with HSB values.
 sub set_color ( $self, $hue, $saturation, $brightness )
 {
 	$hue = int($hue) % 360;
@@ -354,7 +357,7 @@ sub set_color ( $self, $hue, $saturation, $brightness )
 }
 
 # $self->dimmer_step($direction):
-#	Increase or decrease dimmer by step (L3).
+#	Increase or decrease the dimmer by one step (L3).
 #	$direction: '+' to increase, '-' to decrease
 sub dimmer_step ( $self, $direction = '+' )
 {
@@ -366,7 +369,7 @@ sub dimmer_step ( $self, $direction = '+' )
 }
 
 # $self->dimmer_min():
-#	Set dimmer to minimum (L3).
+#	Set the dimmer to the minimum (L3).
 sub dimmer_min ($self)
 {
 	$OpenHAP::logger->debug( 'Lightbulb %s dimmer to minimum',
@@ -377,7 +380,7 @@ sub dimmer_min ($self)
 }
 
 # $self->dimmer_max():
-#	Set dimmer to maximum (L3).
+#	Set the dimmer to the maximum (L3).
 sub dimmer_max ($self)
 {
 	$OpenHAP::logger->debug( 'Lightbulb %s dimmer to maximum',
@@ -388,7 +391,7 @@ sub dimmer_max ($self)
 }
 
 # $self->_parse_hsbcolor($value):
-#	Parse HSBColor string "h,s,b" and update state.
+#	Parse the HSBColor string "h,s,b". Update the state.
 sub _parse_hsbcolor ( $self, $value )
 {
 	return unless $self->{has_color};
@@ -408,7 +411,7 @@ sub _parse_hsbcolor ( $self, $value )
 		$self->notify_change(14);
 	}
 
-	# Brightness from HSB updates Dimmer too
+	# The brightness value from HSB also updates the Dimmer
 	if ( $self->{has_dimmer} && $self->{brightness} != $b ) {
 		$self->{brightness} = $b;
 		$self->notify_change(12);
@@ -416,8 +419,9 @@ sub _parse_hsbcolor ( $self, $value )
 }
 
 # $self->_parse_color($value):
-#	Parse Color field (M3: SetOption17 support).
-#	Handles both hex (FF5500) and decimal (255,85,0) formats.
+#	Parse the Color field (M3: SetOption17 support).
+#	The method accepts the hex (FF5500) and decimal (255,85,0)
+#	formats.
 sub _parse_color ( $self, $value )
 {
 	return unless $self->{has_color};
@@ -456,7 +460,7 @@ sub _parse_color ( $self, $value )
 #	Convert RGB (0-255) to HSB (h: 0-360, s: 0-100, b: 0-100).
 sub _rgb_to_hsb ( $self, $r, $g, $b )
 {
-	# Normalize to 0-1
+	# Normalize the values to 0-1
 	my ( $rn, $gn, $bn ) = ( $r / 255, $g / 255, $b / 255 );
 
 	my $max =

--- a/lib/OpenHAP/Tasmota/Sensor.pm
+++ b/lib/OpenHAP/Tasmota/Sensor.pm
@@ -31,7 +31,7 @@ sub new ( $class, %args )
 	$self->{current_humidity} = undef;
 	$self->{has_humidity}     = $args{has_humidity} // 0;
 
-	# Add Temperature Sensor service
+	# Add the Temperature Sensor service
 	my $temp_sensor = OpenHAP::Service->new(
 		type    => 'TemperatureSensor',
 		iid     => 10,
@@ -52,7 +52,7 @@ sub new ( $class, %args )
 
 	$self->add_service($temp_sensor);
 
-	# Optionally add Humidity Sensor service (H5)
+	# Add the optional Humidity Sensor service (H5)
 	if ( $self->{has_humidity} ) {
 		$self->{current_humidity} = 50.0;
 
@@ -81,7 +81,8 @@ sub new ( $class, %args )
 
 sub subscribe_mqtt ($self)
 {
-	# Call base class to set up standard subscriptions (C1, C2, C3)
+	# Call the base class to set up the standard subscriptions
+	# (C1, C2, C3)
 	$self->SUPER::subscribe_mqtt();
 
 	return unless $self->{mqtt_client}->is_connected();
@@ -90,14 +91,16 @@ sub subscribe_mqtt ($self)
 		'Sensor %s subscribing to additional MQTT topics',
 		$self->{name} );
 
-	# Subscribe to STATUS8 for sensor data (when actively queried)
+	# Subscribe to STATUS8 for sensor data. The device sends
+	# STATUS8 after an active query.
 	$self->{mqtt_client}->subscribe(
 		$self->_build_topic( 'stat', 'STATUS8' ),
 		sub ( $recv_topic, $payload ) {
 			$self->_handle_status8($payload);
 		} );
 
-	# Subscribe to STATUS10 for sensor data (recommended per spec)
+	# Subscribe to STATUS10 for sensor data. The spec recommends
+	# this query.
 	$self->{mqtt_client}->subscribe(
 		$self->_build_topic( 'stat', 'STATUS10' ),
 		sub ( $recv_topic, $payload ) {
@@ -105,22 +108,24 @@ sub subscribe_mqtt ($self)
 		} );
 }
 
-# Override to process sensor data from SENSOR messages
+# Override the base method to process the sensor data from
+# SENSOR messages
 sub _process_sensor_data ( $self, $data )
 {
 	$self->_extract_sensor_values($data);
 }
 
-# Override to process sensor data from STATUS8 responses
+# Process the sensor data from STATUS8 responses
 sub _handle_status8 ( $self, $payload )
 {
 	eval {
 		my $data = decode_json($payload);
 
-		# STATUS8 wraps data in StatusSNS
+		# STATUS8 wraps the data in StatusSNS
 		if ( exists $data->{StatusSNS} ) {
 
-			# Extract temperature unit if present (H4)
+			# Extract the temperature unit if it is
+			# present (H4)
 			if ( exists $data->{StatusSNS}{TempUnit} ) {
 				$self->{temp_unit} =
 				    $data->{StatusSNS}{TempUnit};
@@ -136,13 +141,14 @@ sub _handle_status8 ( $self, $payload )
 	}
 }
 
-# Override to handle STATUS10 responses (recommended sensor query)
+# Process the STATUS10 responses (recommended sensor query)
 sub _handle_status10 ( $self, $payload )
 {
 	eval {
 		my $data = decode_json($payload);
 
-		# STATUS10 wraps data in StatusSNS (same as STATUS8)
+		# STATUS10 wraps the data in StatusSNS, the same as
+		# STATUS8
 		if ( exists $data->{StatusSNS} ) {
 			if ( exists $data->{StatusSNS}{TempUnit} ) {
 				$self->{temp_unit} =
@@ -159,14 +165,14 @@ sub _handle_status10 ( $self, $payload )
 }
 
 # $self->_extract_sensor_values($data):
-#	Extract temperature and humidity from sensor data (H5).
+#	Extract the temperature and humidity from the sensor data (H5).
 sub _extract_sensor_values ( $self, $data )
 {
 	my ( $temp, $humidity, $sensor_id ) = $self->_find_sensor_values($data);
 
 	if ( defined $temp ) {
 
-		# Convert to Celsius if needed (H4)
+		# Convert the value to Celsius if necessary (H4)
 		$temp = $self->convert_temperature($temp);
 
 		$OpenHAP::logger->debug(
@@ -183,24 +189,25 @@ sub _extract_sensor_values ( $self, $data )
 		$self->notify_change(21);
 	}
 
-	# L3: Track sensor hardware ID
+	# L3: Store the sensor hardware ID
 	if ( defined $sensor_id ) {
 		$self->{sensor_id} = $sensor_id;
 	}
 }
 
 # $self->_find_sensor_values($data):
-#	Find temperature, humidity, and sensor ID in sensor data (H5, L3).
-#	Handles multiple sensor types and indexed sensors.
+#	Find the temperature, the humidity, and the sensor ID in
+#	the sensor data (H5, L3). The method supports multiple
+#	sensor types and indexed sensors.
 sub _find_sensor_values ( $self, $data )
 {
 	my ( $temp, $humidity, $sensor_id );
 
-	# If sensor type is specified, look for that specific sensor
+	# If the configuration sets a sensor type, look for that sensor
 	if ( defined $self->{sensor_type} ) {
 		my $key = $self->{sensor_type};
 
-		# Handle indexed sensors (e.g., DS18B20-1)
+		# Add the index for indexed sensors, for example DS18B20-1
 		if ( defined $self->{sensor_index} ) {
 			$key .= '-' . $self->{sensor_index};
 		}
@@ -220,7 +227,8 @@ sub _find_sensor_values ( $self, $data )
 				$humidity  = $data->{$type}{Humidity};
 				$sensor_id = $data->{$type}{Id};            # L3
 
-				# Enable humidity if sensor supports it
+				# Enable the humidity if the sensor
+				# supports it
 				if ( defined $humidity
 					&& !$self->{has_humidity} )
 				{
@@ -231,7 +239,7 @@ sub _find_sensor_values ( $self, $data )
 				last;
 			}
 
-			# Check for indexed sensors (e.g., DS18B20-1)
+			# Check for indexed sensors, for example DS18B20-1
 			for my $i ( 1 .. 8 ) {
 				my $indexed = "$type-$i";
 				if ( exists $data->{$indexed} ) {

--- a/lib/OpenHAP/Tasmota/Thermostat.pm
+++ b/lib/OpenHAP/Tasmota/Thermostat.pm
@@ -38,7 +38,7 @@ sub new ( $class, %args )
 	$self->{heating_state}        = 0;              # 0=Off, 1=Heat, 2=Cool
 	$self->{target_heating_state} = 0;
 
-	# Add Thermostat service
+	# Add the Thermostat service
 	my $thermostat = OpenHAP::Service->new(
 		type => 'Thermostat',
 		iid  => 10,
@@ -105,7 +105,8 @@ sub new ( $class, %args )
 
 sub subscribe_mqtt ($self)
 {
-	# Call base class to set up standard subscriptions (C1, C2, C3)
+	# Call the base class to set up the standard subscriptions
+	# (C1, C2, C3)
 	$self->SUPER::subscribe_mqtt();
 
 	return unless $self->{mqtt_client}->is_connected();
@@ -114,7 +115,8 @@ sub subscribe_mqtt ($self)
 		'Thermostat %s subscribing to additional MQTT topics',
 		$self->{name} );
 
-	# M2: Subscribe to plain-text POWER response (SetOption4 support)
+	# M2: Subscribe to the plain-text POWER response
+	# (SetOption4 support)
 	$self->{mqtt_client}->subscribe(
 		$self->_build_topic( 'stat', $self->_get_power_key() ),
 		sub ( $recv_topic, $payload ) {
@@ -135,24 +137,26 @@ sub subscribe_mqtt ($self)
 			$self->_handle_status8($payload);
 		} );
 
-	# Subscribe to STATUS10 for sensor data (recommended per spec)
+	# Subscribe to STATUS10 for sensor data. The spec recommends
+	# this query.
 	$self->{mqtt_client}->subscribe(
 		$self->_build_topic( 'stat', 'STATUS10' ),
 		sub ( $recv_topic, $payload ) {
 			$self->_handle_status10($payload);
 		} );
 
-	# Query sensor status immediately
+	# Query the sensor status immediately
 	$self->query_status(10);
 }
 
-# Override to process sensor data from SENSOR messages
+# Override the base method to process the sensor data from
+# SENSOR messages
 sub _process_sensor_data ( $self, $data )
 {
 	$self->_extract_temperature($data);
 }
 
-# Override to handle power state updates
+# Override the base method to process the power state updates
 sub _on_power_update ( $self, $state )
 {
 	if ( $self->{heating_state} != $state ) {
@@ -163,7 +167,7 @@ sub _on_power_update ( $self, $state )
 	}
 }
 
-# Handle STATUS8 response
+# Process the STATUS8 response
 sub _handle_status8 ( $self, $payload )
 {
 	eval {
@@ -171,7 +175,8 @@ sub _handle_status8 ( $self, $payload )
 
 		if ( exists $data->{StatusSNS} ) {
 
-			# Extract temperature unit if present (H4)
+			# Extract the temperature unit if it is
+			# present (H4)
 			if ( exists $data->{StatusSNS}{TempUnit} ) {
 				$self->{temp_unit} =
 				    $data->{StatusSNS}{TempUnit};
@@ -187,7 +192,7 @@ sub _handle_status8 ( $self, $payload )
 	}
 }
 
-# Handle STATUS10 response (recommended sensor query)
+# Process the STATUS10 response (recommended sensor query)
 sub _handle_status10 ( $self, $payload )
 {
 	eval {
@@ -209,14 +214,14 @@ sub _handle_status10 ( $self, $payload )
 }
 
 # $self->_extract_temperature($data):
-#	Extract temperature from sensor data (H4, H5).
+#	Extract the temperature from the sensor data (H4, H5).
 sub _extract_temperature ( $self, $data )
 {
 	my $temp = $self->_find_temperature($data);
 
 	if ( defined $temp ) {
 
-		# Convert to Celsius if needed (H4)
+		# Convert the value to Celsius if necessary (H4)
 		$temp = $self->convert_temperature($temp);
 
 		$OpenHAP::logger->debug(
@@ -229,14 +234,14 @@ sub _extract_temperature ( $self, $data )
 }
 
 # $self->_find_temperature($data):
-#	Find temperature value in sensor data (H5).
+#	Find the temperature value in the sensor data (H5).
 sub _find_temperature ( $self, $data )
 {
-	# If sensor type is specified, look for that specific sensor
+	# If the configuration sets a sensor type, look for that sensor
 	if ( defined $self->{sensor_type} ) {
 		my $key = $self->{sensor_type};
 
-		# Handle indexed sensors (e.g., DS18B20-1)
+		# Add the index for indexed sensors, for example DS18B20-1
 		if ( defined $self->{sensor_index} ) {
 			$key .= '-' . $self->{sensor_index};
 		}
@@ -253,7 +258,7 @@ sub _find_temperature ( $self, $data )
 			return $data->{$type}{Temperature};
 		}
 
-		# Check for indexed sensors (e.g., DS18B20-1)
+		# Check for indexed sensors, for example DS18B20-1
 		for my $i ( 1 .. 8 ) {
 			my $indexed = "$type-$i";
 			if ( exists $data->{$indexed} ) {
@@ -293,12 +298,12 @@ sub _check_thermostat_logic ($self)
 
 	if ( $self->{target_heating_state} == 0 ) {
 
-		# Target is OFF
+		# The target is OFF
 		$self->set_power(0) if $self->{heating_state};
 	}
 	elsif ( $self->{target_heating_state} == 1 ) {
 
-		# Target is HEAT
+		# The target is HEAT
 		if ( $current < $target - $hysteresis ) {
 			$self->set_power(1);
 		}

--- a/lib/OpenHAP/Test/Controller.pm
+++ b/lib/OpenHAP/Test/Controller.pm
@@ -26,10 +26,10 @@ use OpenHAP::TLV;
 use OpenHAP::Pairing;
 use OpenHAP::Test::Controller::SRP;
 
-# A minimal HomeKit controller for tests: completes pair-setup (SRP
-# M1-M6), pair-verify (X25519), and speaks the encrypted session
-# framing, against a live accessory over TCP or in-process through an
-# injected transport code ref.
+# This module is a minimal HomeKit controller for tests. It completes
+# pair-setup (SRP M1-M6) and pair-verify (X25519). It uses the
+# encrypted session framing. It connects to a live accessory over
+# TCP, or runs in-process through an injected transport code ref.
 
 use constant MAX_FRAME => 1024;
 
@@ -41,19 +41,20 @@ sub new ( $class, %args )
 		pin       => $args{pin}  // '031-45-154',
 		transport => $args{transport},
 
-		# Socket read timeout. The default suits fast in-process and
-		# native runs; integration tests against a real daemon under
-		# TCG emulation, where a single SRP modexp can take many
-		# seconds, raise it via OPENHAP_TEST_TIMEOUT.
+		# Socket read timeout. The default is correct for fast
+		# in-process and native runs. Under TCG emulation, one
+		# SRP modexp can take many seconds. Thus integration
+		# tests against a real daemon raise the timeout with
+		# OPENHAP_TEST_TIMEOUT.
 		timeout => $args{timeout} // $ENV{OPENHAP_TEST_TIMEOUT} // 5,
 
 		controller_id => $args{controller_id} // 'openhap-test-ctrl',
 
-		# Controller long-term identity (generated once)
+		# Controller long-term identity. new makes it once.
 		ltsk => undef,
 		ltpk => undef,
 
-		# Learned during pair-setup
+		# pair_setup sets these values.
 		accessory_ltpk => undef,
 		accessory_id   => undef,
 
@@ -77,7 +78,8 @@ sub new ( $class, %args )
 }
 
 # $self->last_error():
-#	TLV error code (or message string) of the last failed exchange.
+#	Return the TLV error code or message string of the last
+#	failed exchange.
 sub last_error ($self)
 {
 	return $self->{last_error};
@@ -122,8 +124,8 @@ sub close ($self)
 }
 
 # $self->_round_trip($request_bytes):
-#	Send raw bytes and return the raw response bytes (one HTTP
-#	response; encrypted responses are returned still encrypted).
+#	Send the raw bytes and return the raw response bytes of one
+#	HTTP response. Encrypted responses stay encrypted.
 sub _round_trip ( $self, $request )
 {
 	if ( $self->{transport} ) {
@@ -135,7 +137,7 @@ sub _round_trip ( $self, $request )
 	my $socket = $self->{socket};
 	$socket->syswrite($request);
 
-	# Read until a full HTTP response is decodable from the buffer
+	# Read until the buffer holds a full, decodable HTTP response
 	my $select = IO::Select->new($socket);
 	my $raw    = '';
 	while (1) {
@@ -158,8 +160,8 @@ sub _round_trip ( $self, $request )
 }
 
 # _message_complete($text):
-#	True once $text holds a complete HTTP message (headers plus
-#	Content-Length bytes of body).
+#	Return true when $text holds a complete HTTP message. That
+#	is the headers plus Content-Length bytes of body.
 sub _message_complete ($text)
 {
 	return unless $text =~ /\r\n\r\n/;
@@ -188,8 +190,8 @@ sub _encrypt ( $self, $data )
 }
 
 # _decrypt_peek($data):
-#	Decrypt without consuming the counter state (used while
-#	accumulating frames from the socket).
+#	Decrypt the data but do not consume the counter state. The
+#	socket read loop uses this while it accumulates frames.
 sub _decrypt_peek ( $self, $data )
 {
 	my $count = $self->{decrypt_count};
@@ -268,9 +270,10 @@ sub _parse_response ( $self, $raw )
 }
 
 # $self->request($method, $path, $body?, $headers?):
-#	Perform one HTTP request over the session (encrypted framing
-#	once pair-verify has completed). Returns a hash ref with
-#	status, headers and body, or undef on transport error.
+#	Send one HTTP request over the session. After pair-verify
+#	completes, the session uses the encrypted framing. Return a
+#	hash ref with status, headers and body. Return undef on a
+#	transport error.
 sub request ( $self, $method, $path, $body = undef, $headers = {} )
 {
 	my $raw = $self->_build_request( $method, $path, $body, $headers );
@@ -287,8 +290,9 @@ sub request ( $self, $method, $path, $body = undef, $headers = {} )
 		}
 	}
 
-	# Keep anything beyond the first complete message (e.g. an event
-	# that arrived back-to-back with the response) for next_event
+	# Keep the bytes after the first complete message for
+	# next_event. For example, an event can arrive back-to-back
+	# with the response.
 	if ( $response =~ /\A(.*?\r\n\r\n)(.*)\z/s ) {
 		my ( $head, $rest ) = ( $1, $2 );
 		my ($length) = $head =~ /Content-Length:\s*(\d+)/i;
@@ -326,9 +330,9 @@ sub _tlv_request ( $self, $path, %tlv_items )
 }
 
 # $self->pair_setup():
-#	Complete SRP pair-setup M1-M6. On success the accessory LTPK is
-#	stored and true is returned; on any protocol error undef is
-#	returned with the TLV error code in last_error.
+#	Complete SRP pair-setup M1-M6. On success, store the
+#	accessory LTPK and return true. On a protocol error, return
+#	undef and put the TLV error code in last_error.
 sub pair_setup ($self)
 {
 	$self->{last_error} = undef;
@@ -441,9 +445,9 @@ sub pair_setup ($self)
 }
 
 # $self->pair_verify():
-#	Complete pair-verify M1-M4 and switch the connection to
-#	encrypted session framing. Requires a completed pair_setup (or
-#	an accessory_ltpk supplied by the caller).
+#	Complete pair-verify M1-M4 and switch the connection to the
+#	encrypted session framing. This requires a completed
+#	pair_setup, or an accessory_ltpk from the caller.
 sub pair_verify ($self)
 {
 	$self->{last_error} = undef;
@@ -483,7 +487,8 @@ sub pair_verify ($self)
 	my $acc_id   = $m2_inner{ OpenHAP::Pairing::kTLVType_Identifier() };
 	my $acc_sig  = $m2_inner{ OpenHAP::Pairing::kTLVType_Signature() };
 
-	# Verify the accessory signature when we know its LTPK
+	# Verify the accessory signature when the controller knows
+	# the accessory LTPK
 	if ( defined $self->{accessory_ltpk} ) {
 		unless (
 			OpenHAP::Crypto::verify_ed25519(
@@ -581,8 +586,9 @@ sub list_pairings ($self)
 		return;
 	}
 
-	# Split entries on the zero-length separator; TLV::decode would
-	# concatenate the repeated Identifier/PublicKey types
+	# Split the entries on the zero-length separator. Without
+	# the split, TLV::decode concatenates the repeated
+	# Identifier/PublicKey types.
 	my @pairings;
 	for my $entry ( split /\xFF\x00/, $response->{body} ) {
 		my %tlv = OpenHAP::TLV::decode($entry);
@@ -609,7 +615,7 @@ sub list_pairings ($self)
 		    };
 	}
 
-	# A lone error TLV (no identifiers) means the request failed
+	# A lone error TLV with no identifiers means the request failed
 	if ( !@pairings ) {
 		my %tlv   = OpenHAP::TLV::decode( $response->{body} );
 		my $error = $tlv{ OpenHAP::Pairing::kTLVType_Error() };
@@ -625,12 +631,12 @@ sub list_pairings ($self)
 # --- events -------------------------------------------------------------
 
 # $self->next_event($timeout?):
-#	Wait for an EVENT/1.0 message on the socket, decrypt and parse
-#	it. Returns { status, headers, body } or undef on timeout.
-#	Without an explicit $timeout the wait is bounded by the session
-#	timeout (which honors OPENHAP_TEST_TIMEOUT); pass a literal only
-#	for short negative probes. Requires a socket connection (not an
-#	injected transport).
+#	Wait for an EVENT/1.0 message on the socket, then decrypt
+#	and parse it. Return { status, headers, body }, or undef on
+#	timeout. Without an explicit $timeout, the session timeout
+#	bounds the wait. That timeout honors OPENHAP_TEST_TIMEOUT.
+#	Pass a literal only for short negative probes. This requires
+#	a socket connection, not an injected transport.
 sub next_event ( $self, $timeout = undef )
 {
 	return unless $self->{socket};
@@ -642,7 +648,7 @@ sub next_event ( $self, $timeout = undef )
 
 	while (1) {
 
-		# A complete event may already be buffered
+		# The buffer can already hold a complete event
 		if ( $self->{inbuf} =~ s{\A(EVENT/1\.0.*?\r\n\r\n)}{}s ) {
 			my $head = $1;
 			my ($length) = $head =~ /Content-Length:\s*(\d+)/i;
@@ -675,10 +681,10 @@ sub next_event ( $self, $timeout = undef )
 			next;
 		}
 
-		# A frame may arrive split across reads: accumulate raw
-		# bytes and decrypt only complete frames, leaving a
-		# partial tail buffered so the nonce counter stays in
-		# sync with the accessory
+		# A frame can arrive split across reads. Accumulate the
+		# raw bytes and decrypt only complete frames. Keep a
+		# partial tail buffered. Then the nonce counter stays in
+		# sync with the accessory.
 		$self->{rawbuf} .= $chunk;
 		my $plain = $self->_drain_frames;
 		return unless defined $plain;
@@ -688,9 +694,9 @@ sub next_event ( $self, $timeout = undef )
 
 # $self->_drain_frames():
 #	Decrypt and consume every complete frame at the front of the
-#	raw receive buffer; a trailing partial frame stays buffered for
-#	the next read. Returns the decrypted plaintext (possibly
-#	empty), or undef on an authentication failure.
+#	raw receive buffer. A trailing partial frame stays buffered
+#	for the next read. Return the decrypted plaintext, which can
+#	be empty. Return undef on an authentication failure.
 sub _drain_frames ($self)
 {
 	my $out = '';

--- a/lib/OpenHAP/Test/Controller/SRP.pm
+++ b/lib/OpenHAP/Test/Controller/SRP.pm
@@ -19,16 +19,18 @@ use v5.36;
 
 package OpenHAP::Test::Controller::SRP;
 
-# Match the server: prefer the GMP backend so the controller's own
-# 3072-bit modexp is not the bottleneck when it runs inside the slow
-# emulated test guest. Falls back to pure-Perl Calc when GMP is absent.
+# Prefer the GMP backend to match the server. Then the controller's
+# own 3072-bit modexp is not the bottleneck inside the slow emulated
+# test guest. When GMP is absent, Math::BigInt falls back to the
+# pure-Perl Calc backend.
 use Math::BigInt try => 'GMP';
 use Digest::SHA qw(sha512);
 use OpenHAP::Crypto;
 use OpenHAP::PIN qw(normalize_pin);
 
-# SRP-6a client role for tests (HAP-Pairing.md §2.5): the controller
-# side of the exchange OpenHAP::SRP serves. Same 3072-bit RFC 5054
+# This module is the SRP-6a client role for tests
+# (HAP-Pairing.md §2.5). It is the controller side of the exchange
+# that OpenHAP::SRP serves. It uses the same 3072-bit RFC 5054
 # group, SHA-512 hash, and 384-byte padding rules as the server.
 
 use constant N_LEN => 384;
@@ -83,9 +85,10 @@ sub compute_public ($self)
 }
 
 # $self->compute_proof($salt, $B_bytes):
-#	Complete the client side with the server's salt and public key
-#	B: derive the session key K and return the client proof M1.
-#	Returns undef if B mod N == 0 (bogus server value).
+#	Complete the client side with the server's salt and public
+#	key B. Derive the session key K and return the client proof
+#	M1. Return undef if B mod N == 0, which is a bogus server
+#	value.
 sub compute_proof ( $self, $salt, $B_bytes )
 {
 	die 'SRP: compute_public not called' unless defined $self->{A};

--- a/lib/OpenHAP/Test/Integration.pm
+++ b/lib/OpenHAP/Test/Integration.pm
@@ -66,30 +66,30 @@ sub new ( $class, %options )
 
 sub setup ($self)
 {
-	# Verify we're in integration test mode
+	# Make sure the tests run in integration test mode
 	die "OPENHAP_INTEGRATION_TEST not set\n"
 	    unless $ENV{OPENHAP_INTEGRATION_TEST};
 
-	# The controller drives the accessory's own crypto/pairing library
-	# code in this process, which logs through the $OpenHAP::logger the
-	# daemon normally installs. Give it a quiet logger so those calls
-	# do not die on an undefined logger, matching how the unit tests
-	# set one up per file.
+	# The controller drives the accessory's own crypto/pairing
+	# library code in this process. That code logs through the
+	# $OpenHAP::logger that the daemon normally installs. Give it
+	# a quiet logger. Then those calls do not die on an undefined
+	# logger. The unit tests set one up per file in the same way.
 	$OpenHAP::logger //= FuguLib::Log->new(
 		mode  => 'quiet',
 		ident => 'openhap-integration'
 	);
 
-	# Verify system prerequisites
+	# Verify the system prerequisites
 	$self->_verify_system or die "System prerequisites not met\n";
 
-	# Parse configuration
+	# Parse the configuration
 	$self->_parse_config;
 
-	# Ensure daemon is running
+	# Make sure the daemon is running
 	$self->ensure_daemon_running or die "Cannot start openhapd daemon\n";
 
-	# Record log baseline for this test
+	# Record the log baseline for this test
 	$self->{log_baseline} = $self->_count_log_lines;
 
 	return 1;
@@ -106,7 +106,7 @@ sub teardown ($self)
 	# Close any open sockets
 	$self->close_sockets;
 
-	# Disconnect MQTT if connected
+	# Disconnect MQTT if it is connected
 	if ( defined $self->{mqtt} ) {
 		eval { undef $self->{mqtt}; };
 	}
@@ -116,7 +116,8 @@ sub teardown ($self)
 
 # $self->get_controller(%args):
 #	Construct an OpenHAP::Test::Controller for the configured
-#	host/port/PIN. The connection is tracked and closed in teardown.
+#	host/port/PIN. The harness tracks the connection and closes
+#	it in teardown.
 sub get_controller ( $self, %args )
 {
 	require OpenHAP::Test::Controller;
@@ -134,11 +135,11 @@ sub get_controller ( $self, %args )
 }
 
 # $self->ensure_unpaired():
-#	Guarantee the daemon is verifiably unpaired: when stored
-#	pairings exist, stop the daemon, wipe the pairing state
-#	(keeping the accessory identity), and start it again. The
-#	post-condition is probed with POST /identify, which succeeds
-#	only while unpaired (HAP-HTTP.md §3).
+#	Make sure the daemon is verifiably unpaired. When stored
+#	pairings exist, stop the daemon, wipe the pairing state, and
+#	start it again. The wipe keeps the accessory identity. A
+#	POST /identify probes the post-condition. It succeeds only
+#	while the daemon is unpaired (HAP-HTTP.md §3).
 sub ensure_unpaired ($self)
 {
 	if ( $self->_has_pairings ) {
@@ -159,10 +160,10 @@ sub ensure_unpaired ($self)
 }
 
 # $self->_has_pairings():
-#	True when the pairings database holds at least one entry. The
-#	daemon leaves comment headers in the file after its first save,
-#	so a size check cannot tell paired from unpaired - parse for
-#	non-comment lines instead.
+#	Return true when the pairings database holds at least one
+#	entry. The daemon leaves comment headers in the file after
+#	its first save. Thus a size check cannot tell paired from
+#	unpaired. Parse for non-comment lines instead.
 sub _has_pairings ($self)
 {
 	open my $fh, '<', PAIRINGS_FILE or return 0;
@@ -177,10 +178,11 @@ sub _has_pairings ($self)
 }
 
 # $self->_verify_unpaired():
-#	Probe the pairing state with POST /identify: 204 only when
-#	unpaired, 400 with {"status":-70401} when still paired
-#	(HAP-HTTP.md §3). Fails loudly on the paired answer. The probe
-#	socket is closed immediately rather than left registered with
+#	Probe the pairing state with POST /identify. The daemon
+#	returns 204 only when unpaired. It returns 400 with
+#	{"status":-70401} when still paired (HAP-HTTP.md §3). This
+#	sub fails loudly on the paired answer. It closes the probe
+#	socket immediately. The socket does not stay registered with
 #	the daemon until teardown.
 sub _verify_unpaired ($self)
 {
@@ -205,9 +207,9 @@ sub _verify_unpaired ($self)
 }
 
 # $self->close_sockets():
-#	Close and forget every raw socket opened by http_request, so a
-#	probe connection is not left registered with the daemon until
-#	teardown.
+#	Close and forget every raw socket that http_request opened.
+#	Then a probe connection does not stay registered with the
+#	daemon until teardown.
 sub close_sockets ($self)
 {
 	for my $socket ( @{ $self->{sockets} } ) {
@@ -230,7 +232,7 @@ sub http_request ( $self, $method, $path, $body = undef, $headers = {} )
 
 	push @{ $self->{sockets} }, $socket;
 
-	# Build request
+	# Build the request
 	print $socket "$method $path HTTP/1.1\r\n";
 	print $socket "Host: 127.0.0.1:$self->{hap_port}\r\n";
 
@@ -246,14 +248,14 @@ sub http_request ( $self, $method, $path, $body = undef, $headers = {} )
 	print $socket $body if defined $body;
 	$socket->flush;
 
-	# Read response headers
+	# Read the response headers
 	my $response = '';
 	while ( my $line = <$socket> ) {
 		$response .= $line;
 		last if $line =~ /^\r?\n$/;
 	}
 
-	# Read body if Content-Length present
+	# Read the body if the response has a Content-Length header
 	if ( $response =~ /Content-Length:\s*(\d+)/i ) {
 		my $content_length = $1;
 		my $response_body;
@@ -310,16 +312,18 @@ sub ensure_daemon_running ($self)
 		return if system('rcctl check openhapd >/dev/null 2>&1') != 0;
 	}
 
-	# Running per rcctl is not serving: startup publishes the mDNS
-	# advertisement (waiting for mdnsd's replies) before the HAP
-	# listener opens, so wait for the port rather than a fixed sleep
+	# A daemon that runs per rcctl does not serve yet. At
+	# startup, the daemon publishes the mDNS advertisement and
+	# waits for the mdnsd replies. The HAP listener opens after
+	# that. Thus wait for the port, not for a fixed sleep.
 	return $self->wait_for_hap_port;
 }
 
 # $self->wait_for_hap_port($timeout):
-#	Wait until the HAP port accepts connections, polling every
-#	quarter second up to $timeout seconds (default 30, generous
-#	for TCG emulation). Returns 1 when serving, undef on deadline.
+#	Wait until the HAP port accepts connections. Poll every
+#	quarter second, up to $timeout seconds. The default is 30
+#	seconds, which is generous for TCG emulation. Return 1 when
+#	the daemon serves. Return undef on the deadline.
 sub wait_for_hap_port ( $self, $timeout = 30 )
 {
 	my $port     = $self->get_config_value('hap_port') // DEFAULT_HAP_PORT;
@@ -353,12 +357,12 @@ sub ensure_daemon_stopped ($self)
 }
 
 # $self->ensure_mdnsd_running():
-#	Ensure mdnsd is running and stays running: start it if needed,
-#	then re-check across a settle window, because a point-in-time
-#	probe races green when mdnsd starts and then exits shortly
-#	after. On failure, captured diagnostics are emitted so a dead
-#	mdnsd is diagnosable from the test output instead of failing
-#	bare.
+#	Make sure that mdnsd runs and continues to run. Start it if
+#	necessary. Then check again across a settle window. A
+#	point-in-time probe races green when mdnsd starts and then
+#	exits shortly after. On failure, emit the captured
+#	diagnostics. Then a dead mdnsd is diagnosable from the test
+#	output, and the sub does not fail bare.
 sub ensure_mdnsd_running ($self)
 {
 	my $check = 'rcctl check mdnsd >/dev/null 2>&1';
@@ -380,8 +384,9 @@ sub ensure_mdnsd_running ($self)
 }
 
 # $self->_warn_mdnsd_diagnostics($reason):
-#	Emit captured mdnsd state - rcctl views, the process list, and
-#	recent syslog lines - as warnings for the failure diagnostics.
+#	Emit the captured mdnsd state as warnings for the failure
+#	diagnostics. The state holds the rcctl views, the process
+#	list, and recent syslog lines.
 sub _warn_mdnsd_diagnostics ( $self, $reason )
 {
 	my $syslog = SYSLOG_FILE;
@@ -400,14 +405,14 @@ sub _warn_mdnsd_diagnostics ( $self, $reason )
 
 sub ensure_mqtt_running ($self)
 {
-	# Check if already running
+	# Check if the broker is already running
 	return 1 if system('rcctl check mosquitto >/dev/null 2>&1') == 0;
 
-	# Attempt to start
+	# Try to start the broker
 	system('rcctl start mosquitto >/dev/null 2>&1');
 	sleep 1;
 
-	# Verify it started
+	# Make sure the broker started
 	return system('rcctl check mosquitto >/dev/null 2>&1') == 0;
 }
 
@@ -415,7 +420,7 @@ sub clear_logs ($self)
 {
 	return unless -w SYSLOG_FILE;
 
-	# Truncate would require root, so we just record a new baseline
+	# A truncate requires root. Thus record a new baseline instead.
 	$self->{log_baseline} = $self->_count_log_lines;
 
 	return 1;
@@ -449,10 +454,10 @@ sub get_mqtt ($self)
 	eval { require Net::MQTT::Simple; };
 	return if $@;
 
-	# Ensure broker is running
+	# Make sure the broker is running
 	return unless $self->ensure_mqtt_running;
 
-	# Create connection
+	# Create the connection
 	eval {
 		$self->{mqtt} = Net::MQTT::Simple->new(
 			"$self->{mqtt_host}:$self->{mqtt_port}");
@@ -463,19 +468,19 @@ sub get_mqtt ($self)
 
 sub _verify_system ($self)
 {
-	# Check required binaries
+	# Check the required binaries
 	return unless -x '/usr/sbin/rcctl';
 	return unless -x '/usr/local/bin/openhapd';
 	return unless -x '/usr/local/bin/hapctl';
 
-	# Check configuration exists
+	# Check that the configuration exists
 	return unless -f $self->{config_file};
 	return unless -r $self->{config_file};
 
-	# Check system user exists
+	# Check that the system user exists
 	return unless system('id _openhap >/dev/null 2>&1') == 0;
 
-	# Check data directory exists
+	# Check that the data directory exists
 	return unless -d '/var/db/openhapd';
 
 	return 1;
@@ -513,7 +518,7 @@ sub _parse_config ($self)
 		# Simple key = value
 		if (/^\s*(\w+)\s*=\s*(.+)/) {
 			my ( $key, $value ) = ( $1, $2 );
-			$value =~ s/^"(.*)"$/$1/;    # Remove quotes
+			$value =~ s/^"(.*)"$/$1/;    # Remove the quotes
 
 			if ( defined $device ) {
 				$device->{$key} = $value;
@@ -524,7 +529,7 @@ sub _parse_config ($self)
 
 			$config{$key} = $value;
 
-			# Update hap_port if configured
+			# Update hap_port if the config sets it
 			$self->{hap_port} = $value if $key eq 'hap_port';
 		}
 	}

--- a/lib/OpenHAP/Test/Integration.pm
+++ b/lib/OpenHAP/Test/Integration.pm
@@ -80,7 +80,7 @@ sub setup ($self)
 		ident => 'openhap-integration'
 	);
 
-	# Verify the system prerequisites
+	# Check the system prerequisites
 	$self->_verify_system or die "System prerequisites not met\n";
 
 	# Parse the configuration
@@ -135,7 +135,7 @@ sub get_controller ( $self, %args )
 }
 
 # $self->ensure_unpaired():
-#	Make sure the daemon is verifiably unpaired. When stored
+#	Make sure the daemon is unpaired. When stored
 #	pairings exist, stop the daemon, wipe the pairing state, and
 #	start it again. The wipe keeps the accessory identity. A
 #	POST /identify probes the post-condition. It succeeds only

--- a/scripts/deps
+++ b/scripts/deps
@@ -16,19 +16,21 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-# deps: install the OS packages and CPAN modules named by deps/<OS>.txt.
+# deps: install the OS packages and CPAN modules that deps/<OS>.txt names.
 #
 # usage: deps [--dry-run] [--os NAME] <runtime|test|develop>
 #
-# deps/<OS>.txt is read relative to the current directory, not to this
-# script: the guest runs 'cd /tmp/openhap-* && make deps' out of the
-# extracted tarball, which is a different tree from any checkout.
+# The script reads deps/<OS>.txt relative to the current directory,
+# not relative to this script. The guest runs
+# 'cd /tmp/openhap-* && make deps' out of the extracted tarball. That
+# tree is different from any checkout.
 #
-# This is the bootstrap - nothing it needs may be something it installs -
-# so only core modules, and no v5.36: macOS still ships perl 5.34 and
-# requiring 5.36 would mean installing a perl with the script that
-# installs things.  The 5.34 bundle turns on strict but not warnings
-# (that starts at 5.35), so warnings is asked for by name.
+# This script is the bootstrap. Nothing it needs may be something it
+# installs. Thus it uses only core modules and no v5.36. macOS still
+# ships perl 5.34. A v5.36 floor would make the script that installs
+# things install a perl first.  The 5.34 bundle turns on strict but not
+# warnings. Warnings start at 5.35. Thus the script asks for warnings
+# by name.
 use v5.34;
 use warnings;
 use experimental 'signatures';
@@ -53,8 +55,8 @@ my $env = shift @ARGV;
 defined $env
     or die "usage: deps [--dry-run] [--os NAME] <runtime|test|develop>\n";
 
-# An unrecognised environment selects nothing, and the shell version
-# then reported success for having installed it. Say so instead.
+# An unrecognised environment selects nothing. The shell version then
+# reported success for having installed it. Say so instead.
 grep { $_ eq $env } ENVIRONMENTS
     or die "deps: unknown environment '$env' (expected "
     . join( ', ', ENVIRONMENTS ) . ")\n";
@@ -62,11 +64,11 @@ grep { $_ eq $env } ENVIRONMENTS
 $os //= ( uname() )[0];
 
 # _run(@cmd):
-#	Run a command, list form, and die on anything but a clean exit.
-#	List form is the point: the shell version wrote
-#	'pkg_add $PKG_PACKAGES' and leaned on word splitting, so a
-#	package name containing a space installed two wrong packages.
-#	Every caller passes at least two elements, so perl never falls
+#	Run a command in list form. Die on anything but a clean exit.
+#	List form is the point. The shell version wrote
+#	'pkg_add $PKG_PACKAGES' and leaned on word splitting. Thus a
+#	package name that contains a space installed two wrong packages.
+#	Every caller passes at least two elements. Thus perl never falls
 #	back to a shell.
 sub _run (@cmd)
 {
@@ -90,9 +92,9 @@ sub _run (@cmd)
 }
 
 # _quote($word):
-#	Shell-quote a word for the trace line only. Nothing is ever
-#	handed to a shell; this exists so a --dry-run reader (and the
-#	tests) can see that an argument with a space is one argument.
+#	Shell-quote a word for the trace line only. The script never
+#	gives a word to a shell. This function lets a --dry-run reader
+#	and the tests see that an argument with a space is one argument.
 sub _quote ($word)
 {
 	return $word unless $word eq '' || $word =~ /[^\w.\/:=-]/;
@@ -104,8 +106,8 @@ sub _quote ($word)
 }
 
 # _which($program):
-#	First executable $program on PATH, or undef. Core-only stand-in
-#	for command -v; File::Which is not in base.
+#	Return the first executable $program on PATH, or undef. This is
+#	a core-only stand-in for command -v. File::Which is not in base.
 sub _which ($program)
 {
 	for my $dir ( split /:/, ( $ENV{PATH} // '' ) ) {
@@ -119,13 +121,13 @@ sub _which ($program)
 
 # _read_manifest($file, $want):
 #	Parse deps/<OS>.txt into (\@pkgs, \@cpan) for environment $want.
-#	Fields are whitespace-separated, as sh's 'read env type name'
+#	Whitespace separates the fields, as sh's 'read env type name'
 #	read them.
 #
-#	Every non-comment line is validated, not just the ones matching
-#	$want: the shell version filtered first, so a malformed develop
-#	line stayed invisible to 'make deps' until someone ran
-#	'make deps-develop'.
+#	The function validates every non-comment line, not only the
+#	lines that match $want. The shell version filtered first. Thus a
+#	malformed develop line stayed invisible to 'make deps' until
+#	someone ran 'make deps-develop'.
 sub _read_manifest ( $file, $want )
 {
 	open my $fh, '<', $file
@@ -139,8 +141,8 @@ sub _read_manifest ( $file, $want )
 		next unless defined $env;
 		next if index( $env, '#' ) == 0;
 
-		# split with a limit leaves the tail intact, so trailing
-		# whitespace has to go the way IFS would have taken it
+		# split with a limit keeps the tail intact. Remove the
+		# trailing whitespace, as IFS would have removed it.
 		$name =~ s/\s+\z// if defined $name;
 
 		if ( !defined $type || !defined $name || $name eq '' ) {
@@ -163,7 +165,7 @@ sub _read_manifest ( $file, $want )
 }
 
 # _install_packages($os, @pkgs):
-#	Hand the package list to the platform's package manager.
+#	Give the package list to the platform's package manager.
 sub _install_packages ( $os, @pkgs )
 {
 	say 'Installing OS packages: ', join ' ', @pkgs;
@@ -189,10 +191,10 @@ sub _install_packages ( $os, @pkgs )
 #	Bootstrap cpanm when it is not already on PATH.
 #
 #	The download goes through scripts/ftp, our own cross-platform
-#	fetcher, rather than curl: curl is not in OpenBSD base, so the
-#	shell version's 'curl -L https://cpanmin.us | perl -' could only
-#	ever have worked because vm-provision installs cpanm with
-#	'cpan -T' before this script first runs on a fresh guest.
+#	fetcher, not through curl. curl is not in OpenBSD base. The
+#	shell version used 'curl -L https://cpanmin.us | perl -'. That
+#	only worked because vm-provision installs cpanm with 'cpan -T'
+#	before this script first runs on a fresh guest.
 sub _install_cpanm ()
 {
 	say 'Installing cpanminus...';
@@ -212,8 +214,9 @@ sub _install_cpanm ()
 }
 
 # _install_cpan(@modules):
-#	Install CPAN modules with cpanm, into PERL_LOCAL_LIB_ROOT when
-#	the environment names one (local::lib, and CI's setup-perl).
+#	Install CPAN modules with cpanm. Install into
+#	PERL_LOCAL_LIB_ROOT when the environment names one. local::lib
+#	and CI's setup-perl set that variable.
 sub _install_cpan (@modules)
 {
 	say 'Installing CPAN modules: ', join ' ', @modules;

--- a/scripts/deps
+++ b/scripts/deps
@@ -55,7 +55,7 @@ my $env = shift @ARGV;
 defined $env
     or die "usage: deps [--dry-run] [--os NAME] <runtime|test|develop>\n";
 
-# An unrecognised environment selects nothing. The shell version then
+# An unrecognized environment selects nothing. The shell version then
 # reported success for having installed it. Say so instead.
 grep { $_ eq $env } ENVIRONMENTS
     or die "deps: unknown environment '$env' (expected "
@@ -190,7 +190,7 @@ sub _install_packages ( $os, @pkgs )
 # _install_cpanm():
 #	Bootstrap cpanm when it is not already on PATH.
 #
-#	The download goes through scripts/ftp, our own cross-platform
+#	The download goes through scripts/ftp, the repository's own cross-platform
 #	fetcher, not through curl. curl is not in OpenBSD base. The
 #	shell version used 'curl -L https://cpanmin.us | perl -'. That
 #	only worked because vm-provision installs cpanm with 'cpan -T'

--- a/scripts/deps-key
+++ b/scripts/deps-key
@@ -16,25 +16,26 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-# deps-key: print the provisioning key, a short digest over everything
-# that determines the guest's installed dependencies.
+# deps-key: print the provisioning key. The key is a short digest over
+# everything that determines the guest's installed dependencies.
 #
 # scripts/vm-up restores the snapshot named after this key, and
-# scripts/vm-provision saves it, so both must derive it identically.
-# Whatever this hashes must also be hashed into the CI cache key
-# (.github/workflows/integration.yml), or a change here would rotate the
-# snapshot name without letting the runner persist the result.
+# scripts/vm-provision saves it. Thus both must derive it identically.
+# The CI cache key (.github/workflows/integration.yml) must also hash
+# whatever this script hashes. Without that, a change here would rotate
+# the snapshot name without letting the runner persist the result.
 #
-# Only file contents and the fixed label strings below enter the digest -
-# never a path, the environment, or the host OS. That is what lets the
-# two callers agree wherever the checkout lives, and what makes --root
+# Only file contents and the fixed label strings below enter the digest.
+# A path, the environment, or the host OS never enters it. That lets the
+# two callers agree wherever the checkout lives. That also makes --root
 # safe.
 
-# The bootstrap scripts run before anything is installed, on hosts whose
-# perl predates the project's v5.36 floor - macOS still ships 5.34 - so
-# this one stops at v5.34 and asks for signatures separately.  The 5.34
-# bundle turns on strict but not warnings (that starts at 5.35), so
-# warnings is asked for by name.
+# The bootstrap scripts run first, before the project installs anything.
+# They run on hosts whose perl predates the project's v5.36 floor. macOS
+# still ships 5.34. Thus this script stops at v5.34 and asks for
+# signatures separately.  The 5.34 bundle turns on strict but not
+# warnings. Warnings start at 5.35. Thus the script asks for warnings
+# by name.
 use v5.34;
 use warnings;
 use experimental 'signatures';
@@ -55,8 +56,9 @@ $root //= dirname( dirname( File::Spec->rel2abs(__FILE__) ) );
 -d $root or die "deps-key: no such directory: $root\n";
 
 # _slurp($path):
-#	Raw bytes of $path, or undef when it does not exist. Binary mode
-#	is explicit: the digest is over bytes, not decoded text.
+#	Return the raw bytes of $path, or undef when it does not exist.
+#	Binary mode is explicit. The digest is over bytes, not decoded
+#	text.
 sub _slurp ($path)
 {
 	return unless -f $path;
@@ -71,8 +73,9 @@ sub _slurp ($path)
 }
 
 # _require($root, @path):
-#	Raw bytes of a digest input that has to be there. Dies rather
-#	than digesting a hole - see the fail-closed note below.
+#	Return the raw bytes of a digest input that must exist. The
+#	function dies instead of digesting a hole. See the fail-closed
+#	note below.
 sub _require ( $root, @path )
 {
 	my $path    = File::Spec->catfile( $root, @path );
@@ -84,18 +87,19 @@ sub _require ( $root, @path )
 }
 
 # _deps_layer($path):
-#	The BEGIN..END deps layer block of scripts/vm-provision,
-#	inclusive and verbatim. Returns (text, saw_begin, saw_end).
+#	Extract the BEGIN..END deps layer block of scripts/vm-provision,
+#	inclusive and verbatim. Return (text, saw_begin, saw_end).
 #
-#	The deps layer only, not the whole file: the OpenHAP layer runs
-#	on every provision and never enters the snapshot, so editing it
-#	must not invalidate the cached dependencies.
+#	The function reads the deps layer only, not the whole file. The
+#	OpenHAP layer runs on every provision and never enters the
+#	snapshot. Thus an edit to it must not invalidate the cached
+#	dependencies.
 #
-#	The markers sit inside an 'else' block, so they are indented.
-#	Anchoring on '^#' once extracted nothing at all, which silently
-#	dropped this input from the digest and left every edit to the
-#	layer unable to invalidate its cached snapshot - hence the
-#	leading whitespace is trimmed before comparing.
+#	The markers sit inside an 'else' block. Thus they are indented.
+#	An anchor on '^#' once extracted nothing at all. That silently
+#	dropped this input from the digest. Then no edit to the layer
+#	could invalidate its cached snapshot. Thus the function trims
+#	the leading whitespace before it compares.
 sub _deps_layer ($path)
 {
 	open my $fh, '<:raw', $path
@@ -123,9 +127,9 @@ sub _deps_layer ($path)
 	return ( $text, $saw_begin, $saw_end );
 }
 
-# Fail closed: a digest over silently-missing inputs is worse than no
-# digest, because it looks valid and caches a stale layer forever. Both
-# markers are required - the shell version counted lines instead, which
+# Fail closed. A digest over silently-missing inputs is worse than no
+# digest. It looks valid and caches a stale layer forever. The script
+# requires both markers. The shell version counted lines instead. That
 # would have accepted a BEGIN with no END whenever the tail of the file
 # supplied two or more lines.
 my $provision = File::Spec->catfile( $root, 'scripts', 'vm-provision' );
@@ -136,13 +140,13 @@ if ( !$saw_begin || !$saw_end ) {
 	    . "scripts/vm-provision\n";
 }
 
-# Labelled inputs, so a boundary shift between two of them cannot
-# silently produce the same digest. The labels are part of the key:
-# editing one rotates every cached snapshot.
+# Each input has a label. Thus a boundary shift between two inputs
+# cannot silently produce the same digest. The labels are part of the
+# key. An edit to one rotates every cached snapshot.
 #
-# The cpanfile label is emitted whether or not the file exists, so an
-# absent cpanfile and an empty one agree. That is the shell version's
-# behavior and rotating the key to change it would buy nothing.
+# The script emits the cpanfile label whether or not the file exists.
+# Thus an absent cpanfile and an empty one agree. That is the shell
+# version's behavior. A key rotation to change it would buy nothing.
 my $cpanfile = _slurp( File::Spec->catfile( $root, 'cpanfile' ) );
 
 my $input = join '',

--- a/scripts/integration
+++ b/scripts/integration
@@ -19,20 +19,21 @@ vm_scp() { scp ${SSH_OPTS} -P "${SSH_PORT}" "$@"; }
 echo "==> Copying test files..."
 cd "${PROJECT_ROOT}"
 TARBALL="/tmp/tests-$$.tar.gz"
-# t/fugulib/sandbox.t rides along: its enforcement subtests (a pledge
-# violation aborts, unveil hides the filesystem, required paths are
-# fatal) are OpenBSD-only and skip on the Linux hosts `make check`
-# runs on, so this guest run is the one place CI executes them
+# The tarball also carries t/fugulib/sandbox.t. Its enforcement
+# subtests are OpenBSD-only: a pledge violation aborts, unveil hides
+# the filesystem, and required paths are fatal. They skip on the Linux
+# hosts that `make check` runs on. Thus this guest run is the one
+# place where CI executes them.
 tar czf "${TARBALL}" t/openhap/integration/ t/fugulib/sandbox.t \
     t/lib/ lib/OpenHAP/Test/
 vm_scp "${TARBALL}" "root@127.0.0.1:/tmp/tests.tar.gz"
 rm -f "${TARBALL}"
 
 echo "==> Running integration tests..."
-# The heredoc runs under its own set -e so a broken guest setup step
-# fails the run loudly instead of reporting a half-prepared suite; the
-# host-side set -e is suspended so the failure diagnostics below stay
-# reachable when vm_run fails.
+# The heredoc runs under its own set -e. Thus a broken guest setup
+# step fails the run loudly and does not report a half-prepared suite.
+# The script suspends the host-side set -e. Thus the failure
+# diagnostics below stay reachable when vm_run fails.
 set +e
 vm_run <<'EOF'
 set -e

--- a/scripts/spec-coverage
+++ b/scripts/spec-coverage
@@ -18,11 +18,12 @@
 
 # spec-coverage: cross-verify spec/ section anchors against test citations.
 #
-# Parses the numbered ##/### headings of spec/*.md into a section
-# inventory, scans t/ for [<spec-stem> §<section>] citations, and prints
-# a coverage matrix. Exits non-zero iff a citation points at a section
-# that does not exist (stale after a spec edit). Low coverage is
-# informative, never fatal. See t/CLAUDE.md for the citation convention.
+# The script parses the numbered ##/### headings of spec/*.md into a
+# section inventory. It scans t/ for [<spec-stem> §<section>] citations.
+# It prints a coverage matrix. It exits non-zero when, and only when, a
+# citation points at a section that does not exist. Such a citation is
+# stale after a spec edit. Low coverage is informative, never fatal.
+# See t/CLAUDE.md for the citation convention.
 
 use v5.36;
 use File::Basename qw(dirname);
@@ -51,8 +52,8 @@ $test_dir //= "$root/t";
 -d $test_dir or die "spec-coverage: no such directory: $test_dir\n";
 
 # _read_inventory($dir):
-#	Parse numbered ##/### headings of every *.md file in $dir.
-#	Returns a hash: stem => {
+#	Parse the numbered ##/### headings of every *.md file in $dir.
+#	Return a hash: stem => {
 #		file     => basename,
 #		index    => 1 for index files (stem without '-'),
 #		sections => { '2.6' => 1, ... },
@@ -92,8 +93,8 @@ sub _read_inventory ($dir)
 }
 
 # _scan_citations($dir):
-#	Grep test files recursively for the citation pattern.
-#	Returns a list of { stem, section, row, site => 'file:line' }.
+#	Grep the test files recursively for the citation pattern.
+#	Return a list of { stem, section, row, site => 'file:line' }.
 sub _scan_citations ($dir)
 {
 	my @citations;

--- a/scripts/spec-coverage
+++ b/scripts/spec-coverage
@@ -16,7 +16,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-# spec-coverage: cross-verify spec/ section anchors against test citations.
+# spec-coverage: compare spec/ section anchors with the test citations.
 #
 # The script parses the numbered ##/### headings of spec/*.md into a
 # section inventory. It scans t/ for [<spec-stem> §<section>] citations.

--- a/scripts/vm-provision
+++ b/scripts/vm-provision
@@ -3,9 +3,9 @@
 # Provision OpenHAP in the OpenBSD VM
 #
 # Two layers. The deps layer installs the guest's packages and Perl
-# modules and is cached as a fuguvm snapshot, because under TCG
-# emulation it costs as much as the OS install itself. The OpenHAP layer
-# installs this checkout and runs every time.
+# modules. A fuguvm snapshot caches this layer, because under TCG
+# emulation it costs as much as the OS install itself. The OpenHAP
+# layer installs this checkout and runs every time.
 
 set -e
 
@@ -13,8 +13,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 FUGUVM="${PROJECT_ROOT}/bin/fuguvm"
 
-# Read a field from 'fuguvm status'. fuguvm logs to stderr, so stderr
-# has to be folded in for the value to be readable at all.
+# Read a field from 'fuguvm status'. fuguvm logs to stderr. Thus the
+# function folds stderr in. Without that, the value is not readable.
 vm_status() {
 	"${FUGUVM}" status 2>&1 | sed -n "s/.*$1: *//p" | head -1
 }
@@ -43,9 +43,9 @@ fi
 echo "Using tarball: ${TARBALL}"
 
 # make deps only exists inside the extracted tarball, along with deps/
-# and scripts/deps which it reads relative to cwd. So the package has
-# to reach the guest before the deps layer runs, not with make install
-# after it.
+# and scripts/deps. make deps reads those relative to the cwd. Thus
+# the package must reach the guest before the deps layer runs, not
+# with make install after it.
 copy_and_extract() {
 	vm_scp "${TARBALL}" "root@127.0.0.1:/tmp/openhap.tar.gz"
 	vm_run <<'EOF'
@@ -55,11 +55,11 @@ EOF
 }
 
 # The guest itself says whether the deps layer is already present. A
-# host-side flag could not: vm-up and vm-provision are sibling
-# make recipes in separate shells, so nothing can be handed over. The
-# marker travels inside the snapshot, which also answers the local case
-# where nothing was restored but the working disk already carries the
-# dependencies.
+# host-side flag could not. vm-up and vm-provision are sibling
+# make recipes in separate shells. Thus they cannot give data to each
+# other. The marker travels inside the snapshot. Thus it also answers
+# the local case where the script restored nothing, but the working
+# disk already carries the dependencies.
 if vm_run "test -f ${DEPS_MARKER}"; then
 	echo "==> Guest dependencies already present (${DEPS_SNAPSHOT}), skipping"
 else
@@ -67,19 +67,19 @@ else
 	copy_and_extract
 
 	# BEGIN deps layer
-	# Everything between these markers is hashed into DEPS_KEY by
-	# scripts/deps-key: editing it invalidates the cached layer.
-	# Guest heredocs run under set -e so a failed pkg_add/cpan/make
+	# scripts/deps-key hashes everything between these markers into
+	# DEPS_KEY. An edit here invalidates the cached layer.
+	# Guest heredocs run under set -e. Thus a failed pkg_add/cpan/make
 	# cannot report a provisioned guest.
 	#
 	# Every command here that might read stdin needs </dev/null. The
-	# remote shell reads THIS SCRIPT from stdin, so a command that reads
-	# stdin consumes the rest of the script as its own input: cpan(1)
-	# answering its configuration prompts swallowed 'make deps', the
-	# cleanup and the marker below, and the truncated block still exited
-	# 0 - so set -e never fired, the layer was cached without any
-	# dependencies in it, and provisioning failed much later on
-	# 'rcctl enable mosquitto'.
+	# remote shell reads THIS SCRIPT from stdin. Thus a command that
+	# reads stdin consumes the rest of the script as its own input.
+	# Once, cpan(1) answered its configuration prompts and swallowed
+	# 'make deps', the cleanup, and the marker below. The truncated
+	# block still exited 0. Thus set -e never fired. The cache then
+	# held a layer without any dependencies in it, and provisioning
+	# failed much later on 'rcctl enable mosquitto'.
 	vm_run <<EOF
 set -e
 pkg_add -u </dev/null 2>/dev/null || true
@@ -105,24 +105,24 @@ touch ${DEPS_MARKER}
 EOF
 	# END deps layer
 
-	# The layer has to have finished, not merely exited 0: the marker
-	# is its last statement, so its absence means the block was cut
-	# short. Check before snapshotting, or an incomplete layer enters
-	# the cache and every later run restores it.
+	# The layer must have finished, not merely exited 0. The marker
+	# is its last statement. Thus a missing marker means the block
+	# ended early. Check before the snapshot. Otherwise an incomplete
+	# layer enters the cache and every later run restores it.
 	if ! vm_run "test -f ${DEPS_MARKER}"; then
 		echo "Error: deps layer did not complete; not caching" >&2
 		exit 1
 	fi
 
-	# The snapshot verbs run under set -e, and a base-image cache
-	# miss legitimately leaves a standalone disk that cannot be
-	# snapshotted. Guard them here rather than softening the verb: a
-	# cache miss must not abort provisioning.
+	# The snapshot verbs run under set -e. A base-image cache miss
+	# legitimately leaves a standalone disk. fuguvm cannot snapshot
+	# such a disk. Guard the verbs here. Do not soften the verb
+	# itself. A cache miss must not abort provisioning.
 	echo "==> Caching guest dependencies as ${DEPS_SNAPSHOT}..."
 	"${FUGUVM}" down
 	if "${FUGUVM}" snapshot save "${DEPS_SNAPSHOT}"; then
-		# Safe to prune: snapshots are flattened onto the base
-		# image, so no deps-* layer is another one's parent.
+		# The prune is safe. fuguvm flattens snapshots onto the
+		# base image. Thus no deps-* layer is another one's parent.
 		for old in $("${FUGUVM}" snapshot list --names || true); do
 			case "${old}" in
 			deps-*)

--- a/scripts/vm-provision
+++ b/scripts/vm-provision
@@ -152,7 +152,7 @@ if [ -f /etc/rc.d/openhapd ]; then
 	rcctl stop openhapd 2>/dev/null || true
 	rcctl disable openhapd 2>/dev/null || true
 	cd /tmp/openhap-* && make uninstall 2>/dev/null || true
-	# Remove config to ensure fresh installation for testing
+	# Remove the config so that the test installation is fresh
 	rm -f /etc/openhapd.conf
 fi
 
@@ -183,7 +183,7 @@ rm -f /var/db/openhapd/pairings.db /var/db/openhapd/auth_attempts
 # Clean up
 cd /tmp && rm -rf openhap-* openhap.tar.gz
 
-# Enable and start services (start fails when already running, e.g.
+# Enable and start services (start fails when already running, for example
 # on a warm-cached disk where rc started it at boot)
 rcctl enable mosquitto
 rcctl check mosquitto >/dev/null || rcctl start mosquitto
@@ -191,12 +191,13 @@ rcctl check mosquitto >/dev/null || rcctl start mosquitto
 # Configure and start mdnsd on the primary network interface. The
 # openmdns package ships an rc script whose default flags name an
 # interface this guest does not have (em0), and mdnsd exits fatally
-# on an unknown interface - so the flags must always be set to a real
-# interface here. Guard on the rc script, NOT on 'rcctl get': its exit
-# status reflects whether the service is enabled, which is false on
-# every fresh disk and silently skipped this whole block.
-# Prefer the default-route interface, fall back to the first UP, non
-# loopback interface, and verify the daemon actually came up.
+# on an unknown interface. Thus the flags must always name a real
+# interface here. Guard on the rc script, NOT on 'rcctl get'. The
+# 'rcctl get' exit status shows whether the service is enabled. That
+# is false on every fresh disk and would silently skip this whole
+# block.
+# Prefer the default-route interface. Fall back to the first UP, non
+# loopback interface. Then make sure the daemon started.
 if [ -x /etc/rc.d/mdnsd ]; then
 	IFACE=$(route -n show -inet 2>/dev/null |
 		awk '/^default/ { print $NF; exit }')
@@ -209,9 +210,9 @@ if [ -x /etc/rc.d/mdnsd ]; then
 		rcctl enable mdnsd
 		rcctl set mdnsd flags "${IFACE}"
 		rcctl restart mdnsd || true
-		# Settle-then-verify: an immediate point-in-time check
+		# Settle, then check: an immediate point-in-time check
 		# races green when mdnsd starts and then exits shortly
-		# after. Require it to stay up across the window.
+		# after. Make sure it stays up across the window.
 		mdnsd_up=1
 		for probe in 1 2 3; do
 			sleep 2
@@ -221,9 +222,10 @@ if [ -x /etc/rc.d/mdnsd ]; then
 			fi
 		done
 		if [ "${mdnsd_up}" -ne 1 ]; then
-			# Surface why mdnsd would not stay up so the mDNS
-			# integration tests are diagnosable from CI logs
-			# instead of just reporting a missing daemon.
+			# Show why mdnsd did not stay up.  This makes
+			# the mDNS integration tests diagnosable from
+			# the CI logs, not only from a missing-daemon
+			# report.
 			echo "WARNING: mdnsd did not stay up on ${IFACE}; diagnostics:"
 			rcctl get mdnsd || true
 			ifconfig "${IFACE}" || true
@@ -242,21 +244,22 @@ if [ -x /etc/rc.d/openhapd ]; then
 	rcctl enable openhapd
 
 	# rc.subr gives a daemon 30 seconds to background itself.
-	# openhapd generates its accessory identity keys on first start,
-	# and the 3072-bit SRP work behind that is slow enough under TCG
-	# emulation to blow that budget on a fresh disk.  A warm disk
-	# already carries the keys and starts immediately, which is why
-	# this only bites on the run after the deps layer is rebuilt -
-	# rare enough to look like a flake and stay unfixed.
+	# openhapd generates its accessory identity keys on first start.
+	# The 3072-bit SRP work behind that is slow under TCG emulation.
+	# On a fresh disk it can take more than those 30 seconds.  A warm
+	# disk already carries the keys and starts immediately.  Thus the
+	# timeout hits only on the run after a deps layer rebuild.  That
+	# is rare enough to look like a flake and stay unfixed.
 	# scripts/integration raises OPENHAP_TEST_TIMEOUT for the same
-	# reason; this is the same allowance at the rc layer.
+	# reason.  This is the same allowance at the rc layer.
 	rcctl set openhapd timeout 300
 
 	if ! rcctl check openhapd >/dev/null && ! rcctl start openhapd; then
-		# Say why.  A bare "openhapd(timeout)" is indistinguishable
-		# from a config error, a missing module and a slow start,
-		# and provisioning dies here before the test step's own
-		# diagnostics can run.  Same reasoning as mdnsd above.
+		# Say why.  A bare "openhapd(timeout)" does not show the
+		# cause: a config error, a missing module, and a slow start
+		# all look the same.  Provisioning dies here before the test
+		# step's own diagnostics can run.  Same reasoning as mdnsd
+		# above.
 		echo "WARNING: openhapd would not start; diagnostics:"
 		rcctl get openhapd || true
 		echo "-- config test --"

--- a/scripts/vm-up
+++ b/scripts/vm-up
@@ -1,6 +1,6 @@
 #!/bin/sh
 # ex:ts=8 sw=4:
-# Bring up the OpenBSD VM, restoring the cached deps layer if there is one
+# Bring up the OpenBSD VM. Restore the cached deps layer if there is one.
 #
 # Usage: ./vm-up [--fresh]
 
@@ -16,8 +16,8 @@ if [ ! -x "${FUGUVM}" ]; then
 	exit 1
 fi
 
-# Read a field from 'fuguvm status'. fuguvm logs to stderr, so stderr
-# has to be folded in for the value to be readable at all.
+# Read a field from 'fuguvm status'. fuguvm logs to stderr. Thus the
+# function folds stderr in. Without that, the value is not readable.
 vm_status() {
 	"${FUGUVM}" status 2>&1 | sed -n "s/.*$1: *//p" | head -1
 }
@@ -47,15 +47,15 @@ if [ ${FRESH} -eq 1 ]; then
 	"${FUGUVM}" destroy 2>/dev/null || true
 fi
 
-# Restore the cached provisioning layer before the VM is created, so a
-# warm cache boots straight into a guest that already has its packages
-# and Perl modules. Only when there is no working disk yet: an existing
-# disk already carries whatever it carries, and replacing it would throw
-# away local state.
+# Restore the cached provisioning layer before the script creates the
+# VM. Then a warm cache boots straight into a guest that already has
+# its packages and Perl modules. Restore only when there is no working
+# disk yet. An existing disk already carries whatever it carries. A
+# replacement would throw away local state.
 #
-# A miss is normal - it exits 11 - so absorb it here rather than let
-# set -e abort; vm-provision then installs the deps layer and saves
-# it for next time.
+# A miss is normal. It exits 11. Thus absorb it here rather than let
+# set -e abort. vm-provision then installs the deps layer and saves
+# it for the next time.
 if [ "$(vm_status disk_exists)" != "1" ]; then
 	DEPS_SNAPSHOT="deps-$("${SCRIPT_DIR}/deps-key")"
 	if ! "${FUGUVM}" snapshot restore "${DEPS_SNAPSHOT}"; then
@@ -63,8 +63,9 @@ if [ "$(vm_status disk_exists)" != "1" ]; then
 	fi
 fi
 
-# Bring up VM (idempotent). Under TCG emulation (e.g. CI runners
-# without hardware acceleration) boot and install take far longer than
-# under HVF/KVM, so the wait timeout is overridable.
+# Bring up the VM. This step is idempotent. Under TCG emulation, for
+# example on CI runners without hardware acceleration, boot and install
+# take far longer than under HVF/KVM. Thus you can override the wait
+# timeout.
 "${FUGUVM}" up
 "${FUGUVM}" wait --timeout "${FUGUVM_WAIT_TIMEOUT:-120}"

--- a/share/fuguvm/expect/command.exp
+++ b/share/fuguvm/expect/command.exp
@@ -5,7 +5,7 @@
 # Usage: command.exp <host> <port> <command> [user] [password]
 #
 
-# Use environment variable if set, otherwise default to 60
+# Use the environment variable when it exists. Otherwise use 60.
 if {[info exists env(FUGUVM_TIMEOUT)]} {
     set timeout $env(FUGUVM_TIMEOUT)
 } else {

--- a/share/fuguvm/expect/firstboot.exp
+++ b/share/fuguvm/expect/firstboot.exp
@@ -71,7 +71,7 @@ expect {
 }
 
 expect "#" {
-    # Enable root login via SSH with pubkey
+    # Enable root login over SSH with pubkey
     send "sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config\r"
 }
 

--- a/share/fuguvm/expect/firstboot.exp
+++ b/share/fuguvm/expect/firstboot.exp
@@ -6,7 +6,8 @@
 #
 
 # Use FUGUVM_TIMEOUT from the environment when it exceeds the
-# script default (slow hosts, e.g. TCG emulation in CI)
+# script default. Slow hosts need this, for example under TCG
+# emulation in CI.
 proc env_timeout {default} {
     global env
     if {[info exists env(FUGUVM_TIMEOUT)] && $env(FUGUVM_TIMEOUT) > $default} {
@@ -89,7 +90,7 @@ expect "#" {
     send "pkg_add qemu-ga\r"
 }
 
-# Wait for package installation (may take a while)
+# Wait for the package installation. It can take a while.
 expect {
     "#" {
         # Enable qemu_ga service
@@ -97,7 +98,7 @@ expect {
     }
     timeout {
         puts stderr "Timeout waiting for qemu-ga installation"
-        # Continue anyway - agent is optional
+        # Continue anyway. The agent is optional.
     }
 }
 

--- a/share/fuguvm/expect/install.exp
+++ b/share/fuguvm/expect/install.exp
@@ -1,6 +1,6 @@
 #!/usr/bin/expect -f
 #
-# Automated OpenBSD installation via serial console
+# Automated OpenBSD installation over the serial console
 #
 # Usage: install.exp <host> <port> [root_password] [proxy_url]
 #
@@ -215,7 +215,7 @@ expect {
 # The install is complete once the system halts. Do NOT wait for eof.
 # OpenBSD's halt stops at the "press any key to reboot" prompt and
 # does not close the console. Thus telnet stays connected and no eof
-# ever arrives. fuguvm stops QEMU via QMP once this script returns.
+# ever arrives. fuguvm stops QEMU through QMP once this script returns.
 # Then fuguvm restarts from the installed disk.
 set timeout [env_timeout 120]
 expect {

--- a/share/fuguvm/expect/install.exp
+++ b/share/fuguvm/expect/install.exp
@@ -6,7 +6,8 @@
 #
 
 # Use FUGUVM_TIMEOUT from the environment when it exceeds the
-# script default (slow hosts, e.g. TCG emulation in CI)
+# script default. Slow hosts need this, for example under TCG
+# emulation in CI.
 proc env_timeout {default} {
     global env
     if {[info exists env(FUGUVM_TIMEOUT)] && $env(FUGUVM_TIMEOUT) > $default} {
@@ -37,7 +38,7 @@ if {$proxy_url eq ""} {
 
 log_user 1
 
-# Helper proc to send response after matching
+# Helper proc to send a response after a match
 proc respond {response} {
     sleep 0.5
     send "$response\r"
@@ -47,12 +48,14 @@ proc respond {response} {
 spawn telnet $host $port
 
 # Wait for the console connection. telnet prints "Connected to <host>"
-# on success; match on the host-independent prefix since the host may be
-# an IP address. An eof means telnet could not connect at all (console
-# port not listening) - fail fast rather than hang to the full timeout.
+# on success. Match on the host-independent prefix, because the host
+# can be an IP address. An eof means telnet could not connect at all,
+# because the console port does not listen. Fail fast rather than hang
+# to the full timeout.
 expect {
     "Connected to" {
-        # Send an empty line to trigger prompt if already at installer
+        # Send an empty line to trigger the prompt if the console
+        # already shows the installer
         sleep 0.5
         send "\r"
     }
@@ -111,7 +114,7 @@ expect "IPv6 address" { respond "none" }
 # Done with network interfaces
 expect "Network interface to configure?" { respond "done" }
 
-# Password for root - wait for the actual prompt
+# Password for root. Wait for the actual prompt.
 expect "Password for root account?" 
 sleep 0.5
 send "$root_password\r"
@@ -135,7 +138,7 @@ expect "What timezone are you in?" { respond "UTC" }
 # Root disk
 expect "Which disk is the root disk?" { respond "" }
 
-# Disk encryption - no
+# Disk encryption: no
 expect "Encrypt the root disk" { respond "no" }
 
 # Use whole disk or GPT
@@ -150,7 +153,7 @@ expect {
     "Auto layout" { respond "a" }
 }
 
-# Additional disks to initialize - none
+# Additional disks to initialize: none
 expect "Which disk do you wish to initialize?" { respond "done" }
 
 # Location of sets
@@ -162,10 +165,10 @@ expect "HTTP proxy URL?" { respond $proxy_url }
 # HTTP server
 expect "HTTP Server?" { respond "cdn.openbsd.org" }
 
-# Server directory - accept default
+# Server directory: accept the default
 expect "Server directory?" { respond "" }
 
-# Select sets - skip games and X
+# Select the sets. Skip games and X.
 expect "Set name(s)?" {
     sleep 0.5
     send -- "-game* -x*\r"
@@ -174,7 +177,7 @@ expect "Set name(s)?" {
 # Confirm selection
 expect "Set name(s)?" { respond "done" }
 
-# Wait for sets to install and prompt for more sets
+# Wait for the sets to install. Then answer the prompt for more sets.
 set timeout [env_timeout 900]
 expect {
     "Continue without verification?" { 
@@ -188,11 +191,12 @@ expect {
     }
 }
 
-# The installer may ask to correct the clock before finishing; answer
-# yes if it does. The (R)eboot? prompt marks the end of the install -
-# choose halt instead of reboot so fuguvm can restart from the
-# installed disk without the miniroot attached. A single expect block
-# handles both so a missing time prompt never stalls to the timeout.
+# The installer can ask to correct the clock before it finishes.
+# Answer yes if it does. The (R)eboot? prompt marks the end of the
+# install. Choose halt instead of reboot. Then fuguvm can restart
+# from the installed disk without the miniroot attached. A single
+# expect block matches both prompts. Thus a missing time prompt never
+# stalls to the timeout.
 set timeout [env_timeout 900]
 expect {
     "Time appears wrong" {
@@ -208,11 +212,11 @@ expect {
     }
 }
 
-# The install is complete once the system halts. Do NOT wait for eof:
-# OpenBSD's halt stops at the "press any key to reboot" prompt without
-# closing the console, so telnet stays connected and no eof ever
-# arrives. fuguvm terminates QEMU via QMP once this script
-# returns, then restarts from the installed disk.
+# The install is complete once the system halts. Do NOT wait for eof.
+# OpenBSD's halt stops at the "press any key to reboot" prompt and
+# does not close the console. Thus telnet stays connected and no eof
+# ever arrives. fuguvm stops QEMU via QMP once this script returns.
+# Then fuguvm restarts from the installed disk.
 set timeout [env_timeout 120]
 expect {
     "The operating system has halted" { exit 0 }

--- a/share/fuguvm/expect/login.exp
+++ b/share/fuguvm/expect/login.exp
@@ -6,7 +6,8 @@
 #
 
 # Use FUGUVM_TIMEOUT from the environment when it exceeds the
-# script default (slow hosts, e.g. TCG emulation in CI)
+# script default. Slow hosts need this, for example under TCG
+# emulation in CI.
 proc env_timeout {default} {
     global env
     if {[info exists env(FUGUVM_TIMEOUT)] && $env(FUGUVM_TIMEOUT) > $default} {

--- a/share/fuguvm/fuguvm.conf.sample
+++ b/share/fuguvm/fuguvm.conf.sample
@@ -8,7 +8,7 @@
 #
 # fuguvm installs this key in the VM's /root/.ssh/authorized_keys during
 # the initial installation. After the installation, all SSH connections
-# use SSH agent authentication via SSH_AUTH_SOCK.
+# use SSH agent authentication through SSH_AUTH_SOCK.
 #
 # To get your public key, run: cat ~/.ssh/id_ed25519.pub
 # or: ssh-add -L

--- a/share/fuguvm/fuguvm.conf.sample
+++ b/share/fuguvm/fuguvm.conf.sample
@@ -6,11 +6,11 @@
 
 # SSH public key for VM authentication
 #
-# This key will be installed in the VM's /root/.ssh/authorized_keys during
-# initial installation. After installation, all SSH connections use SSH
-# agent authentication via SSH_AUTH_SOCK.
+# fuguvm installs this key in the VM's /root/.ssh/authorized_keys during
+# the initial installation. After the installation, all SSH connections
+# use SSH agent authentication via SSH_AUTH_SOCK.
 #
-# You can get your public key with: cat ~/.ssh/id_ed25519.pub
+# To get your public key, run: cat ~/.ssh/id_ed25519.pub
 # or: ssh-add -L
 #
 ssh_pubkey ssh-ed25519 AAAA... user@host
@@ -19,17 +19,18 @@ ssh_pubkey ssh-ed25519 AAAA... user@host
 # cached installed-image bases
 # cache_dir ~/.cache/fuguvm
 
-# Optional: reuse cached installed images instead of reinstalling
-# OpenBSD on every fresh disk (default: yes). See fuguvm(1).
+# Optional: reuse the cached installed images. Then fuguvm does not
+# reinstall OpenBSD on every fresh disk. The default is yes. See
+# fuguvm(1).
 # image_cache yes
 
-# Optional: default VM name when not specified
+# Optional: the default VM name when you do not specify one
 # default_vm default
 
 # VM definitions
 #
-# VMs can be defined in blocks here or in project .fuguvmrc files.
-# Project config takes precedence over global config.
+# You can define VMs in blocks here or in project .fuguvmrc files.
+# The project config overrides the global config.
 #
 # vm "default" {
 #     version      7.8

--- a/share/fuguvm/vms/default.conf.sample
+++ b/share/fuguvm/vms/default.conf.sample
@@ -1,8 +1,8 @@
 # Sample FuguVM VM configuration block
 #
-# Add VM definitions to ~/.fuguvmrc (global) or .fuguvmrc (project)
+# Add VM definitions to the global ~/.fuguvmrc or the project .fuguvmrc
 #
-# Project config takes precedence over global config for the same VM name.
+# The project config overrides the global config for the same VM name.
 
 vm "default" {
 	version      7.8

--- a/t/ci/setup-perl.t
+++ b/t/ci/setup-perl.t
@@ -2,18 +2,20 @@
 # ex:ts=8 sw=4:
 # Guards for .github/actions/setup-perl and the workflows that use it
 #
-# Nothing else in the tree checks CI wiring: a workflow that stops
-# passing an environment, or a cache key that stops covering an input
-# that decides what gets installed, both fail on a runner - the first as
-# a job that installs the wrong dependency set, the second as a tree
-# that is silently rebuilt and re-cached under a stale key on every run.
+# Nothing else in the tree checks CI wiring. Two failures show only
+# on a runner. One is a workflow that stops passing an environment.
+# The other is a cache key that stops covering an input that decides
+# what gets installed. The first fails as a job that installs the
+# wrong dependency set. The second fails as a tree that every run
+# silently rebuilds and re-caches under a stale key.
 #
-# Text, not YAML: a parser is not in base perl and the invariants here
-# are all about which literal strings appear, not about structure - with
-# one exception, the cache key, whose shell is extracted and run.  Reading
-# it was not enough: interpolating the hashFiles expression straight after
-# $prefix made the digest part of the variable NAME, which produced an
-# empty key and failed every job at the restore step.
+# Text, not YAML: a parser is not in base perl, and the invariants
+# here are all about which literal strings appear, not about
+# structure. The one exception is the cache key. The test extracts
+# its shell and runs it.  To read the shell was not enough: an
+# interpolation of the hashFiles expression straight after $prefix
+# made the digest part of the variable NAME. That produced an empty
+# key and failed every job at the restore step.
 
 use v5.36;
 use Test::More;
@@ -24,9 +26,9 @@ my $root     = "$RealBin/../..";
 my $action   = "$root/.github/actions/setup-perl/action.yml";
 my $workflow = "$root/.github/workflows";
 
-# The environments deps/<OS>.txt names, and the make target each one
-# selects. deps-develop and deps-test have their own targets; runtime is
-# plain `make deps`.
+# The environments that deps/<OS>.txt names, and the make target that
+# each one selects. deps-develop and deps-test have their own targets.
+# runtime is plain `make deps`.
 my %TARGET = (
 	runtime => 'deps',
 	test    => 'deps-test',
@@ -49,8 +51,8 @@ sub _slurp ($path)
 }
 
 # _run_block($yml, $step_name):
-#	The `run: |` script of the named step, dedented to column zero so
-#	it can be handed to a shell. Undef when the step or its block is
+#	The `run: |` script of the named step, dedented to column zero
+#	so that a shell can run it. Undef when the step or its block is
 #	not there.
 sub _run_block ( $yml, $name )
 {
@@ -61,7 +63,7 @@ sub _run_block ( $yml, $name )
 		$seen = 1 if $lines[$i] =~ /^\s+-\s+name:\s*\Q$name\E\s*$/;
 		next unless $seen;
 
-		# A later step begins, so the block is over
+		# A later step begins. The block is over.
 		last if @block && $lines[$i] =~ /^\s+-\s+name:/;
 
 		if ( !defined $indent ) {
@@ -93,8 +95,8 @@ subtest 'the action takes one environment input' => sub {
 	like( $yml, qr/^\s+default:\s*"?test"?\s*$/m,
 		'defaults to the test environment' );
 
-	# Every environment resolves, and only through the input: a
-	# workflow must not have to know the target names.
+	# Every environment resolves, and only through the input. A
+	# workflow must not need to know the target names.
 	for my $env ( sort keys %TARGET ) {
 		like( $yml, qr/\b\Q$env\E\b/,
 			"resolves the $env environment" );
@@ -108,10 +110,11 @@ subtest 'the action takes one environment input' => sub {
 };
 
 subtest 'the cache key covers what decides the tree' => sub {
-	# One computed key, read twice. actions/cache/save rejects a write
-	# to an existing key, so a restore and a save that disagreed would
-	# miss on every run and then fail to store the result - which is
-	# why neither step may spell the key out for itself.
+	# One computed key, read twice. actions/cache/save rejects a
+	# write to an existing key. Thus a restore and a save that
+	# disagreed would miss on every run and then fail to store the
+	# result. This is why neither step may spell the key out for
+	# itself.
 	my @refs = $yml =~ /^\s+key:\s*(.*)$/mg;
 	is( scalar @refs, 2, 'a restore key and a save key' );
 	is_deeply(
@@ -125,14 +128,14 @@ subtest 'the cache key covers what decides the tree' => sub {
 	like( $yml, qr/prefix=\S*\$\{\{\s*inputs\.dependencies\s*\}\}/,
 		'the key names the environment' );
 
-	# The tree holds compiled XS, so it is only valid for the perl that
-	# built it.
+	# The tree holds compiled XS. Thus it is only valid for the perl
+	# that built it.
 	like( $yml, qr/\$Config\{version\}/,  'the key names perl version' );
 	like( $yml, qr/\$Config\{archname\}/, 'the key names the archname' );
 
 	# Fail closed: hashFiles over a path that matches nothing returns
-	# an empty string rather than an error, so a renamed input would
-	# quietly collapse the key instead of rotating it.
+	# an empty string rather than an error. Thus a renamed input
+	# would quietly collapse the key, not rotate it.
 	my ($hashed) = $yml =~ /hashFiles\(([^)]*)\)/;
 	ok( defined $hashed, 'the key hashes files' ) or return;
 
@@ -141,7 +144,7 @@ subtest 'the cache key covers what decides the tree' => sub {
 	ok( -f "$root/$_", "hashed path $_ exists" ) for @paths;
 
 	# The two inputs that decide which modules end up installed.
-	# Anything else - the Makefile above all - changes for unrelated
+	# Anything else, the Makefile above all, changes for unrelated
 	# reasons and would rebuild the tree from source each time.
 	for my $want ( 'deps/Linux.txt', 'scripts/deps' ) {
 		ok( scalar( grep { $_ eq $want } @paths ),
@@ -156,10 +159,10 @@ subtest 'the cache key covers what decides the tree' => sub {
 };
 
 subtest 'the cache key shell actually composes a key' => sub {
-	# The step is legal YAML and legal shell either way, so nothing
+	# The step is legal YAML and legal shell either way. Thus nothing
 	# above can tell a working key from an empty one. Run it: the
-	# runner interpolates the expressions before bash sees them, so do
-	# the same with stand-in values and read the outputs back.
+	# runner interpolates the expressions before bash sees them. Do
+	# the same with stand-in values. Then read the outputs back.
 	my $shell = _run_block( $yml, 'Compute the cache key' );
 	ok( defined $shell, 'the key-computing step has a shell block' )
 	    or return;
@@ -187,7 +190,7 @@ subtest 'the cache key shell actually composes a key' => sub {
 	ok( length( $got{key}    // '' ), 'it emits a non-empty key' );
 
 	# The bug: $prefix followed by the digest read as one variable
-	# name, so key= was empty and restore-keys= was fine - which is
+	# name. Thus key= was empty and restore-keys= was fine. This is
 	# why only the composition catches it.
 	is( $got{key}, ( $got{prefix} // '' ) . $digest,
 		'and the key is exactly the prefix plus the digest' );
@@ -217,8 +220,8 @@ subtest 'workflows delegate installing to the action' => sub {
 		is( scalar @own, 0, "$file runs no deps target of its own" )
 		    or diag( join "\n", @own );
 
-		# Whatever a workflow does pass has to be an environment
-		# the action accepts.
+		# Whatever a workflow does pass must be an environment
+		# that the action accepts.
 		for my $i ( 0 .. $#lines ) {
 			next
 			    unless $lines[$i] =~
@@ -236,8 +239,8 @@ subtest 'workflows delegate installing to the action' => sub {
 				}
 			}
 
-			# Omitting it is fine - that is what the default
-			# is for - but a value that is not an environment
+			# To omit it is fine. That is what the default
+			# is for. But a value that is not an environment
 			# is a job that installs nothing.
 			ok( !defined $env || exists $TARGET{$env},
 				"$file line @{[$i + 1]}: "

--- a/t/conformance/hap-categories.t
+++ b/t/conformance/hap-categories.t
@@ -45,8 +45,8 @@ subtest '[HAP-Categories §3] category advertised in mDNS ci field' => sub {
 	ok( exists $txt->{ci}, 'ci field present in TXT records' );
 	like( $txt->{ci}, qr/^\d+$/, 'ci is a numeric identifier' );
 
-	# The category is a UI hint only; bridged accessories of any
-	# service type still live behind ci=2
+	# The category is a UI hint only. Bridged accessories of any
+	# service type stay behind ci=2.
 	is( $txt->{ci}, 2, 'bridge category regardless of bridged devices' );
 };
 

--- a/t/conformance/hap-characteristics.t
+++ b/t/conformance/hap-characteristics.t
@@ -2,9 +2,9 @@
 # ex:ts=8 sw=4:
 # Conformance tests for spec/HAP-Characteristics.md
 #
-# Data-driven over the characteristics OpenHAP implements; catalog rows
-# are cited as [HAP-Characteristics §5/<Name>] and the UUID table as
-# §6 rows.
+# The tests are data-driven over the characteristics that OpenHAP
+# implements. The tests cite catalog rows as
+# [HAP-Characteristics §5/<Name>] and UUID table entries as §6 rows.
 
 use v5.36;
 use Test::More;
@@ -22,8 +22,9 @@ use_ok('OpenHAP::Tasmota::Sensor');
 use_ok('OpenHAP::Tasmota::Thermostat');
 use_ok('OpenHAP::Tasmota::Lightbulb');
 
-# [HAP-Characteristics §5] catalog rows for the characteristics OpenHAP
-# implements: short UUID, format, spec permissions, spec range, unit
+# [HAP-Characteristics §5] catalog rows for the characteristics that
+# OpenHAP implements: short UUID, format, spec permissions, spec
+# range, unit
 my %catalog = (
 	Identify => {
 		short  => '14',
@@ -181,7 +182,8 @@ subtest '[HAP-Characteristics §1][HAP-Characteristics §7] JSON shape' =>
 	is( $json->{unit},     'percentage', 'unit encoded' );
 	is_deeply( $json->{perms}, [ 'pr', 'pw', 'ev' ], 'perms encoded' );
 
-	# [HAP-Characteristics §8] a write-only characteristic omits value
+	# [HAP-Characteristics §8] a write-only characteristic omits the
+	# value
 	my $write_only = OpenHAP::Characteristic->new(
 		type   => 'Identify',
 		iid    => 2,
@@ -192,8 +194,8 @@ subtest '[HAP-Characteristics §1][HAP-Characteristics §7] JSON shape' =>
 		'[HAP-Characteristics §8] non-readable value omitted' );
 };
 
-# Instantiate every device type and check each characteristic instance
-# against its catalog row
+# Instantiate every device type. Check each characteristic instance
+# against its catalog row.
 subtest '[HAP-Characteristics §5] device characteristics match rows' =>
     sub {
 	my $mqtt        = OpenHAP::TestMock::MQTT->new;
@@ -280,7 +282,7 @@ sub check_row ( $where, $name, $char )
 			"$label: unit is $row->{unit}" );
 	}
 
-	# [HAP-Characteristics §4] any unit used must be a spec unit
+	# [HAP-Characteristics §4] each unit in use must be a spec unit
 	if ( defined $char->{unit} ) {
 		my %spec_units =
 		    map { $_ => 1 } qw(celsius percentage arcdegrees

--- a/t/conformance/hap-encryption-exchange.t
+++ b/t/conformance/hap-encryption-exchange.t
@@ -1,7 +1,8 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Session-framing assertions over a real verified in-process session
-# established by OpenHAP::Test::Controller (spec/HAP-Encryption.md).
+# Session-framing assertions for spec/HAP-Encryption.md.
+# OpenHAP::Test::Controller makes a real verified in-process session.
+# The tests assert on the frames of that session.
 
 use v5.36;
 use Test::More;
@@ -32,7 +33,7 @@ use_ok('OpenHAP::Test::Controller');
 
 my $PIN = '123-45-678';
 
-# Transport that records the raw (encrypted) bytes both directions
+# The transport records the raw encrypted bytes in both directions
 my @wire;
 
 sub make_verified_pair ()
@@ -120,14 +121,14 @@ subtest '[HAP-Encryption §2][HAP-Encryption §3] frame layout both '
 		ok( ( !grep { $_ > 1024 } @$lengths ),
 			"$name frames carry at most 1024 bytes" );
 
-		# each frame is 2-byte LE length + ciphertext + 16-byte tag
+		# Each frame is: 2-byte LE length + ciphertext + 16-byte tag
 		my $expected = 0;
 		$expected += 2 + $_ + 16 for @$lengths;
 		is( length( $capture->{bytes} ),
 			$expected, "$name frame overhead is 18 bytes" );
 	}
 
-	# Plaintext is not visible on the wire
+	# The plaintext is not visible on the wire
 	unlike( $a2c->{bytes}, qr/"accessories"/,
 		'accessory JSON not visible in the encrypted stream' );
 
@@ -141,8 +142,9 @@ subtest '[HAP-Encryption §4][HAP-Encryption §6] counters increment '
 	$controller->request( 'GET', '/accessories' );
 	$controller->request( 'GET', '/accessories' );
 
-	# Two requests, two responses; the response to /accessories is
-	# larger than 1024 bytes so it spans several frames
+	# There are two requests and two responses. The response to
+	# /accessories is larger than 1024 bytes. Thus it spans several
+	# frames.
 	my @c2a = grep { $_->{direction} eq 'c2a' } @wire;
 	is( scalar @c2a, 2, 'two request transmissions' );
 
@@ -163,7 +165,7 @@ subtest '[HAP-Encryption §4][HAP-Encryption §6] counters increment '
 subtest '[HAP-Encryption §9] tampered frame fails the session' => sub {
 	my ( $controller, $hap, $session ) = make_verified_pair();
 
-	# Build a valid encrypted request, then flip a ciphertext bit
+	# Build a valid encrypted request. Then flip a ciphertext bit.
 	my $raw = $controller->_build_request( 'GET', '/accessories' );
 	my $encrypted = $controller->_encrypt($raw);
 	substr( $encrypted, 5, 1 ) =

--- a/t/conformance/hap-encryption.t
+++ b/t/conformance/hap-encryption.t
@@ -23,7 +23,7 @@ use_ok('OpenHAP::Session');
 my $key_a2c = pack( 'H*', '11' x 32 );
 my $key_c2a = pack( 'H*', '22' x 32 );
 
-# Accessory-side session: encrypts with a2c, decrypts with c2a
+# The accessory-side session encrypts with a2c and decrypts with c2a
 sub accessory_session ()
 {
 	my $session = OpenHAP::Session->new( socket => 'dummy' );
@@ -31,7 +31,8 @@ sub accessory_session ()
 	return $session;
 }
 
-# Controller-side decrypt of an accessory frame, built from primitives
+# Decrypt an accessory frame on the controller side. The function
+# uses the crypto primitives directly.
 sub controller_decrypt ( $frame, $counter )
 {
 	my $aad        = substr( $frame, 0, 2 );
@@ -84,11 +85,11 @@ subtest '[HAP-Encryption §3] AAD is the length field' => sub {
 	my $session = accessory_session();
 	my $frame   = $session->encrypt('hello');
 
-	# Decrypting with the frame's own AAD succeeds
+	# A decrypt with the frame's own AAD succeeds
 	is( controller_decrypt( $frame, 0 ),
 		'hello', 'decrypts with length field as AAD' );
 
-	# Recomputing with a different AAD fails
+	# A decrypt with a different AAD fails
 	my $length     = unpack( 'v', substr( $frame, 0, 2 ) );
 	my $ciphertext = substr( $frame, 2, $length );
 	my $tag        = substr( $frame, 2 + $length, 16 );
@@ -104,7 +105,8 @@ subtest '[HAP-Encryption §4] nonce is 4 zero bytes + LE counter' => sub {
 	my $frame0  = $session->encrypt('first');
 	my $frame1  = $session->encrypt('second');
 
-	# Counter starts at 0 and increments per frame, per direction
+	# The counter starts at 0. It increments once for each frame in
+	# each direction.
 	is( controller_decrypt( $frame0, 0 ),
 		'first', 'first frame uses counter 0' );
 	is( controller_decrypt( $frame1, 1 ),
@@ -112,8 +114,9 @@ subtest '[HAP-Encryption §4] nonce is 4 zero bytes + LE counter' => sub {
 	ok( !defined controller_decrypt( $frame1, 0 ),
 		'frame does not decrypt under the wrong counter' );
 
-	# Direction counters are independent: controller->accessory
-	# counter starts at 0 regardless of accessory->controller traffic
+	# The direction counters are independent. The
+	# controller->accessory counter starts at 0. Accessory->controller
+	# traffic does not change it.
 	my $c2a_nonce = pack( 'x[4]Q<', 0 );
 	my ( $ciphertext, $tag ) =
 	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $key_c2a, $c2a_nonce,
@@ -170,7 +173,7 @@ subtest '[HAP-Encryption §7] ChaCha20-Poly1305 RFC 8439 vector' => sub {
 subtest '[HAP-Encryption §9] error handling' => sub {
 	my $session = accessory_session();
 
-	# Build a valid inbound frame, then tamper with it
+	# Build a valid inbound frame. Then tamper with it.
 	my $nonce = pack( 'x[4]Q<', 0 );
 	my ( $ciphertext, $tag ) =
 	    OpenHAP::Crypto::chacha20_poly1305_encrypt( $key_c2a, $nonce,
@@ -194,7 +197,7 @@ subtest '[HAP-Encryption §9] error handling' => sub {
 	ok( !defined accessory_session()->decrypt($oversize),
 		'frame length over 1024 is an error' );
 
-	# Valid frame still decrypts (control)
+	# The valid frame still decrypts. This is the control check.
 	is( accessory_session()->decrypt($good),
 		'GET /accessories',
 		'[HAP-Encryption §5] control frame decrypts' );
@@ -202,7 +205,8 @@ subtest '[HAP-Encryption §9] error handling' => sub {
 
 subtest '[HAP-Encryption §1] session key derivation' => sub {
 
-	# Both directions derive from the shared secret with Control-Salt
+	# The keys for both directions derive from the shared secret
+	# with Control-Salt
 	my $shared = pack( 'H*', 'ab' x 32 );
 	my $read_key =
 	    OpenHAP::Crypto::hkdf_sha512( $shared, 'Control-Salt',
@@ -217,7 +221,7 @@ subtest '[HAP-Encryption §1] session key derivation' => sub {
 		unpack( 'H*', $write_key ),
 		'read and write keys differ' );
 
-	# The accessory session encrypts outbound with the read key
+	# The accessory session encrypts outbound data with the read key
 	my $session = OpenHAP::Session->new( socket => 'dummy' );
 	$session->set_encryption( $read_key, $write_key );
 	my $frame = $session->encrypt('response');
@@ -243,7 +247,7 @@ subtest '[HAP-Encryption §10] connection lifecycle' => sub {
 	is( $session->decrypt('plain'), 'plain',
 		'pre-verify inbound data is passed through' );
 
-	# After key setup every byte is framed and encrypted
+	# After key setup, the session frames and encrypts every byte
 	$session->set_encryption( $key_a2c, $key_c2a );
 	ok( $session->is_encrypted, 'session encrypted after key setup' );
 	isnt( $session->encrypt('plain'), 'plain',

--- a/t/conformance/hap-http.t
+++ b/t/conformance/hap-http.t
@@ -3,7 +3,7 @@
 # Conformance tests for spec/HAP-HTTP.md
 #
 # The tests drive OpenHAP::HAP request dispatch in-process, without
-# sockets. The tests set the session's verification state directly to
+# sockets. The tests set the session's verified state directly to
 # model the paired and unpaired cases.
 
 use v5.36;
@@ -124,7 +124,7 @@ subtest '[HAP-HTTP §1] endpoints require a verified session' => sub {
 			    . 'without pair-verify' );
 	}
 
-	# Pairing endpoints do not require verification
+	# Pairing endpoints do not need a verified session
 	my $m1 = OpenHAP::TLV::encode(
 		OpenHAP::Pairing::kTLVType_State(),  pack( 'C', 1 ),
 		OpenHAP::Pairing::kTLVType_Method(), pack( 'C', 0 ),
@@ -621,7 +621,7 @@ subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
 	ok( $data->{characteristics}[0]{value},
 		'event carries the new value (true)' );
 
-	# An unsubscribe via ev:false stops delivery
+	# An unsubscribe with ev:false stops delivery
 	$sub_sock->{written} = '';
 	my $unsubscribe = $json->encode( { characteristics =>
 		    [ { aid => $aid, iid => $iid, ev => \0 } ] } );

--- a/t/conformance/hap-http.t
+++ b/t/conformance/hap-http.t
@@ -2,9 +2,9 @@
 # ex:ts=8 sw=4:
 # Conformance tests for spec/HAP-HTTP.md
 #
-# Drives OpenHAP::HAP request dispatch in-process (no sockets); the
-# session's verification state is set directly to model the paired and
-# unpaired cases.
+# The tests drive OpenHAP::HAP request dispatch in-process, without
+# sockets. The tests set the session's verification state directly to
+# model the paired and unpaired cases.
 
 use v5.36;
 use Test::More;
@@ -136,7 +136,7 @@ subtest '[HAP-HTTP §1] endpoints require a verified session' => sub {
 	);
 	OpenHAP::Pairing->clear_pairing_state();
 
-	# Pair-verify is likewise open and answers with TLV
+	# Pair-verify is also open and answers with TLV
 	my $pv_m1 = OpenHAP::TLV::encode(
 		OpenHAP::Pairing::kTLVType_State(),     pack( 'C', 1 ),
 		OpenHAP::Pairing::kTLVType_PublicKey(), 'X' x 32,
@@ -243,7 +243,7 @@ subtest '[HAP-HTTP §8] GET /characteristics' => sub {
 	ok( exists $data->{characteristics}[0]{value},
 		'[HAP-HTTP §16.1] response carries the value' );
 
-	# meta/perms/type parameters include optional fields
+	# The meta/perms/type parameters include the optional fields
 	( $status, undef, $body ) = dispatch( $hap, 'GET',
 		"/characteristics?id=$aid.$iid&meta=1&perms=1&type=1" );
 	$data = $json->decode($body);
@@ -268,7 +268,7 @@ subtest '[HAP-HTTP §9] PUT /characteristics' => sub {
 	    dispatch( $hap, 'GET', '/accessories' );
 	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
 
-	# Successful write returns 204 No Content
+	# A successful write returns 204 No Content
 	my $put = $json->encode( { characteristics =>
 		    [ { aid => $aid, iid => $iid, value => 1 } ] } );
 	my ( $status, undef, $body ) =
@@ -320,7 +320,8 @@ subtest '[HAP-HTTP §10] PUT /prepare timed write' => sub {
 	is( $json->decode($body)->{status},
 		-70410, 'missing ttl/pid has status -70410' );
 
-	# POST also accepted (spec shows POST in the endpoint table)
+	# The server also accepts POST. The spec shows POST in the
+	# endpoint table.
 	( $status, undef, undef ) =
 	    dispatch( $hap, 'POST', '/prepare', $prepare, $session );
 	is( $status, 200, 'POST /prepare also accepted' );
@@ -416,7 +417,7 @@ subtest '[HAP-Pairing §7.2][HAP-Pairing §7.3] remove and list' => sub {
 	like( $body, qr/\xFF\x00/,
 		'entries separated by zero-length 0xFF separator' );
 
-	# Remove a pairing that does not exist returns success
+	# The removal of a pairing that does not exist returns success
 	my $remove_ghost = OpenHAP::TLV::encode(
 		OpenHAP::Pairing::kTLVType_State(),      pack( 'C', 1 ),
 		OpenHAP::Pairing::kTLVType_Method(),     pack( 'C', 4 ),
@@ -428,7 +429,7 @@ subtest '[HAP-Pairing §7.2][HAP-Pairing §7.3] remove and list' => sub {
 	ok( !exists $tlv{ OpenHAP::Pairing::kTLVType_Error() },
 		'removing nonexistent pairing returns success' );
 
-	# Removing the last admin clears all pairings
+	# The removal of the last admin clears all pairings
 	my $remove_admin = OpenHAP::TLV::encode(
 		OpenHAP::Pairing::kTLVType_State(),      pack( 'C', 1 ),
 		OpenHAP::Pairing::kTLVType_Method(),     pack( 'C', 4 ),
@@ -457,7 +458,7 @@ subtest '[HAP-HTTP §15][HAP-HTTP §15.1] JSON value encoding' => sub {
 	    dispatch( $hap, 'GET', '/accessories' );
 	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
 
-	# bool encodes as JSON true/false, not 1/0
+	# A bool encodes as JSON true/false, not 1/0
 	my ( undef, undef, $body ) =
 	    dispatch( $hap, 'GET', "/characteristics?id=$aid.$iid" );
 	like( $body, qr/"value"\s*:\s*(?:true|false)/,
@@ -470,7 +471,7 @@ subtest '[HAP-HTTP §15][HAP-HTTP §15.1] JSON value encoding' => sub {
 	    dispatch( $hap, 'GET', "/characteristics?id=$aid.$iid" );
 	like( $body, qr/"value"\s*:\s*true/, 'true after write of 1' );
 
-	# string characteristics encode as JSON strings
+	# The string characteristics encode as JSON strings
 	my ( undef, $name_iid ) = find_char( $json->decode($acc_body), '23' );
 	( undef, undef, $body ) =
 	    dispatch( $hap, 'GET', "/characteristics?id=$aid.$name_iid" );
@@ -533,8 +534,8 @@ sub encrypted_session ( $sock, $id )
 	return $session;
 }
 
-# decrypt_event($sock, $counter): decrypt one event frame written to a
-# mock socket and return the plaintext EVENT/1.0 message
+# decrypt_event($sock, $counter): decrypt one event frame from the
+# mock socket. Return the plaintext EVENT/1.0 message.
 sub decrypt_event ( $sock, $counter = 0 )
 {
 	my $frame  = $sock->{written};
@@ -550,7 +551,8 @@ sub decrypt_event ( $sock, $counter = 0 )
 }
 
 # flush_until($hap, $sock): run the coalescing flush until the socket
-# has data or the deadline passes (resilient to timing variations)
+# has data or the deadline passes. This makes the test resilient to
+# timing variations.
 sub flush_until ( $hap, $sock )
 {
 	require Time::HiRes;
@@ -570,8 +572,9 @@ subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
 	    dispatch( $hap, 'GET', '/accessories' );
 	my ( $aid, $iid ) = find_char( $json->decode($acc_body), '25' );
 
-	# Three encrypted sessions: a subscriber, the writer (also
-	# subscribed), and a bystander that never subscribes
+	# Three encrypted sessions: a subscriber, the writer, and a
+	# bystander. The writer is also subscribed. The bystander never
+	# subscribes.
 	my $sub_sock    = MockSocket->new;
 	my $sub_sess    = encrypted_session( $sub_sock, 'subscriber' );
 	my $writer_sock = MockSocket->new;
@@ -587,9 +590,9 @@ subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
 		is( $status, 204, 'subscription accepted' );
 	}
 
-	# A write through the PUT handler queues an event; the On type
-	# is not exempt from coalescing, so delivery happens on the
-	# post-window flush
+	# A write through the PUT handler queues an event. The On type
+	# is not exempt from coalescing. Thus delivery occurs on the
+	# post-window flush.
 	my $put = $json->encode( { characteristics =>
 		    [ { aid => $aid, iid => $iid, value => \1 } ] } );
 	my ( $status, undef, undef ) =
@@ -605,7 +608,7 @@ subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
 	is( $writer_sock->{written}, '',
 		'originating connection receives no event for its own write' );
 
-	# Decrypt the frame and check the EVENT/1.0 message format
+	# Decrypt the frame. Check the EVENT/1.0 message format.
 	my $plain = decrypt_event($sub_sock);
 	like( $plain, qr{^EVENT/1\.0 200 OK\r\n},
 		'event starts with EVENT/1.0 200 OK' );
@@ -618,7 +621,7 @@ subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
 	ok( $data->{characteristics}[0]{value},
 		'event carries the new value (true)' );
 
-	# Unsubscribing via ev:false stops delivery
+	# An unsubscribe via ev:false stops delivery
 	$sub_sock->{written} = '';
 	my $unsubscribe = $json->encode( { characteristics =>
 		    [ { aid => $aid, iid => $iid, ev => \0 } ] } );
@@ -633,7 +636,7 @@ subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
 	is( $sub_sock->{written}, '',
 		'unsubscribed session receives nothing' );
 
-	# A disconnecting session loses all its subscriptions
+	# A session that disconnects loses all its subscriptions
 	dispatch( $hap, 'PUT', '/characteristics', $subscribe, $sub_sess );
 	ok( exists $hap->{event_subscriptions}{"$aid.$iid"}{$sub_sess},
 		'session re-subscribed' );
@@ -641,7 +644,7 @@ subtest '[HAP-HTTP §14][HAP-HTTP §16.4] EVENT/1.0 notifications' => sub {
 	ok( !exists $hap->{event_subscriptions}{"$aid.$iid"}{$sub_sess},
 		'subscriptions purged on disconnect' );
 
-	# Event coalescing delay is 250ms
+	# The event coalescing delay is 250ms
 	is( OpenHAP::HAP::EVENT_COALESCE_DELAY(),
 		0.250, 'coalescing delay is 250ms' );
 };
@@ -670,8 +673,8 @@ subtest '[HAP-HTTP §14] device-side change delivers event with device aid'
 		    [ { aid => 2, iid => 11, ev => \1 } ] } );
 	dispatch( $hap, 'PUT', '/characteristics', $subscribe, $sub_sess );
 
-	# A Tasmota state report reaches the subscriber as an event
-	# carrying the device aid, not the bridge's
+	# A Tasmota state report reaches the subscriber as an event.
+	# The event carries the device aid, not the bridge aid.
 	$mqtt->simulate_message( 'stat/heater/POWER', 'ON' );
 	flush_until( $hap, $sub_sock );
 

--- a/t/conformance/hap-mdns.t
+++ b/t/conformance/hap-mdns.t
@@ -35,9 +35,9 @@ sub make_hap (%extra)
 
 subtest '[HAP-mDNS §1] service type is hap over tcp' => sub {
 
-	# openhapd publishes app 'hap' over proto 'tcp'; mdnsd itself
-	# prepends the underscores to form _hap._tcp.local. Browsing
-	# _hap._tcp is asserted by the mdns integration test.
+	# openhapd publishes app 'hap' over proto 'tcp'. mdnsd itself
+	# prepends the underscores to form _hap._tcp.local. The mdns
+	# integration test asserts the browse of _hap._tcp.
 	my $mdns = FuguLib::MDNS->new;
 	ok( !defined $mdns->publish_service(
 			name  => 'mDNS Bridge',
@@ -105,9 +105,10 @@ subtest '[HAP-mDNS §9] complete TXT record' => sub {
 
 subtest '[HAP-mDNS §10] bridge advertises a single service' => sub {
 
-	# One mDNS service covers the bridge and all bridged accessories;
-	# individual bridged accessories are not advertised separately.
-	# openhapd formats exactly one TXT string for that one service.
+	# One mDNS service covers the bridge and all bridged accessories.
+	# openhapd does not advertise individual bridged accessories
+	# separately. openhapd formats exactly one TXT string for that
+	# one service.
 	my $hap = make_hap();
 	my $txt = $hap->get_mdns_txt_string;
 	ok( length($txt), 'single TXT string for the bridge' );
@@ -144,7 +145,7 @@ subtest '[HAP-mDNS §3.5] protocol version' => sub {
 	my $hap = make_hap();
 
 	# pv=1 rather than 1.1: mdnsd uses '.' as the TXT record
-	# delimiter and cannot escape it; HomeKit accepts pv=1
+	# delimiter and cannot escape it. HomeKit accepts pv=1.
 	is( $hap->get_mdns_txt_records->{pv},
 		'1', 'pv advertised (1, see mdnsd delimiter note)' );
 };
@@ -192,8 +193,8 @@ subtest '[HAP-mDNS §4] service instance name' => sub {
 	is( $hap->get_mdns_txt_records->{md},
 		'mDNS Bridge', 'model name matches the display name' );
 
-	# The display name is the instance name openhapd publishes: it
-	# lands in the name field of the advertised service
+	# The display name is the instance name that openhapd publishes.
+	# It goes into the name field of the advertised service.
 	my $mdns = FuguLib::MDNS->new;
 	$mdns->{service} = {
 		name  => $hap->{name},
@@ -208,8 +209,8 @@ subtest '[HAP-mDNS §4] service instance name' => sub {
 
 subtest '[HAP-mDNS §6] port' => sub {
 
-	# The advertised port is whatever openhapd listens on; it rides
-	# in the port field of the service structure
+	# The advertised port is the port that openhapd listens on. It
+	# goes into the port field of the service structure.
 	my $mdns = FuguLib::MDNS->new;
 	$mdns->{service} = {
 		name  => 'x',

--- a/t/conformance/hap-pairing-exchange.t
+++ b/t/conformance/hap-pairing-exchange.t
@@ -1,9 +1,9 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Full pair-setup and pair-verify exchanges through
-# OpenHAP::Test::Controller wired in-process to an OpenHAP::HAP
-# instance (spec/HAP-Pairing.md). No crypto is mocked: the accessory
-# ends these tests actually paired.
+# Full pair-setup and pair-verify exchanges for spec/HAP-Pairing.md.
+# OpenHAP::Test::Controller connects in-process to an OpenHAP::HAP
+# instance. The tests do not mock the crypto. The accessory is really
+# paired when these tests end.
 
 use v5.36;
 use Test::More;
@@ -35,8 +35,9 @@ use_ok('OpenHAP::Test::Controller');
 my $PIN = '123-45-678';
 
 # Wire a controller to a fresh OpenHAP::HAP instance through an
-# in-process transport: requests are parsed and dispatched directly,
-# with one accessory-side session per controller connection.
+# in-process transport. The transport parses and dispatches requests
+# directly. Each controller connection gets one accessory-side
+# session.
 sub make_pair ( %controller_args )
 {
 	OpenHAP::Pairing->clear_pairing_state();
@@ -49,8 +50,8 @@ sub make_pair ( %controller_args )
 	);
 	$hap->{pairing}->reset_auth_attempts;
 
-	# Mirror _handle_client: the pair-verify M4 response is sent in
-	# the clear even though dispatch just enabled encryption
+	# Mirror _handle_client: dispatch just enabled encryption, but
+	# the transport sends the pair-verify M4 response in the clear
 	my $session   = OpenHAP::Session->new( socket => 'in-process' );
 	my $transport = sub ($request_bytes) {
 		my $was_encrypted = $session->is_encrypted;
@@ -118,7 +119,7 @@ subtest '[HAP-Pairing §2.4] already-paired M2 error' => sub {
 	my ( $controller, $hap, $session ) = make_pair();
 	ok( $controller->pair_setup, 'first pairing succeeds' );
 
-	# A second controller on a fresh connection is refused
+	# The accessory refuses a second controller on a fresh connection
 	my $session2   = OpenHAP::Session->new( socket => 'in-process-2' );
 	my $transport2 = sub ($request_bytes) {
 		my $request = OpenHAP::HTTP::parse($request_bytes);
@@ -149,7 +150,8 @@ subtest '[HAP-Pairing §3] pair-verify and key derivation' => sub {
 	is( $session->controller_id, 'openhap-test-ctrl',
 		'accessory knows the controller identity' );
 
-	# The derived keys interoperate: authenticated request succeeds
+	# The derived keys interoperate. The authenticated request
+	# succeeds.
 	my $response = $controller->request( 'GET', '/accessories' );
 	ok( defined $response, 'encrypted request round-trips' );
 	is( $response->{status}, 200,
@@ -166,17 +168,17 @@ subtest '[HAP-Pairing §7.2] remove-pairing and last-admin behavior' =>
 	ok( $controller->pair_setup,  'pair-setup completes' );
 	ok( $controller->pair_verify, 'pair-verify completes' );
 
-	# Add a second (non-admin) pairing, then list both
+	# Add a second non-admin pairing. Then list both pairings.
 	ok( $controller->add_pairing( 'user-ctrl', 'U' x 32, 0 ),
 		'[HAP-Pairing §7.1] admin adds a second pairing' );
 	my $pairings = $controller->list_pairings;
 	is( scalar @$pairings, 2, '[HAP-Pairing §7.3] two pairings listed' );
 
-	# Removing a pairing that does not exist returns success
+	# The removal of a pairing that does not exist returns success
 	ok( $controller->remove_pairing('ghost-ctrl'),
 		'removing nonexistent pairing succeeds' );
 
-	# Removing the last admin clears all pairings
+	# The removal of the last admin clears all pairings
 	my $old_ltpk = $hap->{accessory_ltpk};
 	ok( $controller->remove_pairing, 'admin removes itself' );
 	ok( !$hap->is_paired, 'all pairings removed with the last admin' );
@@ -190,8 +192,8 @@ subtest '[HAP-Pairing §2.4] re-pair after remove' => sub {
 	my ( $controller, $hap, $session ) = make_pair();
 	ok( $controller->pair_setup, 'first pairing' );
 
-	# Unpair directly through storage (the encrypted session died
-	# with the identity regeneration in the previous flow)
+	# Unpair directly through storage. The encrypted session died
+	# when the previous flow regenerated the identity.
 	$hap->{storage}->remove_all_pairings;
 	ok( !$hap->is_paired, 'unpaired again' );
 

--- a/t/conformance/hap-pairing-exchange.t
+++ b/t/conformance/hap-pairing-exchange.t
@@ -88,7 +88,7 @@ subtest '[HAP-Pairing §2.2][HAP-Pairing §2.8] full pair-setup M1-M6' =>
 	is( length( $controller->{accessory_ltpk} ),
 		32, 'accessory LTPK is a 32-byte Ed25519 key' );
 
-	# The accessory is actually paired now
+	# The accessory is paired now
 	ok( $hap->is_paired, 'accessory is paired after M6' );
 	my $pairings = $hap->{storage}->load_pairings;
 	ok( exists $pairings->{'openhap-test-ctrl'},

--- a/t/conformance/hap-pairing.t
+++ b/t/conformance/hap-pairing.t
@@ -2,10 +2,10 @@
 # ex:ts=8 sw=4:
 # Conformance tests for spec/HAP-Pairing.md
 #
-# The controller side of pair-setup and pair-verify is scripted inline
-# from the spec formulas (Math::BigInt for SRP, OpenHAP::Crypto
-# primitives for the rest), independent of the accessory-side modules
-# under test.
+# The tests script the controller side of pair-setup and pair-verify
+# inline from the spec formulas. They use Math::BigInt for SRP and
+# OpenHAP::Crypto primitives for the rest. The controller side is
+# independent of the accessory-side modules under test.
 
 use v5.36;
 use Test::More;
@@ -75,8 +75,8 @@ sub error_code ($response)
 	return defined $error ? unpack( 'C', $error ) : undef;
 }
 
-# Client-side SRP per HAP-Pairing.md §2.5, independent of OpenHAP::SRP
-# state. Returns (A_bytes, M1, K).
+# Do client-side SRP as HAP-Pairing.md §2.5 specifies. The function
+# does not use OpenHAP::SRP state. It returns (A_bytes, M1, K).
 sub client_srp ( $salt, $B_bytes, $pin )
 {
 	my $I = 'Pair-Setup';
@@ -110,7 +110,7 @@ sub client_srp ( $salt, $B_bytes, $pin )
 }
 
 # Drive pair-setup M1..M4 against a pairing handler with a given PIN.
-# Returns (m4_response, K, session).
+# It returns (m4_response, K, session).
 sub run_m1_to_m4 ( $pairing, $pin )
 {
 	my $session = OpenHAP::Session->new( socket => 'client' );
@@ -258,7 +258,7 @@ subtest '[HAP-Pairing §2][HAP-Pairing §2.1] pair setup state machine' =>
 	my ($pairing) = make_pairing();
 	my $session = OpenHAP::Session->new( socket => 'client' );
 
-	# Invalid state value is rejected
+	# The handler rejects an invalid state value
 	my $bogus = OpenHAP::TLV::encode(
 		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 99 ),
 	);
@@ -266,7 +266,7 @@ subtest '[HAP-Pairing §2][HAP-Pairing §2.1] pair setup state machine' =>
 		OpenHAP::Pairing::kTLVError_Unknown(),
 		'invalid state rejected with kTLVError_Unknown' );
 
-	# M3 without a preceding M1 is rejected
+	# The handler rejects M3 without a preceding M1
 	my $m3 = OpenHAP::TLV::encode(
 		OpenHAP::Pairing::kTLVType_State(),     pack( 'C', 3 ),
 		OpenHAP::Pairing::kTLVType_PublicKey(), 'A' x 384,
@@ -283,7 +283,7 @@ subtest '[HAP-Pairing §3.1] pair verify state machine' => sub {
 	my ($pairing) = make_pairing();
 	my $session = OpenHAP::Session->new( socket => 'client' );
 
-	# Invalid state value is rejected
+	# The handler rejects an invalid state value
 	my $bogus = OpenHAP::TLV::encode(
 		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 99 ),
 	);
@@ -291,7 +291,7 @@ subtest '[HAP-Pairing §3.1] pair verify state machine' => sub {
 		OpenHAP::Pairing::kTLVError_Unknown(),
 		'invalid state rejected with kTLVError_Unknown' );
 
-	# M3 without a preceding M1 is rejected
+	# The handler rejects M3 without a preceding M1
 	my $m3 = OpenHAP::TLV::encode(
 		OpenHAP::Pairing::kTLVType_State(), pack( 'C', 3 ),
 		OpenHAP::Pairing::kTLVType_EncryptedData(), 'X' x 32,
@@ -367,7 +367,8 @@ subtest '[HAP-Pairing §2.5][HAP-Pairing §2.6] M3 -> M4 SRP proof' => sub {
 	my $proof = tlv_field( $m4, OpenHAP::Pairing::kTLVType_Proof() );
 	is( length($proof), 64, 'M4 proof is 64 bytes (SHA-512)' );
 
-	# M2 = H(PAD(A) | M1 | K), verified client-side
+	# M2 = H(PAD(A) | M1 | K). The test verifies it on the client
+	# side.
 	is( unpack( 'H*', $proof ),
 		unpack( 'H*', sha512( $A . $M1 . $K ) ),
 		'server proof M2 = H(A | M1 | K) verifies' );
@@ -383,7 +384,7 @@ subtest '[HAP-Pairing §2.5][HAP-Pairing §2.6] M3 -> M4 SRP proof' => sub {
 		1, 'failed proof increments attempt counter' );
 	OpenHAP::Pairing->clear_pairing_state();
 
-	# A mod N == 0: rejected before proof verification
+	# A mod N == 0: the handler rejects it before proof verification
 	my ($pairing3) = make_pairing();
 	my $s = OpenHAP::Session->new( socket => 'client' );
 	my $m1 = OpenHAP::TLV::encode(
@@ -450,7 +451,7 @@ subtest '[HAP-Pairing §2.7][HAP-Pairing §2.8] M5 -> M6 exchange' => sub {
 		6, 'M6 has State 0x06' );
 	ok( !defined error_code($m6), 'M5 accepted' );
 
-	# Pairing persisted with admin permissions
+	# The accessory stores the pairing with admin permissions
 	my $pairings = $storage->load_pairings();
 	ok( exists $pairings->{$ios_id},
 		'[HAP-Pairing §6] controller pairing persisted' );
@@ -471,7 +472,8 @@ subtest '[HAP-Pairing §2.7][HAP-Pairing §2.8] M5 -> M6 exchange' => sub {
 		pack('x[4]') . 'PS-Msg06', $m6_data, $m6_tag );
 	ok( defined $m6_plain, 'M6 sub-TLV decrypts with PS-Msg06 nonce' );
 
-	# Verify accessory signature ([HAP-Pairing §4/Accessory Signature])
+	# Verify the accessory signature
+	# ([HAP-Pairing §4/Accessory Signature])
 	my %m6_inner = OpenHAP::TLV::decode($m6_plain);
 	my $acc_id =
 	    $m6_inner{ OpenHAP::Pairing::kTLVType_Identifier() };
@@ -572,7 +574,7 @@ subtest '[HAP-Pairing §3] pair-verify handshake' => sub {
 	);
 	my $m4 = $pairing->handle_pair_verify( $m3, $session );
 
-	# [HAP-Pairing §3.5] M4: success, session becomes encrypted
+	# [HAP-Pairing §3.5] M4: success. The session becomes encrypted.
 	is( unpack( 'C',
 		    tlv_field( $m4, OpenHAP::Pairing::kTLVType_State() ) ),
 		4, 'M4 has State 0x04' );
@@ -581,7 +583,8 @@ subtest '[HAP-Pairing §3] pair-verify handshake' => sub {
 	ok( $session->is_encrypted, 'session encryption enabled' );
 
 	# [HAP-Pairing §4/Session Read Key][HAP-Pairing §4/Session Write Key]
-	# Accessory encrypts with the Read key, decrypts with the Write key
+	# The accessory encrypts with the Read key and decrypts with the
+	# Write key
 	my $read_key =
 	    OpenHAP::Crypto::hkdf_sha512( $shared, 'Control-Salt',
 		'Control-Read-Encryption-Key', 32 );
@@ -597,7 +600,7 @@ subtest '[HAP-Pairing §3] pair-verify handshake' => sub {
 		'accessory-to-controller key is Control-Read-Encryption-Key'
 	);
 
-	# Unknown controller is rejected with 0x02
+	# The accessory rejects an unknown controller with 0x02
 	my $session2 = OpenHAP::Session->new( socket => 'client2' );
 	my ( $pairing2, $storage2 ) = make_pairing();
 	my $m2_2 = $pairing2->handle_pair_verify( $m1, $session2 );
@@ -632,7 +635,8 @@ subtest '[HAP-Pairing §8] authentication attempt limits' => sub {
 	    OpenHAP::Storage->new( db_path => tempdir( CLEANUP => 1 ) );
 	my ( $pairing, undef, undef ) = make_pairing($storage);
 
-	# Limit is 100 attempts; at the limit M1 returns 0x05 MaxTries
+	# The limit is 100 attempts. At the limit, M1 returns 0x05
+	# MaxTries.
 	is( OpenHAP::Pairing::MAX_AUTH_ATTEMPTS(),
 		100, 'maximum unsuccessful attempts is 100' );
 
@@ -646,7 +650,8 @@ subtest '[HAP-Pairing §8] authentication attempt limits' => sub {
 		OpenHAP::Pairing::kTLVError_MaxTries(),
 		'M1 at the limit returns 0x05 MaxTries' );
 
-	# Counter is stored persistently and survives restart
+	# The accessory stores the counter persistently. Thus the
+	# counter survives a restart.
 	my ($pairing2) = run_failed_attempt($storage);
 	is( $storage->get_auth_attempts, 1, 'failed attempt persisted' );
 
@@ -659,7 +664,8 @@ subtest '[HAP-Pairing §8] authentication attempt limits' => sub {
 	is( OpenHAP::Pairing->get_failed_attempts(),
 		1, 'attempt counter restored from storage on restart' );
 
-	# Reset only after a successful SRP proof verification
+	# The counter resets only after a successful SRP proof
+	# verification
 	my ( $pairing3, undef, undef ) = make_pairing($storage);
 	my ($m4) = run_m1_to_m4( $pairing3, $PIN );
 	ok( !defined error_code($m4), 'successful SRP proof' );
@@ -670,7 +676,7 @@ subtest '[HAP-Pairing §8] authentication attempt limits' => sub {
 	OpenHAP::Pairing->clear_pairing_state();
 };
 
-# Run a single failed pairing attempt (wrong PIN) against $storage
+# Run one failed pairing attempt with a wrong PIN against $storage
 sub run_failed_attempt ($storage)
 {
 	OpenHAP::Pairing->clear_pairing_state();

--- a/t/conformance/hap-pairing.t
+++ b/t/conformance/hap-pairing.t
@@ -367,7 +367,7 @@ subtest '[HAP-Pairing §2.5][HAP-Pairing §2.6] M3 -> M4 SRP proof' => sub {
 	my $proof = tlv_field( $m4, OpenHAP::Pairing::kTLVType_Proof() );
 	is( length($proof), 64, 'M4 proof is 64 bytes (SHA-512)' );
 
-	# M2 = H(PAD(A) | M1 | K). The test verifies it on the client
+	# M2 = H(PAD(A) | M1 | K). The test checks it on the client
 	# side.
 	is( unpack( 'H*', $proof ),
 		unpack( 'H*', sha512( $A . $M1 . $K ) ),
@@ -664,8 +664,8 @@ subtest '[HAP-Pairing §8] authentication attempt limits' => sub {
 	is( OpenHAP::Pairing->get_failed_attempts(),
 		1, 'attempt counter restored from storage on restart' );
 
-	# The counter resets only after a successful SRP proof
-	# verification
+	# The counter resets only after the SRP proof
+	# verification succeeds
 	my ( $pairing3, undef, undef ) = make_pairing($storage);
 	my ($m4) = run_m1_to_m4( $pairing3, $PIN );
 	ok( !defined error_code($m4), 'successful SRP proof' );

--- a/t/conformance/hap-services.t
+++ b/t/conformance/hap-services.t
@@ -2,8 +2,9 @@
 # ex:ts=8 sw=4:
 # Conformance tests for spec/HAP-Services.md
 #
-# Data-driven over the services OpenHAP implements; catalog rows are
-# cited as [HAP-Services §4/<Name>] and the UUID table as §6 rows.
+# The tests are data-driven over the services that OpenHAP
+# implements. The tests cite catalog rows as [HAP-Services §4/<Name>]
+# and UUID table entries as §6 rows.
 
 use v5.36;
 use Test::More;
@@ -22,7 +23,8 @@ use_ok('OpenHAP::Tasmota::Sensor');
 use_ok('OpenHAP::Tasmota::Thermostat');
 use_ok('OpenHAP::Tasmota::Lightbulb');
 
-# [HAP-Services §6] UUID table rows for every service OpenHAP defines
+# [HAP-Services §6] UUID table rows for every service that OpenHAP
+# defines
 my %uuid_table = (
 	AccessoryInformation => '3E',
 	ProtocolInformation  => 'A2',

--- a/t/conformance/hap-tlv8.t
+++ b/t/conformance/hap-tlv8.t
@@ -29,7 +29,7 @@ subtest '[HAP-TLV8 §2] fragmentation of long values' => sub {
 	# 500 bytes -> 255 + 245: 2 records with 2-byte headers each
 	is( length($encoded), 500 + 4, 'two records for 500 bytes' );
 
-	# First fragment must be exactly 255 bytes
+	# The first fragment must be exactly 255 bytes
 	my ( $t1, $l1 ) = unpack( 'CC', substr( $encoded, 0, 2 ) );
 	is( $t1, 0x03, 'first fragment has value type' );
 	is( $l1, 255,  'non-final fragment is exactly 255 bytes' );
@@ -38,7 +38,7 @@ subtest '[HAP-TLV8 §2] fragmentation of long values' => sub {
 	is( $t2, 0x03, 'second fragment has same type' );
 	is( $l2, 245,  'final fragment carries the remainder' );
 
-	# Decoder concatenates same-type records
+	# The decoder concatenates same-type records
 	my %decoded = OpenHAP::TLV::decode($encoded);
 	is( $decoded{0x03}, $value, 'fragments concatenated on decode' );
 };
@@ -67,7 +67,8 @@ subtest '[HAP-TLV8 §3] separators between list items' => sub {
 
 subtest '[HAP-TLV8 §4] value encodings' => sub {
 
-	# [HAP-TLV8 §4.1] integers are little-endian, minimum bytes
+	# [HAP-TLV8 §4.1] integers are little-endian and use the minimum
+	# bytes
 	is( unpack( 'H*', OpenHAP::TLV::encode( 0x0B, pack( 'C', 1 ) ) ),
 		'0b0101', '[HAP-TLV8 §4.1] integer 1 encodes as 01' );
 	is( unpack( 'H*', OpenHAP::TLV::encode( 0x0B, pack( 'v', 256 ) ) ),
@@ -189,7 +190,7 @@ subtest '[HAP-TLV8 §9] base64 encoding in JSON' => sub {
 
 subtest '[HAP-TLV8 §10] parser rules with hostile buffers' => sub {
 
-	# Rule 1: unknown types are preserved, not fatal
+	# Rule 1: the parser keeps unknown types. They are not fatal.
 	my %decoded =
 	    OpenHAP::TLV::decode( pack( 'H*', '060101' . 'aa0142' ) );
 	is( unpack( 'C', $decoded{0x06} ), 1, 'known type decoded' );

--- a/t/conformance/mdns-control.t
+++ b/t/conformance/mdns-control.t
@@ -99,8 +99,8 @@ subtest '[MDNS-Control §4] struct mdns_service against a literal' => sub {
 	};
 
 	# The test builds the whole buffer field by field at the spec's
-	# offsets: zeroed LIST_ENTRY, NUL padding of every fixed field,
-	# the internal padding at 858, and INADDR_ANY. A field-by-field
+	# offsets. It writes a zeroed LIST_ENTRY, NUL padding of every
+	# fixed field, the internal padding at 858, and INADDR_ANY. A field-by-field
 	# comparison would pass even with the total size or padding
 	# wrong. Thus the assertion is on the entire 864 bytes.
 	my $expected = "\0" x 864;

--- a/t/conformance/mdns-control.t
+++ b/t/conformance/mdns-control.t
@@ -16,14 +16,16 @@ use_ok('FuguLib::Imsg');
 use_ok('FuguLib::MDNS');
 
 # The layout literals below are LP64 and little-endian, as measured
-# for the platforms OpenHAP deploys to; on anything else the daemon's
-# own struct differs and byte-exact replay is meaningless
+# for the platforms that OpenHAP deploys to. On other platforms the
+# daemon's own struct differs. There a byte-exact replay is
+# meaningless.
 my $lp64_le = $Config{ptrsize} == 8
     && unpack( 'S', "\x01\x00" ) == 1;
 
 # harness(%replies): a FuguLib::MDNS whose connection is one end of a
-# socketpair, with the given replies already queued on the peer end.
-# Returns ($mdns, $peer) - sent bytes are read back from $peer.
+# socketpair. The harness queues the given replies on the peer end.
+# It returns ($mdns, $peer). Tests read the sent bytes back from
+# $peer.
 sub harness (@reply_types)
 {
 	socketpair( my $a, my $b, AF_UNIX, SOCK_STREAM, PF_UNSPEC )
@@ -54,7 +56,7 @@ sub publish_example ($mdns)
 	);
 }
 
-# read_all($peer): drain everything the client sent
+# read_all($peer): drain everything that the client sent
 sub read_all ($peer)
 {
 	my $wire = '';
@@ -96,11 +98,11 @@ subtest '[MDNS-Control §4] struct mdns_service against a literal' => sub {
 		txt   => 'c#=1.sf=1',
 	};
 
-	# The whole buffer, built field by field at the spec's offsets:
-	# zeroed LIST_ENTRY, NUL padding of every fixed field, the
-	# internal padding at 858, and INADDR_ANY - a field-by-field
+	# The test builds the whole buffer field by field at the spec's
+	# offsets: zeroed LIST_ENTRY, NUL padding of every fixed field,
+	# the internal padding at 858, and INADDR_ANY. A field-by-field
 	# comparison would pass even with the total size or padding
-	# wrong, so the assertion is on the entire 864 bytes
+	# wrong. Thus the assertion is on the entire 864 bytes.
 	my $expected = "\0" x 864;
 	substr( $expected, 16,  3 )  = 'hap';
 	substr( $expected, 80,  3 )  = 'tcp';
@@ -134,8 +136,9 @@ subtest '[MDNS-Control §10] the publish conversation, byte-exact' => sub {
 	my $name_payload = 'OpenHAP Bridge' . ( "\0" x 242 );
 
 	# Message 1: GROUP_ADD. The pid bytes are sender-specific
-	# [MDNS-Imsg §3], so they are asserted as the test process's
-	# pid and the rest byte-for-byte against the spec literal
+	# [MDNS-Imsg §3]. Thus the test asserts them as the test
+	# process's pid. The test asserts the rest byte-for-byte against
+	# the spec literal.
 	my $m1 = substr( $wire, 0, 272 );
 	is( substr( $m1, 0, 4 ), "\x08\x00\x00\x00", 'type = 8' );
 	is( substr( $m1, 4, 4 ), "\x10\x01\x00\x00", 'len = 272' );
@@ -168,8 +171,8 @@ subtest '[MDNS-Control §10] the publish conversation, byte-exact' => sub {
 
 subtest '[MDNS-Control §6.1] progress replies are not terminal' => sub {
 
-	# PROBING and ANNOUNCING alone do not finish the publish; only
-	# PUBLISHED does
+	# PROBING and ANNOUNCING alone do not finish the publish. Only
+	# PUBLISHED does.
 	my ( $mdns, $peer ) = harness( 15, 16 );
 	ok( !defined $mdns->publish_service(
 			name  => 'OpenHAP Bridge',
@@ -205,8 +208,9 @@ subtest '[MDNS-Control §7] group name equals the instance name' => sub {
 	is( $group, $name,
 		'GROUP_ADD payload and struct name field are identical' );
 
-	# The unusable combination is inexpressible: publish_service
-	# has no separate group parameter to disagree with the name
+	# The API cannot express the unusable combination:
+	# publish_service has no separate group parameter to disagree
+	# with the name
 	ok( !FuguLib::MDNS->can('publish_group'),
 		'no API takes a separate group name' );
 };
@@ -278,7 +282,7 @@ subtest '[MDNS-Control §5] TXT travels as one verbatim string' => sub {
 	    unless $lp64_le;
 
 	# Several key=value pairs joined with '.' are a single wire
-	# field; nothing is escaped or re-encoded
+	# field. The code does not escape or re-encode anything.
 	my $mdns = FuguLib::MDNS->new;
 	$mdns->{service} = {
 		name  => 'x',

--- a/t/conformance/mdns-imsg.t
+++ b/t/conformance/mdns-imsg.t
@@ -10,8 +10,8 @@ use Socket qw(AF_UNIX SOCK_STREAM PF_UNSPEC);
 
 use_ok('FuguLib::Imsg');
 
-# pair(): a FuguLib::Imsg endpoint and the raw peer handle, so tests
-# can capture and inject wire bytes
+# pair(): a FuguLib::Imsg endpoint and the raw peer handle. Thus
+# tests can capture and inject wire bytes.
 sub pair ()
 {
 	socketpair( my $a, my $b, AF_UNIX, SOCK_STREAM, PF_UNSPEC )
@@ -26,8 +26,9 @@ subtest '[MDNS-Imsg §1] header is four uint32 fields in order' => sub {
 
 	is( length($hdr), 16, 'IMSG_HEADER_SIZE is 16' );
 
-	# Field layout, not byte order: each field occupies its own
-	# 4-byte slot at the measured offset, whatever the host order
+	# Field layout, not byte order: each field is in its own 4-byte
+	# slot at the measured offset. The host byte order does not
+	# matter.
 	is( unpack( 'L', substr( $hdr, 0, 4 ) ),
 		0x11223344, 'type at offset 0' );
 	is( unpack( 'L', substr( $hdr, 4, 4 ) ),
@@ -62,7 +63,7 @@ subtest '[MDNS-Imsg §2] receiver masks the fd mark off len' => sub {
 	my ( $imsg, $peer ) = pair();
 
 	# A message whose len carries IMSG_FD_MARK still frames
-	# correctly once the mark is masked
+	# correctly after the receiver masks off the mark
 	my $marked = pack( 'L4', 7, ( 16 + 4 ) | 0x80000000, 0, 1 ) . 'data';
 	syswrite $peer, $marked;
 	my $msg = $imsg->recv( timeout => 5 );
@@ -98,7 +99,7 @@ subtest '[MDNS-Imsg §4] short reads accumulate across calls' => sub {
 
 	my $wire = pack( 'L4', 15, 16 + 6, 0, 1 ) . 'abcdef';
 
-	# Header split mid-field, then the rest
+	# Send the header split mid-field. Then send the rest.
 	syswrite $peer, substr( $wire, 0, 10 );
 	ok( !defined $imsg->recv( timeout => 0.1 ),
 		'partial header is not a message yet' );

--- a/t/conformance/mqtt-control.t
+++ b/t/conformance/mqtt-control.t
@@ -96,7 +96,7 @@ subtest '[MQTT-Control §1] multi-relay and SetOption26' => sub {
 	is( $so26->_get_power_key, 'POWER1',
 		'SetOption26 uses POWER1 even for a single relay' );
 
-	# FullTopic composes with relay index
+	# FullTopic composes with the relay index
 	my $custom = OpenHAP::Tasmota::Base->new(
 		aid         => 5,
 		name        => 'Custom',
@@ -182,7 +182,7 @@ subtest '[MQTT-Control §3.2] Color RGB formats' => sub {
 	$mqtt->simulate_message( 'stat/light/RESULT', '{"Color":"0,0,255"}' );
 	is( $light->{hue}, 240, 'decimal color blue parsed (hue 240)' );
 
-	# RGB -> HSB conversion per the spec value ranges
+	# RGB -> HSB conversion follows the spec value ranges
 	my ( $h, $s, $b ) = $light->_rgb_to_hsb( 255, 0, 0 );
 	is_deeply( [ $h, $s, $b ], [ 0, 100, 100 ],
 		'pure red is 0,100,100' );
@@ -203,7 +203,7 @@ subtest '[MQTT-Control §4] color temperature range' => sub {
 		'CT command topic' );
 	is( last_published($mqtt)->{payload}, '300', 'CT in mireds' );
 
-	# Range is 153..500 mireds
+	# The range is 153..500 mireds
 	$mqtt->clear_published;
 	$light->_set_ct(100);
 	is( last_published($mqtt)->{payload},
@@ -232,14 +232,14 @@ subtest '[MQTT-Control §5] status queries' => sub {
 		'Status 10 (sensor information) queried on subscribe'
 	);
 
-	# STATUS8 (legacy sensor) responses are handled
+	# The thermostat parses STATUS8 (legacy sensor) responses
 	$mqtt->simulate_message( 'stat/thermostat/STATUS8',
 		'{"StatusSNS":{"DS18B20":{"Temperature":23},"TempUnit":"C"}}'
 	);
 	is( $thermostat->{current_temp}, 23,
 		'STATUS8 response updates temperature' );
 
-	# STATUS10 responses are handled
+	# The sensor parses STATUS10 responses
 	my $sensor = OpenHAP::Tasmota::Sensor->new(
 		aid         => 3,
 		name        => 'Sensor',
@@ -256,7 +256,7 @@ subtest '[MQTT-Control §5] status queries' => sub {
 	is( $sensor->{current_temp}, 26,
 		'STATUS10 response updates temperature' );
 
-	# STATUS11 (full state) responses are handled
+	# The heater parses STATUS11 (full state) responses
 	my $heater = make_heater($mqtt);
 	$heater->subscribe_mqtt;
 	ok( ( grep { $_ eq 'stat/device/STATUS11' }

--- a/t/conformance/mqtt-sensors.t
+++ b/t/conformance/mqtt-sensors.t
@@ -68,18 +68,18 @@ subtest '[MQTT-Sensors §3] temperature sensors' => sub {
 	my $mqtt   = OpenHAP::TestMock::MQTT->new;
 	my $sensor = make_sensor($mqtt);
 
-	# TempUnit C is passed through
+	# The sensor passes TempUnit C readings through
 	$mqtt->simulate_message( 'tele/sensor/SENSOR',
 		'{"DS18B20":{"Temperature":25},"TempUnit":"C"}' );
 	is( $sensor->{current_temp}, 25, 'Celsius reading passed through' );
 
-	# TempUnit F is converted before use in HomeKit
+	# The sensor converts TempUnit F readings before use in HomeKit
 	$mqtt->simulate_message( 'tele/sensor/SENSOR',
 		'{"DS18B20":{"Temperature":77},"TempUnit":"F"}' );
 	ok( abs( $sensor->{current_temp} - 25 ) < 0.1,
 		'TempUnit F converted to Celsius (77F = 25C)' );
 
-	# The conversion helper handles the boundary case
+	# The conversion helper converts the boundary case correctly
 	my $base = OpenHAP::Tasmota::Base->new(
 		aid         => 9,
 		name        => 'Conv',
@@ -103,7 +103,7 @@ subtest '[MQTT-Sensors §3] temperature sensors' => sub {
 	is( $indexed->{current_temp}, 25,
 		'indexed sensor DS18B20-2 selected' );
 
-	# Sensor Id field is tracked
+	# The module tracks the sensor Id field
 	$mqtt->simulate_message( 'tele/sensor/SENSOR',
 		'{"DS18B20":{"Id":"01131B123456","Temperature":22.5},'
 		    . '"TempUnit":"C"}' );

--- a/t/conformance/mqtt-state.t
+++ b/t/conformance/mqtt-state.t
@@ -132,7 +132,8 @@ subtest '[MQTT-State §5.2] reconnection strategy' => sub {
 	my $mqtt   = OpenHAP::TestMock::MQTT->new;
 	my $heater = make_heater($mqtt);
 
-	# On LWT Online, subscriptions exist and the state is re-queried
+	# On LWT Online, the subscriptions exist. The accessory queries
+	# the state again.
 	$mqtt->clear_published;
 	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );
 	ok(

--- a/t/conformance/mqtt-transport.t
+++ b/t/conformance/mqtt-transport.t
@@ -71,7 +71,8 @@ subtest '[MQTT-Transport §1.3] topic tokens' => sub {
 	my $mqtt = OpenHAP::TestMock::MQTT->new;
 	my $base = make_base( $mqtt, fulltopic => 'home/%topic%/%prefix%/' );
 
-	# %topic% replaced by device topic, %prefix% by cmnd/stat/tele
+	# The builder replaces %topic% with the device topic and
+	# %prefix% with cmnd/stat/tele
 	my $built = $base->_build_topic( 'tele', 'SENSOR' );
 	like( $built, qr{home/device/tele/SENSOR},
 		'%topic% and %prefix% tokens substituted' );
@@ -113,7 +114,8 @@ subtest '[MQTT-Transport §2.3] query pattern' => sub {
 	my $base = make_base($mqtt);
 	$base->subscribe_mqtt;
 
-	# On LWT Online the device state is queried with Status 11
+	# On LWT Online, the accessory queries the device state with
+	# Status 11
 	$mqtt->clear_published;
 	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );
 	ok(
@@ -135,7 +137,8 @@ subtest '[MQTT-Transport §2.4] bidirectional flow' => sub {
 	);
 	$heater->subscribe_mqtt;
 
-	# Command out on cmnd/, state back in on stat/
+	# The command goes out on cmnd/. The state comes back in on
+	# stat/.
 	$mqtt->clear_published;
 	$heater->set_power(1);
 	ok( ( grep { $_->{topic} =~ m{^cmnd/} } $mqtt->get_published ),
@@ -200,7 +203,8 @@ subtest '[MQTT-Transport §5][MQTT-Transport §5.2] reconnection state refresh' 
 	my $base = make_base($mqtt);
 	$base->subscribe_mqtt;
 
-	# After an Offline/Online cycle the state is re-queried
+	# After an Offline/Online cycle, the accessory queries the state
+	# again
 	$mqtt->simulate_message( 'tele/device/LWT', 'Offline' );
 	$mqtt->clear_published;
 	$mqtt->simulate_message( 'tele/device/LWT', 'Online' );

--- a/t/fugulib/imsg.t
+++ b/t/fugulib/imsg.t
@@ -81,8 +81,8 @@ subtest 'write after peer close returns undef, does not die' => sub {
 
 	my $lived = eval {
 
-		# The first write may land in the socket buffer; a
-		# second is guaranteed to raise EPIPE
+		# The first write can land in the socket buffer. A
+		# second write always raises EPIPE.
 		$tx->send( type => 1, data => 'x' );
 		my $r = $tx->send( type => 1, data => 'x' );
 		ok( !defined $r, 'send to a closed peer returns undef' );
@@ -104,7 +104,8 @@ subtest 'invalid length poisons the connection' => sub {
 	    or die "socketpair: $!";
 	my $rx = FuguLib::Imsg->new( fh => $b );
 
-	# len = 4: below IMSG_HEADER_SIZE, invalid per the framing
+	# A len of 4 is less than IMSG_HEADER_SIZE. The framing makes
+	# it invalid.
 	syswrite $a, pack( 'L4', 1, 4, 0, 0 );
 	ok( !defined $rx->recv( timeout => 5 ), 'invalid len yields undef' );
 	ok( !defined $rx->recv( timeout => 0.1 ),

--- a/t/fugulib/log.t
+++ b/t/fugulib/log.t
@@ -19,7 +19,7 @@ use_ok('FuguLib::Log');
 	my $log = FuguLib::Log->new( mode => 'quiet' );
 	ok( defined $log, 'Created quiet logger' );
 
-	# Capture STDERR to prove quiet mode produces no output
+	# Capture STDERR to show that the quiet mode writes no output
 	my $stderr = '';
 	{
 		local *STDERR;
@@ -34,7 +34,8 @@ use_ok('FuguLib::Log');
 {
 	my $log = FuguLib::Log->new( mode => 'quiet', level => 'warning' );
 
-	# Can't easily test output, but can verify methods exist
+	# A direct test of the output is not easy. Make sure that the
+	# methods exist.
 	eval {
 		$log->debug('debug message');
 		$log->info('info message');

--- a/t/fugulib/mdns.t
+++ b/t/fugulib/mdns.t
@@ -18,7 +18,8 @@ use_ok('FuguLib::MDNS');
 my $dir = tempdir( CLEANUP => 1 );
 my $n   = 0;
 
-# Group reply types, mirroring FuguLib::MDNS's pinned enum
+# Group reply types. These values mirror the pinned enum in
+# FuguLib::MDNS.
 my %REPLY = (
 	collision  => 12,
 	not_found  => 13,
@@ -29,13 +30,13 @@ my %REPLY = (
 );
 
 # start_server($behavior):
-#	Fork a fake mdnsd on a fresh socket path. The listener is
-#	created before the fork so the client can connect immediately.
-#	$behavior->($conn_no, $imsg, $dump_fh) runs per accepted
-#	connection and returns 0 to stop accepting. Received messages
-#	are asserted from the dump file in the parent - never from the
-#	child, which shares the TAP stream.
-#	Returns ($path, $dump_file, $pid).
+#	Fork a fake mdnsd on a fresh socket path. The function creates
+#	the listener before the fork. Thus the client can connect
+#	immediately. $behavior->($conn_no, $imsg, $dump_fh) runs once
+#	for each accepted connection. It returns 0 to stop the accept
+#	loop. The parent asserts the received messages from the dump
+#	file. The child shares the TAP stream, so the child never
+#	asserts. The function returns ($path, $dump_file, $pid).
 sub start_server ($behavior)
 {
 	my $path = "$dir/mdnsd" . $n . '.sock';
@@ -67,8 +68,8 @@ sub start_server ($behavior)
 }
 
 # dump_messages($imsg, $fh, $count):
-#	Read $count messages, log type, payload size and the leading
-#	NUL-terminated string of each payload
+#	Read $count messages. Log the type, the payload size, and the
+#	leading NUL-terminated string of each payload.
 sub dump_messages ( $imsg, $fh, $count )
 {
 	my @msgs;
@@ -83,7 +84,7 @@ sub dump_messages ( $imsg, $fh, $count )
 }
 
 # reply($imsg, $name, @types):
-#	Send group replies carrying the 256-byte padded group name
+#	Send group replies that carry the 256-byte padded group name.
 sub reply ( $imsg, $name, @types )
 {
 	$imsg->send( type => $REPLY{$_}, data => pack( 'Z256', $name ) )
@@ -225,7 +226,8 @@ subtest 'over-length fields are errors, not truncations' => sub {
 	ok( !defined $mdns->publish_service( %service, txt => 'x' x 256 ),
 		'256-byte TXT string is rejected' );
 
-	# The wire port field is a u16; pack would truncate modulo 65536
+	# The wire port field is a u16. Without a check, pack truncates
+	# the value modulo 65536.
 	ok( !defined $mdns->publish_service( %service, port => 70000 ),
 		'port above 65535 is rejected, not truncated' );
 	like( $mdns->error, qr/port out of range/, 'error says why' );
@@ -233,10 +235,11 @@ subtest 'over-length fields are errors, not truncations' => sub {
 
 subtest 'republish on a held connection is refused' => sub {
 
-	# mdnsd ignores the duplicate GROUP_ADD, drops the ADD_SERVICE,
-	# and answers the COMMIT with a success-looking sequence for the
-	# old records - so publish_service must not be callable while
-	# published; replacement goes through update_txt
+	# mdnsd ignores the duplicate GROUP_ADD and drops the
+	# ADD_SERVICE. It answers the COMMIT with a success-looking
+	# sequence for the old records. Thus publish_service must refuse
+	# calls while a service is published. Replacement goes through
+	# update_txt.
 	my ( $path, $dump, $pid ) = start_server(
 		sub ( $, $imsg, $fh ) {
 			my $msgs = dump_messages( $imsg, $fh, 3 ) or return 0;

--- a/t/fugulib/privdrop.t
+++ b/t/fugulib/privdrop.t
@@ -46,16 +46,17 @@ SKIP: {
 SKIP: {
 	skip 'Must be root to test actual privilege dropping', 5 unless $> == 0;
 	
-	# This test would actually drop privileges, which would affect the rest of the test suite
-	# So we skip it in normal test runs. It should be tested manually or in isolation.
+	# This test drops privileges for real. That has an effect on
+	# the rest of the test suite. Thus normal test runs skip it.
+	# Test it manually or in isolation.
 	skip 'Actual privilege drop test skipped (would affect other tests)', 5;
 	
-	# If we were to test this:
+	# A manual test does these steps:
 	# - Fork a child process
-	# - In child, call drop_privileges
-	# - Verify UID/GID changed
-	# - Verify cannot regain root
-	# - Exit child
+	# - In the child, call drop_privileges
+	# - Make sure that the UID and the GID have changed
+	# - Make sure that the child cannot get root again
+	# - Exit the child
 }
 
 done_testing();

--- a/t/fugulib/privdrop.t
+++ b/t/fugulib/privdrop.t
@@ -32,7 +32,7 @@ SKIP: {
 	like( $@, qr/Cannot get GID for group/, 'drop_privileges fails with invalid group' );
 }
 
-# Test 5: drop_privileges when already non-root (should be no-op)
+# Test 5: drop_privileges when already non-root (a no-op)
 SKIP: {
 	skip 'Running as root, cannot test non-root behavior', 1 if $> == 0;
 	

--- a/t/fugulib/process.t
+++ b/t/fugulib/process.t
@@ -30,7 +30,8 @@ use_ok('FuguLib::Process');
 
 # Test 3: Process that exits immediately with non-zero (failure)
 SKIP: {
-	# This test is OS-dependent - sh -c may or may not exit immediately
+	# This test is OS-dependent. The sh -c command can exit
+	# immediately, but this is not certain.
 	skip 'Process exit timing varies by OS', 3;
 
 	my $result = FuguLib::Process->spawn_command(
@@ -86,13 +87,13 @@ SKIP: {
 
 # Test 7: Zombie reaping
 {
-	# Spawn and let it exit
+	# Spawn a process and let it exit
 	my $result = FuguLib::Process->spawn_command(
 		cmd         => [ 'true' ],
 		check_alive => 0,
 	);
 
-	sleep 1;    # Let it exit
+	sleep 1;    # Let the process exit
 
 	my $reaped = FuguLib::Process->reap( $result->{pid} );
 	ok( $reaped, 'Reaped zombie process' );
@@ -133,7 +134,7 @@ SKIP: {
 
 # Test 11: Graceful vs forced termination
 {
-	# Process that ignores SIGTERM (sleep handles it)
+	# A process that ignores SIGTERM (sleep handles it)
 	my $result = FuguLib::Process->spawn_command(
 		cmd         => [ 'sleep', '300' ],
 		check_alive => 0,
@@ -154,7 +155,7 @@ SKIP: {
 		FuguLib::Process->spawn_command( cmd => ['true'], check_alive => 0 );
 	}
 
-	sleep 1;    # Let them all exit
+	sleep 1;    # Let all the processes exit
 
 	my $count = FuguLib::Process->reap_all();
 	cmp_ok( $count, '>=', 0, 'Reaped zombies' );

--- a/t/fugulib/process.t
+++ b/t/fugulib/process.t
@@ -132,7 +132,7 @@ SKIP: {
 	FuguLib::Process->terminate( $result->{pid} );
 }
 
-# Test 11: Graceful vs forced termination
+# Test 11: Graceful and forced termination
 {
 	# A process that ignores SIGTERM (sleep handles it)
 	my $result = FuguLib::Process->spawn_command(

--- a/t/fugulib/sandbox.t
+++ b/t/fugulib/sandbox.t
@@ -1,11 +1,11 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Unit tests for FuguLib::Sandbox: the no-op contract everywhere, real
-# enforcement on OpenBSD. Enforcement runs in child processes because
-# a pledge violation kills the violator with an uncatchable SIGABRT
-# and unveil restricts the caller for good - the parent must stay
-# unrestricted or it takes the rest of the suite down. Never assert in
-# the children: they share the TAP stream.
+# Unit tests for FuguLib::Sandbox: the no-op contract everywhere,
+# real enforcement on OpenBSD. Enforcement runs in child processes.
+# A pledge violation kills the violator with an uncatchable SIGABRT.
+# An unveil restricts the caller permanently. The parent must stay
+# unrestricted, or it takes down the rest of the suite. Never assert
+# in the children. The children share the TAP stream.
 
 use v5.36;
 use Test::More;
@@ -20,12 +20,12 @@ my $lib = "$RealBin/../../lib";
 my $dir = tempdir( CLEANUP => 1 );
 
 # run_child($source):
-#	Run perl code in a subprocess with core dumps disabled - the
-#	SIGABRT from a pledge violation would otherwise drop perl.core
-#	into the repository root. The shell must exec perl rather than
-#	fork it: a forked child's death-by-signal is reaped by the
-#	shell and reported as exit code 134, losing the signal from
-#	the wait status this returns.
+#	Run perl code in a subprocess with core dumps disabled.
+#	Without this, the SIGABRT from a pledge violation drops
+#	perl.core into the repository root. The shell must exec perl,
+#	not fork it. The shell reaps a forked child's death-by-signal
+#	and reports exit code 134. That loses the signal from the wait
+#	status this function returns.
 sub run_child ($source)
 {
 	my $script = "$dir/child-$$-" . int( rand 10000 ) . '.pl';
@@ -39,10 +39,10 @@ sub run_child ($source)
 	return $?;
 }
 
-# The child sources, rendered at file scope so the compile subtest
-# below syntax-checks them on every platform: the children themselves
-# only ever run on OpenBSD, and a heredoc interpolation slip in one
-# once hid until a VM run.
+# The test defines the child sources at file scope. Thus the compile
+# subtest below syntax-checks them on every platform. The children
+# themselves only run on OpenBSD. A heredoc interpolation slip in one
+# once stayed hidden until a VM run.
 my $violation_child = <<'EOF';
 use v5.36;
 use FuguLib::Sandbox;
@@ -53,8 +53,8 @@ socket(my $s, AF_INET, SOCK_STREAM, 0);
 POSIX::_exit(0);    # only reachable if the pledge did not enforce
 EOF
 
-# Exit codes pick the failing step apart: 1 = a file outside the view
-# stayed readable, 2 = the file inside did not
+# The exit codes identify the failing step. Exit 1: a file outside
+# the view stayed readable. Exit 2: the file inside did not open.
 my $unveil_child = <<EOF . <<'BODY';
 use v5.36;
 use FuguLib::Sandbox;
@@ -68,8 +68,9 @@ POSIX::_exit(2) unless open(my $in, '<', "$dir/inside.txt");
 POSIX::_exit(0);
 BODY
 
-# 3 = a missing required path was silently accepted, 4 = a missing
-# optional path was not skipped cleanly, 5 = on_skip did not report it
+# Exit 3: unveil silently accepted a missing required path. Exit 4:
+# unveil did not skip a missing optional path cleanly. Exit 5:
+# on_skip did not report the skipped path.
 my $dispositions_child = <<EOF . <<'BODY';
 use v5.36;
 use FuguLib::Sandbox;
@@ -144,7 +145,7 @@ subtest 'no-op platforms return success from every method' => sub {
 		1, 'unveil is a successful no-op' );
 	is( FuguLib::Sandbox->unveil_lock, 1, 'lock is a successful no-op' );
 
-	# And none of them restricted anything
+	# None of the methods restricted anything
 	ok( open( my $fh, '<', $0 ), 'filesystem still fully visible' );
 	close $fh if $fh;
 };
@@ -156,15 +157,15 @@ subtest 'pledge violation aborts the violator' => sub {
 	my $status = run_child($violation_child);
 	is( $status & 127, SIGABRT,
 		'socket(2) outside the promise set delivers SIGABRT' );
-	unlink 'perl.core';    # belt and braces: ulimit already forbids it
+	unlink 'perl.core';    # a second guard: ulimit already forbids it
 };
 
 subtest 'a bogus promise string dies rather than being accepted' => sub {
 	plan skip_all => 'pledge(2) only enforced on OpenBSD'
 	    unless FuguLib::Sandbox->is_supported;
 
-	# An unknown promise fails with EINVAL before anything is
-	# restricted, so this is safe in-process
+	# An unknown promise fails with EINVAL before any restriction
+	# starts. Thus this test is safe in-process.
 	ok( !eval {
 		FuguLib::Sandbox->pledge( promises => 'nosuchpromise' );
 		1;

--- a/t/fugulib/signal.t
+++ b/t/fugulib/signal.t
@@ -43,7 +43,7 @@ use_ok('FuguLib::Signal');
 	ok( !FuguLib::Signal::check_interrupted(), 'Not interrupted before signal' );
 
 	kill 'USR1', $$;
-	sleep 0.1;    # Give signal time to be delivered
+	sleep 0.1;    # Give the signal time to arrive
 
 	ok( FuguLib::Signal::check_interrupted(), 'Interrupted after signal' );
 
@@ -64,7 +64,7 @@ use_ok('FuguLib::Signal');
 		}
 	);
 
-	# Manually trigger cleanup
+	# Trigger the cleanup manually
 	$sig->_run_cleanup_handlers('TEST');
 
 	is( $cleanup_called, 1,      'Cleanup handler called' );

--- a/t/fuguvm/cli.t
+++ b/t/fuguvm/cli.t
@@ -9,7 +9,7 @@ use File::Path qw(make_path);
 use File::Temp qw(tempdir);
 use Cwd qw(getcwd);
 
-# CLI depends on SSH which requires Net::SSH2
+# The CLI depends on SSH, which requires Net::SSH2
 BEGIN {
     eval { require Net::SSH2 };
     if ($@) {
@@ -30,7 +30,7 @@ use_ok('FuguVM::Proxy::Cache');
 
 # Test unknown command returns error (exit code 2 = invalid args)
 {
-    # Suppress warning
+    # Suppress the warning
     local $SIG{__WARN__} = sub {};
     my $result = FuguVM::CLI->run('unknown_command');
     is($result, 2, 'unknown command returns invalid args exit code');
@@ -77,7 +77,7 @@ SKIP: {
     my $orig_dir = getcwd();
     chdir $tmpdir;
     
-    # Initialize project first
+    # Initialize the project first
     FuguVM::CLI->run('init');
     
     local $SIG{__WARN__} = sub {};
@@ -94,7 +94,7 @@ SKIP: {
     my $orig_dir = getcwd();
     chdir $tmpdir;
     
-    # Initialize project first
+    # Initialize the project first
     FuguVM::CLI->run('init');
     
     local $SIG{__WARN__} = sub {};
@@ -111,7 +111,7 @@ SKIP: {
     my $orig_dir = getcwd();
     chdir $tmpdir;
     
-    # Initialize project first
+    # Initialize the project first
     FuguVM::CLI->run('init');
     
     local $SIG{__WARN__} = sub {};
@@ -128,7 +128,7 @@ SKIP: {
     my $orig_dir = getcwd();
     chdir $tmpdir;
     
-    # Initialize project first
+    # Initialize the project first
     FuguVM::CLI->run('init');
     
     my $long_name = 'x' x 10000;
@@ -168,14 +168,14 @@ SKIP: {
 	2, 'unknown cache clear option returns EXIT_INVALID_ARGS');
 }
 
-# Listing an empty cache mirrors 'image list'
+# A 'cache list' on an empty cache mirrors 'image list'
 {
     my $project = _cache_project();
     is(FuguVM::CLI->run("--project=$project", '--quiet', 'cache', 'list'),
 	0, 'cache list on an empty cache succeeds');
 }
 
-# clear removes everything; clear --stale keeps the invoked VM's key
+# clear removes everything. clear --stale keeps the invoked VM's key.
 {
     my $project = _cache_project();
     my $cache = FuguVM::ImageCache->new("$project/cache");
@@ -204,9 +204,9 @@ SKIP: {
     is(scalar @{ $cache->list }, 0, 'bare clear removes everything');
 }
 
-# The proxy's downloads share cache_dir with the images and nothing else
-# bounds them, so the same command prunes both: --stale keeps the OpenBSD
-# version the invoked VM installs, bare clear keeps nothing
+# The proxy's downloads share cache_dir with the images, and nothing
+# else bounds them. Thus the same command prunes both. --stale keeps the
+# OpenBSD version the invoked VM installs. A bare clear keeps nothing.
 {
     my $project = _cache_project();
     my $proxy = FuguVM::Proxy::Cache->new("$project/cache");
@@ -228,8 +228,8 @@ SKIP: {
     is(scalar @{ $proxy->list }, 0, 'bare clear empties the proxy too');
 }
 
-# Listing reports the proxy as well, so neither half of cache_dir is
-# invisible to someone deciding whether to prune
+# The listing also reports the proxy. Thus a user who decides on a
+# prune sees both halves of cache_dir.
 {
     my $project = _cache_project();
     _fake_download($project, '7.7/arm64/base77.tgz');
@@ -241,7 +241,7 @@ SKIP: {
 	'and still says the images are empty');
 }
 
-# clear refuses while a VM whose disk is backed by the entry is running
+# clear refuses while a VM runs on a disk that the entry backs
 SKIP: {
     my $has_qemu = `which qemu-img 2>/dev/null`;
     skip 'qemu-img not installed', 4 unless $has_qemu;
@@ -270,7 +270,7 @@ SKIP: {
 	5, 'clear refuses with EXIT_VM_RUNNING while the VM runs');
     ok(defined $cache->lookup($key), 'the entry survives the refusal');
 
-    # Stopped: removal is allowed, with a warning about the orphan
+    # Once the VM stops, removal proceeds. A warning reports the orphan.
     unlink "$state_dir/default/vm.pid";
     is(FuguVM::CLI->run("--project=$project", '--quiet', 'cache', 'clear'),
 	0, 'clear proceeds once the VM is stopped');
@@ -296,8 +296,8 @@ SKIP: {
 	2, 'a name with a path separator is rejected');
 }
 
-# Missing snapshots report a distinct, scriptable exit code so callers
-# can do 'snapshot restore || provision-from-scratch'
+# Missing snapshots report a distinct, scriptable exit code. Thus
+# callers can do 'snapshot restore || provision-from-scratch'.
 {
     my $project = _cache_project();
     is(FuguVM::CLI->run("--project=$project", '--quiet',
@@ -325,7 +325,8 @@ SKIP: {
     system('qemu-img', 'create', '-f', 'qcow2', $source, '16M') == 0
 	or skip 'cannot create a test disk image', 12;
 
-    # A standalone disk cannot be snapshotted: say so, do not crash
+    # A snapshot of a standalone disk is not possible. Say so. Do
+    # not crash.
     my $disk = FuguVM::Disk->new($state_dir);
     $disk->create('default', '16M');
     my $state = FuguVM::State->new($state_dir, 'default');
@@ -357,7 +358,8 @@ SKIP: {
 	$cache->snapshot_path($key, 'deps'),
 	'restore actually replaced the disk with an overlay on the snapshot');
 
-    # Restore from nothing: no disk, no state, as a fresh checkout has
+    # Restore from nothing. No disk and no state exist, as in a
+    # fresh checkout.
     unlink $disk->path('default');
     unlink "$state_dir/default/status";
     is(FuguVM::CLI->run("--project=$project", '--quiet',
@@ -387,8 +389,8 @@ SKIP: {
 	0, 'rm succeeds');
 }
 
-# --names is the scriptable listing: bare names on stdout, where a
-# shell can read them, rather than through the stderr logger
+# --names is the scriptable listing. It writes bare names on stdout,
+# where a shell can read them. It does not go through the stderr logger.
 SKIP: {
     my $has_qemu = `which qemu-img 2>/dev/null`;
     skip 'qemu-img not installed', 4 unless $has_qemu;
@@ -426,8 +428,8 @@ SKIP: {
 
 done_testing();
 
-# A project whose cache_dir points inside the project, so the tests
-# never touch the developer's real ~/.cache/fuguvm
+# A project whose cache_dir points inside the project. Thus the tests
+# never touch the developer's real ~/.cache/fuguvm.
 sub _cache_project
 {
     my $project = tempdir(CLEANUP => 1);
@@ -446,8 +448,8 @@ sub _cache_project
     return $project;
 }
 
-# Run a command with stdout captured, so the scriptable output can be
-# told apart from the logger's stderr
+# Run a command and capture stdout. This separates the scriptable
+# output from the logger's stderr.
 sub _capture_stdout
 {
     my ($project, @args) = @_;
@@ -466,8 +468,8 @@ sub _capture_stdout
     return $out;
 }
 
-# The logger writes to stderr, so the human listing is captured apart
-# from the scriptable output above
+# The logger writes to stderr. Thus this helper captures the human
+# listing apart from the scriptable output above.
 sub _capture_stderr
 {
     my ($project, @args) = @_;
@@ -486,8 +488,8 @@ sub _capture_stderr
     return $err;
 }
 
-# A cached proxy download, seeded on disk rather than through store(),
-# whose cache_path() wants URI - a develop dependency
+# A cached proxy download, seeded on disk and not through store().
+# store() uses cache_path(), which wants URI, a develop dependency.
 sub _fake_download
 {
     my ($project, $rel) = @_;

--- a/t/fuguvm/cli.t
+++ b/t/fuguvm/cli.t
@@ -122,7 +122,7 @@ SKIP: {
     is($result, 2, 'negative timeout returns EXIT_INVALID_ARGS');
 }
 
-# Issue 1: Long VM name via CLI
+# Issue 1: A long VM name from the CLI
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     my $orig_dir = getcwd();

--- a/t/fuguvm/config.t
+++ b/t/fuguvm/config.t
@@ -27,7 +27,7 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     make_path("$tmpdir/.fuguvm/vms");
-    # Create .fuguvmrc at project root
+    # Create .fuguvmrc at the project root
     open my $fh, '>', "$tmpdir/.fuguvmrc";
     close $fh;
     chdir $tmpdir;
@@ -44,7 +44,7 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     my $tmpdir = tempdir(CLEANUP => 1);
     make_path("$tmpdir/.fuguvm/vms");
     
-    # Create config file at project root
+    # Create the config file at the project root
     open my $fh, '>', "$tmpdir/.fuguvmrc";
     print $fh "cache_dir /tmp/test\n";
     print $fh "default_vm test\n";
@@ -59,7 +59,7 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     my $tmpdir = tempdir(CLEANUP => 1);
     make_path("$tmpdir/.fuguvm/vms");
     
-    # Create project config with VM block
+    # Create a project config with a VM block
     open my $fh, '>', "$tmpdir/.fuguvmrc";
     print $fh "default_vm test\n";
     print $fh "\n";
@@ -84,7 +84,7 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     my $tmpdir = tempdir(CLEANUP => 1);
     make_path("$tmpdir/.fuguvm/vms");
     
-    # Create separate VM config file
+    # Create a separate VM config file
     open my $fh, '>', "$tmpdir/.fuguvm/vms/legacy.conf";
     print $fh "name legacy-vm\n";
     print $fh "memory 2048\n";
@@ -108,8 +108,8 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     is($vm, undef, 'load_vm returns undef for missing VM');
 }
 
-# The resolved cache_dir reaches the per-VM config, so `fuguvm up`
-# writes its image cache where the cache subcommands look for it
+# The resolved cache_dir reaches the per-VM config. Thus `fuguvm up`
+# writes its image cache where the cache subcommands look for it.
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     make_path("$tmpdir/.fuguvm/vms");
@@ -130,8 +130,9 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
 	'and it is the same value cache_dir reports');
 }
 
-# image_cache: default on, project overrides global, and every
-# spelling an OpenBSD-style switch accepts
+# image_cache: the default is on. The project setting overrides the
+# global setting. The test covers every spelling an OpenBSD-style
+# switch accepts.
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     my $homedir = tempdir(CLEANUP => 1);
@@ -189,7 +190,8 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     ok(scalar @warnings, 'and warns about it');
 }
 
-# image_cache inside a vm block is normalized like the global directive
+# The parser normalizes image_cache inside a vm block like the global
+# directive
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     my $homedir = tempdir(CLEANUP => 1);
@@ -231,7 +233,7 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     my $tmpdir = tempdir(CLEANUP => 1);
     make_path("$tmpdir/.fuguvm/vms");
     
-    # Create config with ssh_pubkey at project root
+    # Create a config with ssh_pubkey at the project root
     open my $fh, '>', "$tmpdir/.fuguvmrc";
     print $fh "ssh_pubkey ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test\@example\n";
     close $fh;
@@ -251,7 +253,7 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     print $fh "default_vm test\n";
     close $fh;
     
-    # Create global config with ssh_pubkey
+    # Create a global config with ssh_pubkey
     open my $gh, '>', "$homedir/.fuguvmrc";
     print $gh "ssh_pubkey ssh-rsa AAAAB3NzaC1 global\@test\n";
     close $gh;
@@ -292,7 +294,7 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     print $gh "ssh_pubkey ssh-rsa GLOBAL global\@test\n";
     close $gh;
     
-    # Project config overrides some values
+    # The project config overrides some values
     open my $fh, '>', "$tmpdir/.fuguvmrc";
     print $fh "default_vm project-vm\n";
     close $fh;
@@ -310,16 +312,16 @@ is(FuguVM::Config::DEFAULT_VERSION(), '7.8', 'DEFAULT_VERSION is 7.8');
     my $tmpdir = tempdir(CLEANUP => 1);
     make_path("$tmpdir/subdir/deep/nested");
     
-    # Create .fuguvmrc at project root
+    # Create .fuguvmrc at the project root
     open my $fh, '>', "$tmpdir/.fuguvmrc";
     close $fh;
     
-    # Save cwd, change to nested directory
+    # Save the cwd. Change to the nested directory.
     use Cwd qw(getcwd realpath);
     my $orig_cwd = getcwd();
     chdir "$tmpdir/subdir/deep/nested";
     my $root = FuguVM::Config->find_project_root;
-    chdir $orig_cwd;  # Restore cwd before cleanup
+    chdir $orig_cwd;  # Restore the cwd before cleanup
     
     my $expected = realpath($tmpdir);
     my $actual = realpath($root);

--- a/t/fuguvm/disk.t
+++ b/t/fuguvm/disk.t
@@ -75,9 +75,9 @@ SKIP: {
     is($info->{'virtual-size'}, $disk->info('test')->{'virtual-size'},
 	'overlay inherits the backing image virtual size');
 
-    # qemu-img still reports the reference once the parent is gone:
-    # that is what makes a broken chain diagnosable rather than an
-    # opaque failure at boot.
+    # qemu-img still reports the reference once the parent is gone.
+    # This makes a broken chain diagnosable, not an opaque failure
+    # at boot.
     unlink $path;
     is($overlay->backing_file('child'), $path,
 	'backing_file still names a missing parent');
@@ -85,10 +85,10 @@ SKIP: {
 	'and the caller can see that it is gone');
 }
 
-# A running QEMU holds an exclusive lock on its disk, so inspection has
-# to ask for shared access. Without it, info() fails on exactly the VMs
-# whose chain callers most need: 'cache clear' would see no backing file
-# for a running VM and remove the base out from under it.
+# A running QEMU holds an exclusive lock on its disk. Thus inspection
+# must ask for shared access. Without it, info() fails on exactly the
+# VMs whose chain callers most need. 'cache clear' then sees no backing
+# file for a running VM and removes the base while the VM uses it.
 SKIP: {
     my $has_qemu_io = `which qemu-io 2>/dev/null`;
     skip 'qemu-io not installed', 4 unless $has_qemu_io;
@@ -108,8 +108,9 @@ SKIP: {
 	open(my $io2, '|-', "qemu-io '@{[$overlay->path('kid')]}' >/dev/null 2>&1");
     skip 'cannot spawn qemu-io', 4 unless $spawned && $spawned_kid;
 
-    # Wait for the lock, and prove it is really held: an unshared query
-    # failing here is the condition that used to break the callers.
+    # Wait for the lock and prove that qemu-io really holds it. An
+    # unshared query that fails here is the condition that used to
+    # break the callers.
     my $locked = 0;
     for (1 .. 100) {
 	`qemu-img info --output=json '$path' 2>&1`;

--- a/t/fuguvm/image.t
+++ b/t/fuguvm/image.t
@@ -16,9 +16,9 @@ is(FuguVM::Image::CDN_HOST(), 'cdn.openbsd.org',
 is(FuguVM::Image::ARCH(), 'arm64',
     'ARCH is correct');
 
-# download() only warns when the helper is missing, so a rename would
-# degrade silently to "no download" instead of failing.  Assert the path
-# still resolves.
+# download() only warns when the helper is missing. Thus a rename
+# degrades silently to "no download" instead of a failure. Assert
+# that the path still resolves.
 ok(-x FuguVM::Image::_ftp_script(),
     'the ftp helper resolves to an executable');
 
@@ -62,7 +62,7 @@ ok(-x FuguVM::Image::_ftp_script(),
     my $tmpdir = tempdir(CLEANUP => 1);
     my $image = FuguVM::Image->new($tmpdir);
     
-    # Create fake cached image in proxy cache structure
+    # Create a fake cached image in the proxy cache structure
     my $cache_path = "$tmpdir/proxy/cdn.openbsd.org/pub/OpenBSD/7.8/arm64";
     make_path($cache_path);
     open my $fh, '>', "$cache_path/miniroot78.img";
@@ -89,7 +89,7 @@ ok(-x FuguVM::Image::_ftp_script(),
     my $tmpdir = tempdir(CLEANUP => 1);
     my $image = FuguVM::Image->new($tmpdir);
     
-    # Create fake cached images in proxy cache structure
+    # Create fake cached images in the proxy cache structure
     for my $ver (qw(7.7 7.8)) {
         (my $shortver = $ver) =~ s/\.//;
         my $cache_path = "$tmpdir/proxy/cdn.openbsd.org/pub/OpenBSD/$ver/arm64";

--- a/t/fuguvm/imagecache.t
+++ b/t/fuguvm/imagecache.t
@@ -73,8 +73,8 @@ my %CONFIG = (
 }
 
 # The installer script and the generation counter rotate the key.
-# Both inputs are redirected at synthetic files rather than edited in
-# the checkout, so an aborted test cannot leave the tree modified.
+# The test points both inputs at synthetic files and does not edit
+# the checkout. Thus an aborted test cannot leave the tree modified.
 {
 	my $tmp = tempdir( CLEANUP => 1 );
 	_spit( "$tmp/install.exp", "#!/usr/bin/expect\n" );
@@ -97,7 +97,7 @@ my %CONFIG = (
 		'a bumped generation counter rotates the key' );
 
 	# An unreadable input means no key at all, and therefore no
-	# caching - never a key derived from partial inputs.
+	# caching. The code never derives a key from partial inputs.
 	unlink "$tmp/cache-generation";
 	my $missing = do {
 		local $SIG{__WARN__} = sub { };
@@ -142,7 +142,7 @@ my %CONFIG = (
 	is_deeply( $cache->list, [], 'list skips incomplete entries' );
 }
 
-# Temporary trees are swept, whatever left them behind
+# sweep_temp removes temporary trees, whatever left them behind
 {
 	my $tmp   = tempdir( CLEANUP => 1 );
 	my $cache = FuguVM::ImageCache->new($tmp);
@@ -186,7 +186,7 @@ SKIP: {
 	    == 0
 	    or skip 'cannot create a test disk image', 19;
 
-	# Store and look back up
+	# Store an entry. Look it up again.
 	my $base = $cache->store( $key, $disk,
 		{ root_password => 's3cret', version => '7.8' } );
 	ok( defined $base, 'store returns the published base image path' );
@@ -324,7 +324,7 @@ SKIP: {
 	    or skip 'cannot create a test disk image', 16;
 	my $base = $cache->store( $key, $source, { root_password => 'pw' } );
 
-	# A working overlay, the shape a snapshot is taken from
+	# A working overlay, the shape a snapshot comes from
 	my $disk = FuguVM::Disk->new("$tmp/state");
 	$disk->create( 'default', undef, $base, 'qcow2' );
 	my $disk_path = $disk->path('default');
@@ -352,8 +352,9 @@ SKIP: {
 	is_deeply( $cache->list->[0]{snapshots},
 		['deps'], 'cache listing counts it' );
 
-	# Re-saving from a disk restored FROM the snapshot must not make
-	# the snapshot its own parent, nor stack chains without bound.
+	# A re-save from a disk restored FROM the snapshot must not
+	# make the snapshot its own parent. It must not stack chains
+	# without bound.
 	unlink $disk_path;
 	$disk->create( 'default', undef, $path, 'qcow2' );
 	is( $disk->backing_file('default'),
@@ -372,8 +373,8 @@ SKIP: {
 		undef, 'the snapshot is gone' );
 }
 
-# A snapshot whose base is gone reads as a miss, so callers can fall
-# back to provisioning instead of failing hard
+# A snapshot whose base is gone reads as a miss. Thus callers can
+# fall back to provisioning instead of a hard failure.
 SKIP: {
 	skip 'qemu-img not installed', 3 if !$HAS_QEMU_IMG;
 
@@ -427,11 +428,11 @@ sub _temp_trees ($dir)
 	return scalar @tmp;
 }
 
-# A cache whose two file-backed key inputs live in a scratch directory,
-# so tests can rotate them without touching the checkout.
+# A cache whose two file-backed key inputs live in a scratch
+# directory. Thus tests can rotate them and never touch the checkout.
 package TestInputs;
 
-# Inheritance must be in place before the tests above run
+# The inheritance must be in place before the tests above run
 BEGIN { our @ISA = ('FuguVM::ImageCache'); }
 
 sub new ( $class, $cache_dir, $input_dir )

--- a/t/fuguvm/proxy-cache.t
+++ b/t/fuguvm/proxy-cache.t
@@ -3,16 +3,16 @@
 # FuguVM::Proxy::Cache pruning: the only thing that bounds the proxy's
 # on-disk store of OpenBSD downloads
 #
-# Separate from proxy.t, which skips itself without HTTP::Daemon and
-# LWP::UserAgent.  Those are develop dependencies, so a CI run that
-# installs the test set skips that whole file - and this is code that
-# deletes directories under a user's cache, which must be exercised on
-# every run rather than only where the VM harness can run.
+# This file is separate from proxy.t, which skips itself without
+# HTTP::Daemon and LWP::UserAgent.  Those are develop dependencies.
+# Thus a CI run that installs the test set skips that whole file.
+# But this code deletes directories under a user's cache. Every run
+# must exercise it, not only the hosts where the VM harness can run.
 #
-# Trees are seeded directly rather than through store(), whose
-# cache_path() wants URI - also develop-only, arriving with LWP.  Pruning
-# reads the filesystem layout and never a URL, so the seam is real and
-# not a workaround.
+# The tests seed trees directly and not through store().  store()
+# uses cache_path(), which wants URI. URI is also develop-only and
+# arrives with LWP.  The prune code reads the filesystem layout and
+# never a URL. Thus the seam is real and not a workaround.
 
 use v5.36;
 use Test::More;
@@ -24,7 +24,7 @@ use File::Temp qw(tempdir);
 use_ok('FuguVM::Proxy::Cache');
 
 # _seed($tmpdir, $relative_path, $bytes):
-#	Write a cached file of $bytes bytes, creating its tree.
+#	Write a cached file of $bytes bytes. Also create its tree.
 sub _seed
 {
 	my ($tmpdir, $rel, $bytes) = @_;
@@ -40,10 +40,10 @@ sub _seed
 
 my $MIRROR = 'cdn.openbsd.org/pub/OpenBSD';
 
-# A version bump left the whole previous version's file sets behind for
-# good: unreadable afterwards, since every is_cacheable() pattern is
-# version-scoped, and still carried by every copy of the directory a CI
-# cache makes.
+# A version bump left the whole previous version's file sets behind
+# permanently. They were unreadable afterwards, because every
+# is_cacheable() pattern is version-scoped. Every copy of the
+# directory that a CI cache made still carried them.
 {
 	my $tmpdir = tempdir(CLEANUP => 1);
 	my $cache = FuguVM::Proxy::Cache->new($tmpdir);
@@ -53,8 +53,8 @@ my $MIRROR = 'cdn.openbsd.org/pub/OpenBSD';
 	_seed($tmpdir, "$MIRROR/7.7/arm64/base77.tgz", 200);
 	_seed($tmpdir, "$MIRROR/syspatch/7.7/arm64/001_x.tgz", 50);
 
-	# No version in the path, so prune must leave it: a cache under
-	# $HOME is the wrong place to delete on a guess
+	# The path holds no version, so prune must leave it. A cache
+	# under $HOME is the wrong place to delete on a guess.
 	_seed($tmpdir, 'example.com/loose.txt', 5);
 
 	is($cache->size, 365, 'four versioned files and one loose one');
@@ -78,8 +78,9 @@ my $MIRROR = 'cdn.openbsd.org/pub/OpenBSD';
 	    'the kept version and the unversioned file survive');
 	is($cache->size, 115, 'and the freed bytes are gone');
 
-	# The directory, not just its files: the tree is what a CI cache
-	# uploads and downloads on every key rotation
+	# The directory itself must be gone, not only its files. The
+	# tree is what a CI cache uploads and downloads on every key
+	# rotation.
 	ok(!-e "$tmpdir/proxy/$MIRROR/7.7",
 	    'the pruned release directory is gone');
 	ok(!-e "$tmpdir/proxy/$MIRROR/syspatch/7.7",
@@ -107,7 +108,7 @@ my $MIRROR = 'cdn.openbsd.org/pub/OpenBSD';
 	is($cache->size, 140, 'the other host is untouched');
 }
 
-# Keeping a version that is not there removes everything that is
+# A prune that keeps only an absent version removes everything present
 {
 	my $tmpdir = tempdir(CLEANUP => 1);
 	my $cache = FuguVM::Proxy::Cache->new($tmpdir);
@@ -119,7 +120,8 @@ my $MIRROR = 'cdn.openbsd.org/pub/OpenBSD';
 	is($cache->size, 0, 'the cache is empty');
 }
 
-# Never written to, so proxy/ holds no host directories at all
+# The cache never received a write. Thus proxy/ holds no host
+# directories at all.
 {
 	my $tmpdir = tempdir(CLEANUP => 1);
 	my $cache = FuguVM::Proxy::Cache->new($tmpdir);

--- a/t/fuguvm/proxy-metacache.t
+++ b/t/fuguvm/proxy-metacache.t
@@ -18,7 +18,7 @@ use_ok('FuguVM::Proxy::MetaCache');
 {
 	my $cache = FuguVM::Proxy::MetaCache->new;
 
-	# Create a temp file with .tgz extension
+	# Create a temp file with a .tgz extension
 	my $tmp = File::Temp->new( SUFFIX => '.tgz' );
 	print $tmp "test content\n";
 	$tmp->flush;
@@ -91,7 +91,7 @@ use_ok('FuguVM::Proxy::MetaCache');
 {
 	my $cache = FuguVM::Proxy::MetaCache->new;
 
-	# Create and store temp file
+	# Create and store a temp file
 	my $tmp = File::Temp->new;
 	print $tmp "test content\n";
 	$tmp->flush;
@@ -103,12 +103,12 @@ use_ok('FuguVM::Proxy::MetaCache');
 	ok( defined $cache->lookup($url), 'Found after store' );
 
 	# Modify the file
-	sleep 1;    # Ensure mtime changes
+	sleep 1;    # Make sure that the mtime changes
 	open my $fh, '>>', $path or die "Cannot append: $!";
 	print $fh "more content\n";
 	close $fh;
 
-	# Should not find it (mtime/size changed)
+	# The lookup must miss because the mtime and size changed
 	ok( !defined $cache->lookup($url),
 		'Invalidated after file modification' );
 }

--- a/t/fuguvm/proxy.t
+++ b/t/fuguvm/proxy.t
@@ -31,12 +31,13 @@ use_ok('FuguVM::Proxy::Cache');
 	    "$tmpdir/proxy/cdn.openbsd.org/pub/OpenBSD/7.8/arm64/base78.tgz",
 	    'Cache path derived correctly');
 
-	# Test directory traversal is completely rejected (returns undef)
+	# Test that the cache rejects directory traversal completely
+	# and returns undef
 	my $bad_path = $cache->cache_path(
 	    'http://cdn.openbsd.org/../../../etc/passwd');
 	is($bad_path, undef, 'Directory traversal rejected');
 
-	# Test various traversal patterns are rejected
+	# Test that the cache rejects various traversal patterns
 	is($cache->cache_path('http://example.com/foo/../bar'), undef,
 	    'Mid-path traversal rejected');
 	is($cache->cache_path('http://example.com/..'), undef,
@@ -50,7 +51,7 @@ use_ok('FuguVM::Proxy::Cache');
 	my $tmpdir = tempdir(CLEANUP => 1);
 	my $cache = FuguVM::Proxy::Cache->new($tmpdir);
 
-	# Should be cacheable
+	# These URLs are cacheable
 	ok($cache->is_cacheable(
 	    'http://cdn.openbsd.org/pub/OpenBSD/7.8/arm64/base78.tgz'),
 	    'File set is cacheable');
@@ -67,7 +68,7 @@ use_ok('FuguVM::Proxy::Cache');
 	    'http://cdn.openbsd.org/pub/OpenBSD/7.8/arm64/SHA256.sig'),
 	    'SHA256.sig is cacheable');
 
-	# Should not be cacheable
+	# These URLs are not cacheable
 	ok(!$cache->is_cacheable('http://example.com/random.html'),
 	    'Random HTML is not cacheable');
 	ok(!$cache->is_cacheable(
@@ -83,19 +84,19 @@ use_ok('FuguVM::Proxy::Cache');
 	my $url = 'http://cdn.openbsd.org/pub/OpenBSD/7.8/arm64/SHA256';
 	my $content = "SHA256 (base78.tgz) = abc123\n";
 
-	# Initially not in cache
+	# The URL is not in the cache initially
 	is($cache->lookup($url), undef, 'URL not in cache initially');
 
-	# Store content
+	# Store the content
 	my $stored_path = $cache->store($url, $content);
 	ok(defined $stored_path, 'Content stored');
 	ok(-f $stored_path, 'Cache file exists');
 
-	# Lookup should now succeed
+	# The lookup now succeeds
 	my $cached_path = $cache->lookup($url);
 	is($cached_path, $stored_path, 'Lookup returns stored path');
 
-	# Verify content
+	# Make sure that the content matches
 	open my $fh, '<', $cached_path;
 	my $read_content = do { local $/; <$fh> };
 	close $fh;
@@ -179,7 +180,7 @@ use_ok('FuguVM::Proxy::Cache');
 	my $cache_dir = tempdir(CLEANUP => 1);
 	my $state = FuguVM::State->new($state_dir, 'test');
 
-	# Manually set port to test URL generation
+	# Set the port manually to test the URL generation
 	$state->set_proxy_port(8080);
 
 	my $proxy = FuguVM::Proxy->new($state, $cache_dir);
@@ -188,7 +189,7 @@ use_ok('FuguVM::Proxy::Cache');
 	is($url, 'http://10.0.2.2:8080', 'Proxy guest_url correct');
 }
 
-# Test Proxy start/stop (integration test - may be slow)
+# Test Proxy start/stop (integration test, can be slow)
 SKIP: {
 	skip 'Set FUGUVM_TEST_PROXY=1 to run proxy integration tests', 4
 	    unless $ENV{FUGUVM_TEST_PROXY};

--- a/t/fuguvm/qga.t
+++ b/t/fuguvm/qga.t
@@ -11,9 +11,10 @@ use Time::HiRes qw(time);
 
 use_ok('FuguVM::QGA');
 
-# A QGA object wired to one end of a socketpair, with the peer returned
-# so the test can play the guest agent. Built through IO::Socket so both
-# ends autoflush exactly as the sockets the module itself opens do.
+# A QGA object wired to one end of a socketpair. The helper also
+# returns the peer, so the test can play the guest agent. It builds
+# the pair through IO::Socket. Thus both ends autoflush exactly as
+# the sockets the module itself opens do.
 sub paired_qga
 {
 	my ($ours, $theirs) =
@@ -48,12 +49,12 @@ sub paired_qga
 	    'run_command returns undef when not connected');
 }
 
-# A silent peer must not stall the caller. IO::Socket's timeout() does
-# not bound a read, so this used to block forever - and nothing answers
-# whenever the guest runs no agent, because QEMU, not the guest, serves
-# the socket. That is how 'fuguvm down' hung instead of falling back to
-# a force stop. Bounded here directly: the module's own READ_TIMEOUT is
-# too long to spend in a unit test.
+# A silent peer must not stall the caller. IO::Socket's timeout()
+# does not bound a read. Thus this used to block forever. Nothing
+# answers when the guest runs no agent, because QEMU, not the guest,
+# serves the socket. Thus 'fuguvm down' hung and did not fall back
+# to a force stop. The test bounds the read directly. The module's
+# own READ_TIMEOUT is too long for a unit test.
 {
 	my ($qga, $peer) = paired_qga();
 	SKIP: {
@@ -68,8 +69,8 @@ sub paired_qga
 	}
 }
 
-# A complete line is returned without its terminator, and anything the
-# peer sent past the newline stays for the next read.
+# The read returns a complete line without its terminator. Anything
+# the peer sent past the newline stays for the next read.
 {
 	my ($qga, $peer) = paired_qga();
 	SKIP: {
@@ -86,7 +87,8 @@ sub paired_qga
 	}
 }
 
-# A line split across segments is reassembled rather than truncated
+# The read reassembles a line split across segments and does not
+# truncate it
 {
 	my ($qga, $peer) = paired_qga();
 	SKIP: {

--- a/t/fuguvm/qmp.t
+++ b/t/fuguvm/qmp.t
@@ -10,9 +10,10 @@ use Time::HiRes qw(time);
 
 use_ok('FuguVM::QMP');
 
-# A QMP object wired to one end of a socketpair, with the peer returned
-# so the test can play QEMU. Built through IO::Socket so both ends
-# autoflush exactly as the sockets the module itself opens do.
+# A QMP object wired to one end of a socketpair. The helper also
+# returns the peer, so the test can play QEMU. It builds the pair
+# through IO::Socket. Thus both ends autoflush exactly as the
+# sockets the module itself opens do.
 sub paired_qmp
 {
 	my ($ours, $theirs) =
@@ -55,9 +56,9 @@ sub paired_qmp
 	is($result, undef, 'run_command returns undef when not connected');
 }
 
-# A silent peer must not stall the caller. IO::Socket's timeout() does
-# not bound a read, so this used to block forever: 'fuguvm down' hung
-# instead of falling back to a force stop.
+# A silent peer must not stall the caller. IO::Socket's timeout()
+# does not bound a read. Thus this used to block forever. 'fuguvm
+# down' hung and did not fall back to a force stop.
 {
 	my ($qmp, $peer) = paired_qmp();
 	SKIP: {
@@ -72,8 +73,8 @@ sub paired_qmp
 	}
 }
 
-# A complete line is returned without its terminator, and anything the
-# peer sent past the newline stays for the next read.
+# The read returns a complete line without its terminator. Anything
+# the peer sent past the newline stays for the next read.
 {
 	my ($qmp, $peer) = paired_qmp();
 	SKIP: {
@@ -90,8 +91,8 @@ sub paired_qmp
 	}
 }
 
-# Whole-response path: a well-formed reply decodes, a silent peer does
-# not hang run_command.
+# Whole-response path: a well-formed reply decodes. A silent peer
+# does not hang run_command.
 {
 	my ($qmp, $peer) = paired_qmp();
 	SKIP: {

--- a/t/fuguvm/ssh.t
+++ b/t/fuguvm/ssh.t
@@ -51,7 +51,7 @@ is(FuguVM::SSH::BUFFER_SIZE(), 32768, 'BUFFER_SIZE is 32768');
 
 # _exit_code maps a raw wait status to a 0-255 exit code. This lets
 # `fuguvm ssh`, when it runs a script over stdin, propagate a failing
-# remote command (e.g. a failing `prove` run). Without it, a raw
+# remote command (for example a failing `prove` run). Without it, a raw
 # status like 256 truncates down to exit(256) -> 0.
 {
     is(FuguVM::SSH::_exit_code(0), 0, 'status 0 -> exit 0');

--- a/t/fuguvm/ssh.t
+++ b/t/fuguvm/ssh.t
@@ -6,7 +6,7 @@ use Test::More;
 use FindBin qw($RealBin);
 use lib "$RealBin/../lib";
 
-# Skip if Net::SSH2 not available
+# Skip if Net::SSH2 is not available
 BEGIN {
     eval { require Net::SSH2 };
     if ($@) {
@@ -49,10 +49,10 @@ is(FuguVM::SSH::BUFFER_SIZE(), 32768, 'BUFFER_SIZE is 32768');
     ok(!$ssh->is_available, 'is_available false for closed port');
 }
 
-# _exit_code maps a raw wait status to a 0-255 exit code. This is what
-# lets `fuguvm ssh` running a script over stdin propagate a failing
-# remote command (e.g. a failing `prove` run) instead of truncating a
-# raw status like 256 down to exit(256) -> 0.
+# _exit_code maps a raw wait status to a 0-255 exit code. This lets
+# `fuguvm ssh`, when it runs a script over stdin, propagate a failing
+# remote command (e.g. a failing `prove` run). Without it, a raw
+# status like 256 truncates down to exit(256) -> 0.
 {
     is(FuguVM::SSH::_exit_code(0), 0, 'status 0 -> exit 0');
     is(FuguVM::SSH::_exit_code(1 << 8), 1, 'exit code 1 preserved');

--- a/t/fuguvm/state.t
+++ b/t/fuguvm/state.t
@@ -37,7 +37,7 @@ use_ok('FuguVM::State');
     
     $state->set_vm_pid(54321);
     
-    # Verify vm.pid file exists and contains the PID
+    # Make sure that the vm.pid file exists and contains the PID
     my $pid_file = "$tmpdir/test/vm.pid";
     ok(-f $pid_file, 'vm.pid file created');
     open my $fh, '<', $pid_file;
@@ -46,7 +46,7 @@ use_ok('FuguVM::State');
     chomp $pid_content;
     is($pid_content, '54321', 'vm.pid file contains correct PID');
     
-    # Verify PID is NOT in the status JSON
+    # Make sure that the PID is NOT in the status JSON
     my $status_file = "$tmpdir/test/status";
     if (-f $status_file) {
         open my $sfh, '<', $status_file;
@@ -56,7 +56,7 @@ use_ok('FuguVM::State');
         unlike($json, qr/"pid"/, 'PID not stored in status JSON');
     }
     
-    # Clear and verify pid file is removed
+    # Clear the PID. Make sure that the pid file is gone.
     $state->clear_vm_pid;
     ok(!-f $pid_file, 'vm.pid file removed after clear_vm_pid');
 }
@@ -69,11 +69,11 @@ use_ok('FuguVM::State');
     $state->set_vm_pid($$);
     is($state->get_vm_pid, $$, 'VM PID set to current process');
     
-    # Reload state - PID should still be readable from pid file
+    # Reload the state. The PID stays readable from the pid file.
     my $state2 = FuguVM::State->new($tmpdir, 'test');
     is($state2->get_vm_pid, $$, 'VM PID readable after state reload');
     
-    # Clear PID and reload - should be gone
+    # Clear the PID and reload. The PID must be gone.
     $state2->clear_vm_pid;
     my $state3 = FuguVM::State->new($tmpdir, 'test');
     is($state3->get_vm_pid, undef, 'VM PID cleared persists after reload');
@@ -84,11 +84,11 @@ use_ok('FuguVM::State');
     my $tmpdir = tempdir(CLEANUP => 1);
     my $state = FuguVM::State->new($tmpdir, 'test');
     
-    # Use current process PID (which is running)
+    # Use the current process PID, which is running
     $state->set_vm_pid($$);
     ok($state->is_vm_running, 'is_vm_running returns true for running process');
     
-    # Use invalid PID
+    # Use an invalid PID
     $state->set_vm_pid(99999999);
     ok(!$state->is_vm_running, 'is_vm_running returns false for non-running process');
 }
@@ -112,7 +112,7 @@ use_ok('FuguVM::State');
     
     $state->set_proxy_pid(11111);
     
-    # Verify proxy.pid file exists
+    # Make sure that the proxy.pid file exists
     my $proxy_pid_file = "$tmpdir/test/proxy.pid";
     ok(-f $proxy_pid_file, 'proxy.pid file created');
     open my $fh, '<', $proxy_pid_file;
@@ -121,7 +121,7 @@ use_ok('FuguVM::State');
     chomp $pid_content;
     is($pid_content, '11111', 'proxy.pid file contains correct PID');
     
-    # Clear and verify file is removed
+    # Clear the PID. Make sure that the file is gone.
     $state->clear_proxy_pid;
     ok(!-f $proxy_pid_file, 'proxy.pid file removed after clear_proxy_pid');
 }
@@ -131,11 +131,11 @@ use_ok('FuguVM::State');
     my $tmpdir = tempdir(CLEANUP => 1);
     my $state = FuguVM::State->new($tmpdir, 'test');
     
-    # Use current process PID (which is running)
+    # Use the current process PID, which is running
     $state->set_proxy_pid($$);
     ok($state->is_proxy_running, 'is_proxy_running returns true for running process');
     
-    # Use invalid PID
+    # Use an invalid PID
     $state->set_proxy_pid(99999999);
     ok(!$state->is_proxy_running, 'is_proxy_running returns false for non-running process');
 }
@@ -150,7 +150,7 @@ use_ok('FuguVM::State');
     $state->set_proxy_port(8080);
     is($state->get_proxy_port, 8080, 'Proxy port stored and retrieved');
     
-    # Verify port is in status JSON (persisted)
+    # Make sure that the port persists in the status JSON
     my $state2 = FuguVM::State->new($tmpdir, 'test');
     is($state2->get_proxy_port, 8080, 'Proxy port persisted across reload');
     
@@ -187,7 +187,7 @@ use_ok('FuguVM::State');
     $state->mark_installed;
     ok($state->is_installed, 'Installed after mark_installed');
     
-    # Reload state and verify persistence
+    # Reload the state and make sure that the value persists
     my $state2 = FuguVM::State->new($tmpdir, 'test');
     ok($state2->is_installed, 'Installation state persisted');
 }
@@ -211,7 +211,7 @@ use_ok('FuguVM::State');
     $state->set_root_password('testpass123');
     is($state->get_root_password, 'testpass123', 'Password stored and retrieved');
     
-    # Reload state and verify persistence
+    # Reload the state and make sure that the value persists
     my $state2 = FuguVM::State->new($tmpdir, 'test');
     is($state2->get_root_password, 'testpass123', 'Password persisted');
 }
@@ -227,7 +227,7 @@ use_ok('FuguVM::State');
     $state->mark_ssh_key_installed($test_pubkey);
     is($state->get_installed_ssh_pubkey, $test_pubkey, 'Pubkey stored correctly');
     
-    # Reload state and verify persistence
+    # Reload the state and make sure that the value persists
     my $state2 = FuguVM::State->new($tmpdir, 'test');
     is($state2->get_installed_ssh_pubkey, $test_pubkey, 'Pubkey persisted correctly');
 }
@@ -248,7 +248,7 @@ use_ok('FuguVM::State');
     is($state, undef, 'Long VM name (10000 chars) returns undef');
 }
 
-# Issue 1: VM name at boundary (255 chars should work)
+# Issue 1: a VM name at the boundary of 255 chars works
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     
@@ -257,7 +257,7 @@ use_ok('FuguVM::State');
     ok(defined $state, 'VM name at 255 chars is accepted');
 }
 
-# Issue 1: VM name over boundary (256 chars should fail)
+# Issue 1: a VM name over the boundary at 256 chars fails
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     
@@ -282,7 +282,7 @@ use_ok('FuguVM::State');
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     
-    # Create a file where the VM state directory should be
+    # Create a file where the VM state directory belongs
     my $file_path = "$tmpdir/testvm";
     open my $fh, '>', $file_path or die "Cannot create file: $!";
     print $fh "not a directory\n";
@@ -298,7 +298,7 @@ use_ok('FuguVM::State');
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     
-    # Create a symlink where the VM state directory should be
+    # Create a symlink where the VM state directory belongs
     my $target = "$tmpdir/target";
     mkdir $target;
     my $link = "$tmpdir/symvm";
@@ -327,7 +327,7 @@ use_ok('FuguVM::State');
     is($state, undef, 'Symlink to file as state directory returns undef');
 }
 
-# Valid special characters in VM name (should work)
+# A VM name with valid special characters works
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     
@@ -340,11 +340,13 @@ use_ok('FuguVM::State');
 {
     my $tmpdir = tempdir(CLEANUP => 1);
     
-    # Empty name should still create a directory (it becomes "$tmpdir/")
-    # This might be intentional behavior or could be restricted
+    # An empty name still creates a directory. The directory becomes
+    # "$tmpdir/". This behavior can be intentional, or a later change
+    # can restrict it.
     my $state = FuguVM::State->new($tmpdir, '');
-    # The behavior here depends on whether empty names are allowed
-    # Currently they create a directory named "" which is valid
+    # The behavior here depends on whether the code allows empty
+    # names. Currently an empty name creates a directory named "",
+    # which is valid.
     ok(defined $state || !defined $state, 'Empty VM name handled (either way)');
 }
 

--- a/t/fuguvm/util.t
+++ b/t/fuguvm/util.t
@@ -30,7 +30,8 @@ use_ok('FuguVM::Util');
     my $password = FuguVM::Util->generate_password(32);
     is(length($password), 32, 'generate_password returns correct length');
     
-    # Check it only contains URL-safe base64 characters
+    # Make sure that the password only contains URL-safe base64
+    # characters
     like($password, qr/^[A-Za-z0-9_-]+$/, 'generate_password uses URL-safe characters');
 }
 

--- a/t/fuguvm/vm.t
+++ b/t/fuguvm/vm.t
@@ -7,7 +7,8 @@ use FindBin qw($RealBin);
 use lib "$RealBin/../../lib";
 use File::Temp qw(tempdir);
 
-# Check if module can be loaded (may fail if Net::SSH2 not available)
+# Check that the module loads. The load can fail if Net::SSH2 is
+# not available.
 BEGIN {
 	eval { require FuguVM::VM; 1 }
 	    or plan skip_all => 'FuguVM::VM dependencies not available';
@@ -53,13 +54,14 @@ use_ok('FuguVM::VM');
 		    'hardware acceleration pairs with host CPU');
 	}
 
-	# Host arch helper returns a non-empty machine string
+	# The host arch helper returns a non-empty machine string
 	ok(length(FuguVM::VM::_host_arch()), 'host arch detected');
 }
 
-# Bounded guest interaction: _bounded must return the code's value when
-# it finishes in time and undef (without hanging) when it does not, so a
-# wedged guest can never stall shutdown.
+# Bounded guest interaction: _bounded must return the code's value
+# when the code finishes in time. When it does not, _bounded must
+# return undef and must not hang. Thus a wedged guest can never
+# stall shutdown.
 {
 	my $vm = FuguVM::VM->new;
 	$vm->{log} = TestLog->new;    # swallow the timeout warning
@@ -88,8 +90,9 @@ use_ok('FuguVM::VM');
 	    'a config without cache_dir falls back to the default');
 }
 
-# Switching the cache off suppresses restore and save together: `up`
-# derives no key at all, so it can neither look one up nor publish one.
+# When the cache is off, `up` suppresses restore and save together.
+# It derives no key at all. Thus it can neither look one up nor
+# publish one.
 {
 	my $off = FuguVM::VM->new(
 		config => { cache_dir => '/var/cache/fuguvm', image_cache => 0 });
@@ -135,7 +138,8 @@ SKIP: {
 		log    => TestLog->new,
 	);
 
-	# Restore: overlay plus the state the installation would have left
+	# Restore: the overlay plus the state that the installation
+	# leaves behind
 	ok($vm->_cache_restore($cache, $key), 'restore reports a cache hit');
 	ok($state->disk_exists, 'the working disk exists after a restore');
 	ok($state->is_installed, 'the restored VM is marked installed');
@@ -188,8 +192,8 @@ SKIP: {
 
 done_testing();
 
-# Minimal log stub: counts warnings for _bounded and keeps errors so
-# diagnostics can be asserted on
+# Minimal log stub: it counts warnings for _bounded and keeps errors.
+# Thus the tests can assert on diagnostics.
 package TestLog;
 sub new { return bless { warned => 0, errors => [] }, shift }
 sub warning { my $self = shift; $self->{warned}++; return; }

--- a/t/lib/OpenHAP/TestMock/MQTT.pm
+++ b/t/lib/OpenHAP/TestMock/MQTT.pm
@@ -17,9 +17,10 @@
 
 use v5.36;
 
-# Mock MQTT client for host-side tests. Records subscriptions and
-# publishes, and delivers simulated messages to matching subscription
-# callbacks, including + and # wildcard patterns.
+# This module is a mock MQTT client for host-side tests. It records
+# subscriptions and published messages. It delivers simulated
+# messages to the matching subscription callbacks. The match
+# includes the + and # wildcard patterns.
 
 package OpenHAP::TestMock::MQTT;
 

--- a/t/openhap/accessory.t
+++ b/t/openhap/accessory.t
@@ -48,7 +48,7 @@ use_ok('OpenHAP::Accessory');
     my @services = $accessory->get_services();
     ok(@services > 0, 'Accessory has services');
     
-    # First service should be Accessory Information
+    # The first service must be Accessory Information
     my $info_service = $services[0];
     ok(defined $info_service, 'Accessory Information service exists');
     is($info_service->{iid}, 1, 'Accessory Information has IID 1');
@@ -64,7 +64,7 @@ use_ok('OpenHAP::Accessory');
     $accessory->add_service($service);
     
     my @services = $accessory->get_services();
-    # Should have AccessoryInformation + Switch
+    # The accessory must have AccessoryInformation and Switch
     is(scalar @services, 2, 'Two services present');
 }
 
@@ -72,7 +72,7 @@ use_ok('OpenHAP::Accessory');
 {
     my $accessory = OpenHAP::Accessory->new(aid => 1);
     
-    # Get characteristic from AccessoryInformation service
+    # Get the characteristic from the AccessoryInformation service
     my $char = $accessory->get_characteristic(2);  # IID 2 is Identify
     ok(defined $char, 'Characteristic found');
 }

--- a/t/openhap/bridge.t
+++ b/t/openhap/bridge.t
@@ -130,7 +130,7 @@ use_ok('OpenHAP::Bridge');
     my $acc = OpenHAP::Accessory->new(aid => 2, name => 'Device');
     $bridge->add_bridged_accessory($acc);
     
-    # Trigger event on bridged accessory
+    # Trigger an event on the bridged accessory
     $acc->notify_change(10);
     
     ok($callback_called, 'Bridge callback called from bridged accessory');

--- a/t/openhap/characteristic.t
+++ b/t/openhap/characteristic.t
@@ -26,8 +26,9 @@ use_ok('OpenHAP::Characteristic');
 
 # Test get_value and set_value
 {
-    # Since there seems to be an issue with value storage in the current implementation,
-    # we'll just test that the methods exist and don't die
+    # The current implementation possibly has a problem with value
+    # storage. Thus the test only makes sure that the methods exist
+    # and do not die.
     my $temp = 21.5;
     my $char = OpenHAP::Characteristic->new(
         type => 'CurrentTemperature',
@@ -176,7 +177,7 @@ use_ok('OpenHAP::Characteristic');
     is($name_json->{type}, '23', 'Name type is 23 in short form');
 }
 
-# Test custom UUID is preserved (not shortened)
+# Test that the module does not shorten a custom UUID
 {
     my $custom_uuid = '12345678-1234-1234-1234-123456789012';
     my $char = OpenHAP::Characteristic->new(

--- a/t/openhap/config.t
+++ b/t/openhap/config.t
@@ -9,7 +9,7 @@ use File::Temp qw(tempdir);
 
 use_ok('OpenHAP::Config');
 
-# Create temporary config file
+# Create a temporary config file
 my $temp_dir    = tempdir(CLEANUP => 1);
 my $config_file = "$temp_dir/openhap_test.conf";
 open my $fh, '>', $config_file or die "Cannot create test config: $!";

--- a/t/openhap/crypto.t
+++ b/t/openhap/crypto.t
@@ -8,7 +8,7 @@ $OpenHAP::logger = FuguLib::Log->new(mode => 'quiet', ident => 'test');
 
 # Test Crypto module
 BEGIN {
-    # Skip tests if crypto modules not available
+    # Skip the tests if the crypto modules are not available
     eval {
         require Crypt::Curve25519;
         require Crypt::Ed25519;
@@ -91,7 +91,7 @@ use_ok('OpenHAP::Crypto');
     ok(defined $key, 'HKDF key derived');
     is(length($key), 32, 'HKDF key has correct length');
     
-    # Verify deterministic
+    # Make sure the derivation is deterministic
     my $key2 = OpenHAP::Crypto::hkdf_sha512($ikm, $salt, $info, 32);
     is($key, $key2, 'HKDF is deterministic');
 }

--- a/t/openhap/daemon.t
+++ b/t/openhap/daemon.t
@@ -8,8 +8,8 @@ use FuguLib::Log;
 $OpenHAP::logger = FuguLib::Log->new(mode => 'quiet', ident => 'test');
 use File::Temp qw(tempdir);
 
-# Test daemon mode functionality. mDNS TXT record content is covered by
-# the spec-cited tests in t/conformance/hap-mdns.t.
+# Test the daemon mode functions. The spec-cited tests in
+# t/conformance/hap-mdns.t cover the mDNS TXT record content.
 
 # Test 1: MQTT connection with timeout
 {
@@ -20,13 +20,13 @@ use File::Temp qw(tempdir);
 		port => 1883,
 	);
 
-	# Test timeout parameter exists
+	# Make sure the timeout parameter exists
 	my $start = time;
 	my $result = $mqtt->mqtt_connect(2);  # 2 second timeout
 	my $elapsed = time - $start;
 
-	# Should fail quickly (within 3 seconds) if MQTT not available
-	# or succeed quickly if it is available
+	# The connect must fail quickly, in 3 seconds or less, if MQTT
+	# is not available. It must succeed quickly if MQTT is available.
 	ok($elapsed < 5, 'MQTT connect respects timeout');
 }
 
@@ -39,7 +39,7 @@ use File::Temp qw(tempdir);
 		port => 1883,
 	);
 
-	# Should have reconnect method
+	# The client must have a reconnect method
 	ok($mqtt->can('reconnect'), 'MQTT has reconnect method');
 }
 
@@ -56,19 +56,19 @@ use File::Temp qw(tempdir);
 		storage_path => $tmpdir,
 	);
 
-	# Should have private resubscribe method
+	# The HAP object must have a private resubscribe method
 	ok($hap->can('_mqtt_resubscribe_accessories'),
 	    'HAP has _mqtt_resubscribe_accessories method');
 }
 
-# Test 4: the unveil inventory builder - pure assembly, testable
-# without unveiling anything
+# Test 4: the unveil inventory builder. The builder only assembles
+# data. Thus the test does not unveil anything.
 {
 	use OpenHAP::Daemon;
 
 	my $tmpdir = tempdir(CLEANUP => 1);
 
-	# by_path(): index the pair list for assertions
+	# by_path(): index the pair list for the assertions
 	sub by_path (@paths)
 	{
 		return map { $_->[0] => $_ } @paths;
@@ -81,8 +81,9 @@ use File::Temp qw(tempdir);
 		script_lib  => $tmpdir,    # no OpenHAP/ inside: not a checkout
 	);
 
-	# Deterministic: same inputs, same ordered list (asserted before
-	# any hash access below can autovivify entries)
+	# The builder is deterministic. The same inputs give the same
+	# ordered list. Assert this before a hash access below can
+	# autovivify an entry.
 	my @again = OpenHAP::Daemon->unveil_paths(
 		db_path     => '/var/db/openhapd',
 		config_file => '/etc/openhapd.conf',
@@ -93,20 +94,20 @@ use File::Temp qw(tempdir);
 
 	my %row = by_path(@paths);
 
-	# Required rows: absent means a broken install
+	# Required rows: if one is absent, the install is broken
 	is($row{'/var/db/openhapd'}[1], 'rwc', 'db_path is rwc');
 	ok(!$row{'/var/db/openhapd'}[2]{optional}, 'db_path is required');
 	is($row{'/dev/urandom'}[1], 'r', '/dev/urandom readable');
 	ok(!$row{'/dev/urandom'}[2]{optional}, '/dev/urandom is required');
 
-	# The config file must never be a required row, even though the
-	# path was given: a fresh install has no /etc/openhapd.conf and
-	# must still boot
+	# The config file must never be a required row, even when the
+	# path is given. A fresh install has no /etc/openhapd.conf and
+	# must still boot.
 	ok($row{'/etc/openhapd.conf'}[2]{optional},
 	    'config file is optional');
 	is($row{'/etc/openhapd.conf'}[1], 'r', 'config file read-only');
 
-	# Optional rows that are legitimately absent on a working system
+	# These optional rows can be absent on a working system.
 	for my $optional (
 		'/var/log/openhapd.log', '/var/run/mdnsd.sock',
 		'/etc/resolv.conf',      '/etc/hosts',
@@ -119,9 +120,10 @@ use File::Temp qw(tempdir);
 	is($row{'/var/run/mdnsd.sock'}[1], 'rw',
 	    'mdnsd socket read-write for the update_txt reconnect');
 
-	# The library directories are the enumerated list, deduped -
-	# never live @INC, and never /usr/local/lib on an installed
-	# layout (script_lib without OpenHAP/ inside is excluded)
+	# The library directories are the enumerated list, with
+	# duplicates removed. The list never comes from live @INC. On an
+	# installed layout, it never has /usr/local/lib. The builder
+	# excludes a script_lib that has no OpenHAP/ inside.
 	my @lib_rows = grep { $_->[0] =~ m{^/perl/} } @paths;
 	is_deeply(
 		[map { $_->[0] } @lib_rows],
@@ -133,7 +135,7 @@ use File::Temp qw(tempdir);
 	ok((!grep { $_->[2]{optional} } @lib_rows),
 	    'library directories are required');
 
-	# A real checkout's lib is included read-only
+	# The builder includes the lib of a real checkout read-only
 	my %checkout = by_path(
 		OpenHAP::Daemon->unveil_paths(
 			db_path    => '/var/db/openhapd',
@@ -143,11 +145,11 @@ use File::Temp qw(tempdir);
 	is($checkout{"$RealBin/../../lib"}[1],
 	    'r', 'source checkout lib unveiled read-only');
 
-	# No execute permission anywhere: pledge withholds exec, and an
-	# unveil that grants x would contradict it in the source
+	# No row grants execute permission. Pledge withholds exec. An
+	# unveil that grants x would contradict pledge in the source.
 	ok((!grep { $_->[1] =~ /x/ } @paths), 'no x permission in the view');
 
-	# Without db_path the builder refuses outright
+	# The builder refuses outright when it gets no db_path
 	ok(!eval { OpenHAP::Daemon->unveil_paths(); 1 },
 	    'db_path is not optional to the builder');
 }
@@ -164,7 +166,7 @@ use File::Temp qw(tempdir);
 	is(OpenHAP::Daemon->read_pidfile($pidfile), $$,
 	    'read_pidfile returns the PID that was written');
 
-	# A path that cannot be opened is a recoverable error, not a die
+	# A path that does not open is a recoverable error, not a die
 	my $unwritable = "$tmpdir/nonexistent/openhapd.pid";
 	is(OpenHAP::Daemon->write_pidfile($unwritable), undef,
 	    'write_pidfile returns undef on an unopenable path');

--- a/t/openhap/device-loading.t
+++ b/t/openhap/device-loading.t
@@ -8,7 +8,7 @@ use FuguLib::Log;
 $OpenHAP::logger = FuguLib::Log->new(mode => 'quiet', ident => 'test');
 
 # Test device loading through OpenHAP::DeviceLoader with a mock config,
-# mock MQTT client and a recording HAP stand-in.
+# a mock MQTT client, and a recording HAP stand-in.
 
 use_ok('OpenHAP::DeviceLoader');
 
@@ -55,7 +55,7 @@ sub add_accessory ( $self, $accessory )
 
 package main;
 
-# Valid device is loaded and added to the bridge
+# The loader loads a valid device and adds it to the bridge
 {
 	my $config = MockConfig->new( {
 		type    => 'tasmota',
@@ -80,7 +80,7 @@ package main;
 		'Device subscribed to MQTT topics' );
 }
 
-# Device missing name is rejected
+# The loader rejects a device without a name
 {
 	my $config = MockConfig->new( {
 		type    => 'tasmota',
@@ -95,7 +95,7 @@ package main;
 	is( $count, 0, 'Device without name is skipped' );
 }
 
-# Device missing topic is rejected
+# The loader rejects a device without a topic
 {
 	my $config = MockConfig->new( {
 		type    => 'tasmota',
@@ -110,7 +110,7 @@ package main;
 	is( $count, 0, 'Device without topic is skipped' );
 }
 
-# Device missing id falls back to topic as serial
+# A device without an id uses the topic as the serial
 {
 	my $config = MockConfig->new( {
 		type    => 'tasmota',
@@ -128,7 +128,7 @@ package main;
 	is( $device->{serial}, 'test_heater', 'Topic used as serial fallback' );
 }
 
-# Unsupported device type is skipped
+# The loader skips an unsupported device type
 {
 	my $config = MockConfig->new( {
 		type    => 'zigbee',
@@ -144,7 +144,8 @@ package main;
 	is( $count, 0, 'Unsupported device type is skipped' );
 }
 
-# MQTT subscription deferred when broker not connected
+# The loader defers the MQTT subscription while the broker is not
+# connected
 {
 	my $config = MockConfig->new( {
 		type    => 'tasmota',
@@ -162,7 +163,8 @@ package main;
 		0, 'Subscription deferred while disconnected' );
 }
 
-# Mixed configuration: AIDs assigned sequentially, invalid entries skipped
+# Mixed configuration: the loader assigns AIDs in sequence and skips
+# the invalid entries
 {
 	my $config = MockConfig->new(
 		{

--- a/t/openhap/hap.t
+++ b/t/openhap/hap.t
@@ -72,7 +72,7 @@ use_ok('OpenHAP::Pairing');
     like($device_id, qr/^[0-9A-F]{2}(:[0-9A-F]{2}){5}$/, 'Device ID is MAC format');
 }
 
-# mDNS TXT record content is covered by t/conformance/hap-mdns.t
+# The tests in t/conformance/hap-mdns.t cover the mDNS TXT record content
 
 # Test event queue initialization ([HAP-HTTP §14] event notifications)
 {
@@ -107,7 +107,7 @@ use_ok('OpenHAP::Pairing');
     ok(defined $new_ltpk, 'New LTPK exists after regeneration');
     isnt($new_ltpk, $old_ltpk, 'LTPK changed after regeneration');
 
-    # Verify keys were persisted
+    # Make sure the storage has the new keys
     my ($stored_ltsk, $stored_ltpk) = $hap->{storage}->load_accessory_keys();
     is($stored_ltpk, $new_ltpk, 'New LTPK persisted to storage');
 }
@@ -127,12 +127,12 @@ use_ok('OpenHAP::Pairing');
     is($hap->update_config_number, 1,
         'unchanged database keeps c# stable');
 
-    # Restart with the same database: c# unchanged
+    # Restart with the same database: the c# does not change
     my $hap2 = OpenHAP::HAP->new(%args);
     is($hap2->update_config_number, 1,
         '[HAP-mDNS §8] c# persisted across restart');
 
-    # Restart with an added accessory: c# increments
+    # Restart with an added accessory: the c# increments
     require OpenHAP::Tasmota::Heater;
     require OpenHAP::TestMock::MQTT;
     my $hap3 = OpenHAP::HAP->new(%args);
@@ -148,9 +148,9 @@ use_ok('OpenHAP::Pairing');
     is($hap3->get_mdns_txt_records->{'c#'}, 2, 'TXT c# reflects change');
 }
 
-# TXT string formatter: key=value pairs joined with '.' in sorted key
-# order - mdnsd's TXT delimiter makes the ordering observable, so it
-# must be deterministic ([HAP-mDNS §2])
+# The TXT string formatter joins key=value pairs with '.' in sorted
+# key order. The TXT delimiter of mdnsd makes the order observable.
+# Thus the order must be deterministic ([HAP-mDNS §2]).
 {
     my $temp_dir = tempdir(CLEANUP => 1);
     my $hap = OpenHAP::HAP->new(
@@ -206,7 +206,8 @@ use_ok('OpenHAP::Pairing');
     $hap->_refresh_mdns;
     is(scalar @{ $mdns->{updates} }, 0, 'no update without state change');
 
-    # Pairing added: sf flips to 0 and the TXT record is re-advertised
+    # Pairing added: sf flips to 0 and the bridge re-advertises the
+    # TXT record
     $hap->{storage}->save_pairing('controller', 'X' x 32, 1);
     $hap->_refresh_mdns;
     is(scalar @{ $mdns->{updates} }, 1,
@@ -214,14 +215,14 @@ use_ok('OpenHAP::Pairing');
     like($mdns->{updates}[0], qr/(?:^|\.)sf=0(?:\.|$)/,
         'advertised sf=0 once paired');
 
-    # Pairing removed: re-advertised again with sf=1
+    # Pairing removed: the bridge re-advertises with sf=1
     $hap->{storage}->remove_all_pairings;
     $hap->_refresh_mdns;
     like($mdns->{updates}[1], qr/(?:^|\.)sf=1(?:\.|$)/,
         '[HAP-mDNS §8] advertised sf=1 when pairing removed');
 
     # Unpublished handle: the pairing path must never drive an update
-    # onto it (the guard that used to live inside OpenHAP::MDNS)
+    # onto it. This guard was inside OpenHAP::MDNS before.
     $mdns->{published} = 0;
     $hap->{storage}->save_pairing('controller', 'X' x 32, 1);
     $hap->_refresh_mdns;
@@ -230,8 +231,8 @@ use_ok('OpenHAP::Pairing');
     $hap->{storage}->remove_all_pairings;
 }
 
-# Event emission behavior ([HAP-HTTP §14]) is covered end-to-end by
-# t/conformance/hap-http.t, which drives the PUT handler and the MQTT
-# device path against subscribed mock sessions.
+# The tests in t/conformance/hap-http.t cover the event emission
+# behavior ([HAP-HTTP §14]) end-to-end. They drive the PUT handler and
+# the MQTT device path against subscribed mock sessions.
 
 done_testing();

--- a/t/openhap/http.t
+++ b/t/openhap/http.t
@@ -43,7 +43,7 @@ like($response, qr/Content-Type: application\/hap\+json/, 'Response has headers'
 like($response, qr/Content-Length: 15/, 'Response has content-length');
 like($response, qr/\{"status":"ok"\}$/, 'Response has body');
 
-# Test Connection: keep-alive header is added
+# Test that the builder adds the Connection: keep-alive header
 like($response, qr/Connection: keep-alive/, 'Response has Connection: keep-alive header');
 
 # Test 204 No Content response
@@ -60,7 +60,7 @@ my $multi_status = OpenHAP::HTTP::build_response(
 );
 like($multi_status, qr/HTTP\/1\.1 207 Multi-Status/, '207 response has correct status');
 
-# Test custom Connection header is not overwritten
+# Test that the builder does not overwrite a custom Connection header
 my $custom_conn = OpenHAP::HTTP::build_response(
     status => 200,
     headers => { 'Connection' => 'close' },

--- a/t/openhap/integration/accessories.t
+++ b/t/openhap/integration/accessories.t
@@ -25,9 +25,10 @@ my @device_topics = $env->get_device_topics;
 is($config_count // 0, scalar @device_topics,
    'device count matches configuration');
 
-# The daemon starts unpaired (integration files own their pairing
-# lifecycle), so the data-plane endpoints must be gated with HTTP 470.
-# Paired access is covered by t/openhap/integration/characteristics.t.
+# The daemon starts unpaired, because the integration files own their
+# pairing lifecycle. Thus the data-plane endpoints must return HTTP
+# 470. The file t/openhap/integration/characteristics.t covers paired
+# access.
 
 # Test 3: GET /accessories requires pairing
 my $response = $env->http_request('GET', '/accessories');
@@ -58,7 +59,7 @@ $response = $env->http_request('PUT', '/characteristics',
 is($status, 470,
    '[HAP-HTTP §9] PUT /characteristics returns 470 when unpaired');
 
-# Test 7: Invalid characteristic id is still gated when unpaired
+# Test 7: An invalid characteristic id still returns 470 when unpaired
 $response = $env->http_request('GET', '/characteristics?id=999.999');
 ($status) = OpenHAP::Test::Integration::parse_http_response($response);
 is($status, 470,

--- a/t/openhap/integration/characteristics.t
+++ b/t/openhap/integration/characteristics.t
@@ -77,7 +77,7 @@ $result = $controller->request('GET', "/characteristics?id=$aid.$iid");
 like($result->{body}, qr/"value"\s*:\s*true/,
    '[HAP-HTTP §8] written value reads back as true');
 
-# Test 7: Invalid iid yields 207 with HAP status -70409
+# Test 7: Invalid iid returns 207 with HAP status -70409
 $result = $controller->request('GET', '/characteristics?id=999.999');
 is($result->{status}, 207,
    '[HAP-HTTP §9] invalid id returns 207 Multi-Status');
@@ -91,7 +91,7 @@ $result = $controller->request('PUT', '/prepare',
 is($result->{status}, 200, '[HAP-HTTP §10] /prepare accepted');
 is(decode_json($result->{body})->{status}, 0, '/prepare status 0');
 
-# Test 9: Mixed write is answered with 207 and per-item status
+# Test 9: The daemon answers a mixed write with 207 and per-item status
 $result = $controller->request('PUT', '/characteristics',
 	encode_json({ characteristics => [
 		{ aid => $aid, iid => $iid,  value => \0 },

--- a/t/openhap/integration/characteristics.t
+++ b/t/openhap/integration/characteristics.t
@@ -84,7 +84,7 @@ is($result->{status}, 207,
 is(decode_json($result->{body})->{characteristics}[0]{status}, -70409,
    '[HAP-HTTP §12] invalid iid has HAP status -70409');
 
-# Test 8: Timed write via /prepare with a pid
+# Test 8: Timed write through /prepare with a pid
 $result = $controller->request('PUT', '/prepare',
 	encode_json({ ttl => 2500, pid => 424242 }),
 	{ 'Content-Type' => 'application/hap+json' });

--- a/t/openhap/integration/configuration.t
+++ b/t/openhap/integration/configuration.t
@@ -41,7 +41,7 @@ ok(defined $hap_port, 'configuration has hap_port');
 ok($hap_port =~ /^\d+$/ && $hap_port >= 1024 && $hap_port <= 65535,
    'hap_port is valid');
 
-# Test 7: Device count reported by hapctl matches parsed configuration
+# Test 7: The hapctl device count matches the parsed configuration
 my ($reported_count) = $check_output =~ /Configured devices:\s*(\d+)/;
 my @device_topics = $env->get_device_topics;
 is($reported_count, scalar @device_topics,
@@ -52,7 +52,8 @@ sleep 0.5;
 my $running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
 ok($running, 'daemon still running');
 
-# Test 9: Can restart daemon (reload may not be supported)
+# Test 9: The daemon can restart. The daemon possibly does not
+# support reload.
 system('rcctl restart openhapd >/dev/null 2>&1');
 sleep 1;
 $running = system('rcctl check openhapd >/dev/null 2>&1') == 0;

--- a/t/openhap/integration/daemon.t
+++ b/t/openhap/integration/daemon.t
@@ -27,7 +27,7 @@ if (open my $fh, '<', $pidfile) {
 }
 ok(!defined $pid || $pid =~ /^\d+$/, 'PID file handling correct');
 
-# Test 3: Process is running (check via rcctl or connections)
+# Test 3: Process is running. The check uses rcctl or connections.
 ok($running, 'process is running');
 
 # Test 4: Daemon responds to connections
@@ -65,8 +65,8 @@ $running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
 ok($running, 'daemon starts successfully');
 
 # Test 10: Daemon responds after restart. The listener opens only
-# after the mDNS publish conversation completes, so wait for the port
-# rather than a fixed sleep.
+# after the mDNS publish conversation completes. Thus wait for the
+# port. Do not use a fixed sleep.
 ok($env->wait_for_hap_port, 'daemon responds after restart');
 
 $env->teardown;

--- a/t/openhap/integration/environment.t
+++ b/t/openhap/integration/environment.t
@@ -43,9 +43,10 @@ ok(-d '/var/db/openhapd', 'data directory exists');
 ok(-f '/etc/rc.d/openhapd', 'rc.d script installed');
 
 # Test 11: SRP obtains the GMP Math::BigInt backend. The try => 'GMP'
-# selection falls back silently to pure Perl, which reintroduces
-# multi-minute pair-setups under TCG emulation - a missing backend
-# must be a hard, visible failure here, not a slow-but-green run.
+# selection falls back silently to pure Perl. The pure Perl path
+# reintroduces multi-minute pair-setups under TCG emulation. A
+# missing backend must be a hard, visible failure here, not a
+# slow-but-green run.
 require OpenHAP::SRP;
 is(Math::BigInt->config->{lib}, 'Math::BigInt::GMP',
    'Math::BigInt uses the GMP backend');

--- a/t/openhap/integration/events.t
+++ b/t/openhap/integration/events.t
@@ -50,8 +50,9 @@ $result = $subscriber->request('PUT', '/characteristics',
 	{ 'Content-Type' => 'application/hap+json' });
 is($result->{status}, 204, '[HAP-HTTP §14] subscription accepted');
 
-# Second controller on its own connection: added as a pairing by the
-# admin, then verified; it does NOT subscribe
+# Second controller on its own connection: the admin adds it as a
+# pairing, and then it verifies its own session. It does NOT
+# subscribe.
 my $bystander = $env->get_controller(controller_id => 'bystander-ctrl');
 $subscriber->add_pairing('bystander-ctrl', $bystander->{ltpk}, 1)
     or die 'add_pairing failed: ' . ( $subscriber->last_error // '?' ) . "\n";
@@ -74,8 +75,8 @@ ok(defined $event, '[HAP-HTTP §14] EVENT/1.0 message received')
 	. unpack('H*', $subscriber->{inbuf} // '')
 	. ' raw: ' . unpack('H*', $subscriber->{rawbuf} // ''));
 
-# Decode only a received event so a miss stays a normal failure and the
-# unpair teardown below still runs
+# Decode only a received event. Then a miss stays a normal failure,
+# and the unpair teardown below still runs.
 is($event ? $event->{headers}{'content-type'} : undef,
    'application/hap+json', '[HAP-HTTP §14] event content type');
 my $payload = $event ? eval { decode_json($event->{body}) } : undef;
@@ -84,8 +85,8 @@ my ($change) = grep { $_->{aid} == $aid && $_->{iid} == $iid }
     @{ $payload ? $payload->{characteristics} : [] };
 ok($change, '[HAP-HTTP §14] event carries the changed characteristic');
 
-# Test 3: Subscriptions are per-connection - the unsubscribed
-# controller receives nothing
+# Test 3: Subscriptions are per-connection. The unsubscribed
+# controller receives nothing.
 my $stray = $bystander->next_event(2);
 ok(!defined $stray,
    '[HAP-HTTP §14] unsubscribed connection receives no events');

--- a/t/openhap/integration/hap-protocol.t
+++ b/t/openhap/integration/hap-protocol.t
@@ -96,7 +96,7 @@ my $socket = IO::Socket::INET->new(
 );
 ok(defined $socket, 'connection established');
 
-# Make multiple requests on same connection
+# Make multiple requests on the same connection
 print $socket "GET /accessories HTTP/1.1\r\n";
 print $socket "Host: 127.0.0.1\r\n\r\n";
 my $resp1 = '';
@@ -115,7 +115,7 @@ while (my $line = <$socket>) {
 
 $socket->close;
 
-# Test 15: Both requests succeeded
+# Test 15: Both requests succeed
 ok($resp1 =~ /HTTP/ && $resp2 =~ /HTTP/,
    'connection persistence works');
 
@@ -146,7 +146,7 @@ $response = $env->http_request('GET', '/accessories');
 my $has_keepalive = $response =~ /Connection:\s*keep-alive/i;
 ok($has_keepalive, 'response includes Connection: keep-alive header');
 
-# Test 20: Server handles GET /characteristics with meta/perms/type/ev params
+# Test 20: Server answers GET /characteristics with meta/perms/type/ev params
 $response = $env->http_request('GET', '/characteristics?id=1.10&meta=1&perms=1&type=1&ev=1');
 ($status) = OpenHAP::Test::Integration::parse_http_response($response);
 ok(defined $status && ($status == 200 || $status == 470 || $status == 404 || $status == 207),
@@ -173,7 +173,7 @@ ok($response =~ /HTTP\/1\.1/, 'server uses HTTP/1.1 specifically');
 # Test 24: /pair-setup returns TLV response
 $response = $env->http_request('POST', '/pair-setup', "\x00\x01\x00",
 	{'Content-Type' => 'application/pairing+tlv8'});
-# TLV responses are binary, check for Content-Length
+# TLV responses are binary. Check for Content-Length.
 my ($content_length) = $response =~ /Content-Length:\s*(\d+)/i;
 ok(defined $content_length && $content_length > 0,
    '/pair-setup returns non-empty TLV response');
@@ -191,7 +191,7 @@ ok(defined $response && $response =~ /HTTP\/1\.1\s+200/,
 $response = $env->http_request('PUT', '/characteristics',
 	'invalid json',
 	{'Content-Type' => 'application/hap+json'});
-# Check if response has content-type header
+# Check if the response has a content-type header
 my $error_content_type = $response =~ /Content-Type:\s*application\/(hap\+)?json/i;
 # Either proper error content-type or 470 unpaired
 ok($error_content_type || $response =~ /470/,

--- a/t/openhap/integration/hap-protocol.t
+++ b/t/openhap/integration/hap-protocol.t
@@ -12,7 +12,7 @@ use OpenHAP::Test::Integration;
 my $env = OpenHAP::Test::Integration->new;
 $env->setup;
 
-# Test 1: HAP server is reachable via HTTP
+# Test 1: The HAP server is reachable over HTTP
 my $response = $env->http_request('GET', '/');
 ok(defined $response && $response =~ /^HTTP\/1\.[01]/, 'server reachable');
 

--- a/t/openhap/integration/hapctl.t
+++ b/t/openhap/integration/hapctl.t
@@ -80,7 +80,7 @@ for (1..3) {
 }
 ok($multi_ok, 'multiple invocations work');
 
-# Test 14: hapctl doesn't interfere with daemon
+# Test 14: hapctl does not interfere with the daemon
 my $before = system('rcctl check openhapd >/dev/null 2>&1');
 system("$hapctl -c $config_file status >/dev/null 2>&1");
 system("$hapctl -c $config_file devices >/dev/null 2>&1");

--- a/t/openhap/integration/mdns-cleanup.t
+++ b/t/openhap/integration/mdns-cleanup.t
@@ -1,9 +1,9 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
 # Integration test: mDNS advertisement lifetime and process hygiene.
-# The daemon speaks the mdnsd control protocol over a held socket:
-# there is no child process, no mdnsctl.log, and closing the socket
-# (daemon exit) is what withdraws the advertisement.
+# The daemon speaks the mdnsd control protocol over a held socket.
+# There is no child process and no mdnsctl.log. When the daemon
+# exits, the socket closes, and this withdraws the advertisement.
 
 use v5.36;
 use Test::More;
@@ -22,8 +22,8 @@ die "mdnsd required for mDNS lifetime tests\n"
 my $db_path = $env->get_config_value('db_path') // '/var/db/openhapd';
 my $hap_name = $env->get_config_value('hap_name') // 'OpenHAP';
 
-# Remove any mdnsctl.log a pre-rewrite daemon left behind, so the
-# assertion below fails only if the running daemon creates one
+# Remove any mdnsctl.log that a pre-rewrite daemon left behind. Then
+# the assertion below fails only if the running daemon creates one.
 unlink "$db_path/mdnsctl.log";
 
 # Restart openhapd so it publishes against the running mdnsd
@@ -49,8 +49,8 @@ while ($output !~ /\Q$hap_name\E/i && time < $deadline) {
 like($output, qr/\Q$hap_name\E/i,
      'service advertised while the daemon runs');
 
-# No child processes: the daemon publishes over a socket, it does not
-# spawn a helper. pgrep -P lists children of the daemon's pid.
+# No child processes: the daemon publishes over a socket. It does
+# not spawn a helper. pgrep -P lists children of the daemon's pid.
 chomp( my $daemon_pid = `pgrep -f 'perl.*openhapd' | head -1` );
 like($daemon_pid, qr/^\d+$/, 'daemon pid known');
 
@@ -60,8 +60,9 @@ is($children, '', 'daemon has no child processes at all');
 # No mdnsctl.log: the log file existed only for the mdnsctl child
 ok(!-e "$db_path/mdnsctl.log", 'no mdnsctl.log is created');
 
-# Stopping the daemon closes the control socket, which withdraws the
-# advertisement within a few seconds - no signal, no kill, no child
+# When the daemon stops, the control socket closes. The closed
+# socket withdraws the advertisement within a few seconds. This
+# needs no signal, no kill, and no child.
 system('rcctl stop openhapd >/dev/null 2>&1');
 sleep 2;
 ok(system('rcctl check openhapd >/dev/null 2>&1') != 0,
@@ -76,8 +77,8 @@ while ($output =~ /\Q$hap_name\E/i && time < $deadline) {
 unlike($output, qr/\Q$hap_name\E/i,
        'advertisement withdrawn after the daemon exits');
 
-# The daemon starts and serves with mdnsd stopped: discovery degrades,
-# HAP service does not
+# The daemon starts and serves with mdnsd stopped. Discovery
+# degrades, but the HAP service does not.
 system('rcctl stop mdnsd >/dev/null 2>&1');
 sleep 1;
 system('rcctl start openhapd >/dev/null 2>&1');

--- a/t/openhap/integration/mdns.t
+++ b/t/openhap/integration/mdns.t
@@ -15,10 +15,11 @@ my $env = OpenHAP::Test::Integration->new;
 $env->setup;
 $env->ensure_unpaired or die "Cannot reset pairing state\n";
 
-# Test 1: mdnsd daemon is running and stays running (started if
-# needed; failure emits captured diagnostics). The daemon speaks the
-# mdnsd control protocol directly, so a running mdnsd is the
-# precondition - not the mdnsctl binary, which openhapd never invokes.
+# Test 1: mdnsd daemon is running and stays running. The helper
+# starts mdnsd if necessary and emits captured diagnostics on
+# failure. The daemon speaks the mdnsd control protocol directly.
+# Thus a running mdnsd is the precondition, not the mdnsctl binary.
+# openhapd never invokes mdnsctl.
 my $mdnsd_available = $env->ensure_mdnsd_running;
 ok($mdnsd_available, 'mdnsd daemon is running');
 
@@ -28,16 +29,16 @@ die "mdnsd required for mDNS integration tests\n" unless $mdnsd_available;
 my $daemon_running = system('rcctl check openhapd >/dev/null 2>&1') == 0;
 ok($daemon_running, 'OpenHAP daemon is running');
 
-# Test 3: mdnsctl available as the browsing tool these tests observe
-# advertisements with
+# Test 3: mdnsctl is available as the browse tool. These tests
+# observe advertisements with it.
 my $mdnsctl_available = -x '/usr/sbin/mdnsctl' || -x '/usr/local/bin/mdnsctl';
 ok($mdnsctl_available, 'mdnsctl browse tool available');
 
 die "mdnsctl required to observe advertisements\n" unless $mdnsctl_available;
 
-# Restart openhapd so it re-registers with the running mdnsd; the
-# listener opens after the publish conversation, so serving means
-# published
+# Restart openhapd so that it re-registers with the running mdnsd.
+# The listener opens after the publish conversation. Thus a daemon
+# that serves has published the service.
 system('rcctl restart openhapd >/dev/null 2>&1');
 $env->wait_for_hap_port or die "daemon not serving after restart\n";
 
@@ -45,8 +46,8 @@ $env->wait_for_hap_port or die "daemon not serving after restart\n";
 my $mdns_output = `timeout 5 mdnsctl browse hap tcp 2>&1 || true`;
 ok(length($mdns_output) > 0, 'mdnsctl browse produces output');
 
-# Test 5: HAP service is advertised ([HAP-mDNS §1] _hap._tcp)
-sleep 1;    # Give time for registration
+# Test 5: The daemon advertises the HAP service ([HAP-mDNS §1] _hap._tcp)
+sleep 1;    # Give time for the registration
 $mdns_output = `timeout 5 mdnsctl browse hap tcp 2>&1 || true`;
 my $hap_found = $mdns_output =~ /hap.*tcp/i;
 ok($hap_found, '[HAP-mDNS §1] HAP service advertised via mDNS');
@@ -68,7 +69,7 @@ $mdns_output = `timeout 5 mdnsctl browse hap tcp 2>&1 || true`;
 ok($mdns_output =~ /hap.*tcp/i,
    '[HAP-mDNS §8] service re-advertised after daemon restart');
 
-# Test 9: Port advertised by daemon matches configuration
+# Test 9: The port that the daemon advertises matches the configuration
 my $hap_port = $env->get_config_value('hap_port')
     // OpenHAP::Test::Integration::DEFAULT_HAP_PORT;
 my $lookup_output =
@@ -77,7 +78,8 @@ if ($lookup_output =~ /(\d{4,5})/) {
 	ok($lookup_output =~ /\b\Q$hap_port\E\b/,
 	   '[HAP-mDNS §6] advertised port matches configured hap_port');
 } else {
-	# browse output carries no port; verify the daemon listens on it
+	# The browse output carries no port. Make sure that the daemon
+	# listens on the configured port.
 	my $listening = IO::Socket::INET->new(
 		PeerAddr => '127.0.0.1',
 		PeerPort => $hap_port,
@@ -101,8 +103,8 @@ like($txt_output, qr/sf=1/,
    '[HAP-mDNS §3.7] sf=1 advertised while unpaired');
 
 # Test 11: after pairing, sf flips to 0 in the browsed TXT record.
-# The daemon withdraws and republishes on the state change, so poll
-# the browsed TXT rather than sleeping a fixed interval.
+# The daemon withdraws and republishes on the state change. Thus
+# poll the browsed TXT. Do not sleep for a fixed interval.
 my $controller = $env->get_controller;
 $controller->pair_setup
     or die 'pair-setup failed: ' . ( $controller->last_error // '?' ) . "\n";
@@ -125,6 +127,6 @@ my ($config_number_after) = $txt_output =~ /c#=(\d+)/;
 is($config_number_after, $config_number,
    '[HAP-mDNS §3.1] c# persisted across daemon restart');
 
-# Teardown: unpair via state wipe (the pairing survived the restart)
+# Teardown: unpair with a state wipe. The pairing survived the restart.
 $env->ensure_unpaired or die "Cannot reset pairing state\n";
 $env->teardown;

--- a/t/openhap/integration/mqtt-reconnect.t
+++ b/t/openhap/integration/mqtt-reconnect.t
@@ -2,12 +2,12 @@
 # ex:ts=8 sw=4:
 # Integration test: MQTT reconnection under the pledge. The reconnect
 # path is the one code path that opens new sockets and resolves names
-# after the pledge point, so it exercises the inet and dns promises
-# and the resolver files in the unveil view - none of which the
-# steady-state suite touches, since the stock config's numeric
-# mqtt_host never resolves anything. The daemon runs with
-# mqtt_host = localhost here, the broker is restarted underneath it,
-# and recovery is observed through the paired HAP data plane.
+# after the pledge point. Thus it exercises the inet and dns promises
+# and the resolver files in the unveil view. The steady-state suite
+# touches none of these, because the stock config's numeric mqtt_host
+# never resolves anything. Here the daemon runs with
+# mqtt_host = localhost. The test restarts the broker underneath it
+# and observes recovery through the paired HAP data plane.
 
 use v5.36;
 use Test::More;
@@ -41,9 +41,9 @@ sub restore ($config_file, $saved)
 	return;
 }
 
-# Point mqtt_host at a name instead of an address, so every broker
-# (re)connect resolves via the unveiled /etc/hosts under the dns
-# promise
+# Point mqtt_host at a name instead of an address. Then every broker
+# (re)connect resolves through the unveiled /etc/hosts under the dns
+# promise.
 system($^X, '-pi', '-e',
 	's/^\s*mqtt_host\s*=.*/mqtt_host = localhost/', $config_file);
 my $switched = do {
@@ -59,8 +59,8 @@ unless ($env->wait_for_hap_port) {
 }
 ok(1, 'daemon serves with mqtt_host = localhost');
 
-# Pair and locate the light's On characteristic, so MQTT delivery is
-# observable through the paired data plane rather than daemon logs
+# Pair and locate the light's On characteristic. Then MQTT delivery
+# is observable through the paired data plane, not the daemon logs.
 my $controller = $env->get_controller;
 $controller->pair_setup
     or die 'pair-setup failed: ' . ($controller->last_error // '?') . "\n";
@@ -89,9 +89,9 @@ ok(defined $iid, 'light On characteristic located') or do {
 };
 
 # on_value(): the current On value through the paired session, or
-# undef when the daemon stopped answering - the poll loops then run to
-# their deadline and fail with the rcctl diagnosis instead of a JSON
-# parse error
+# undef when the daemon stopped answering. The poll loops then run
+# to their deadline. They fail with the rcctl diagnosis instead of a
+# JSON parse error.
 sub on_value ($controller, $aid, $iid)
 {
 	my $value = eval {
@@ -103,8 +103,9 @@ sub on_value ($controller, $aid, $iid)
 	return JSON::PP::is_bool($value) ? ($value ? 1 : 0) : $value;
 }
 
-# Baseline: a device state published on the broker reaches HAP while
-# connected via the resolved hostname
+# Baseline: the test publishes a device state on the broker. The
+# state reaches HAP while the daemon connection uses the resolved
+# hostname.
 my $mqtt = $env->get_mqtt or die "cannot connect test MQTT client\n";
 $mqtt->publish("stat/$light->{topic}/POWER", 'ON');
 my $deadline = time + 15;
@@ -115,15 +116,15 @@ is(on_value($controller, $aid, $iid), 1,
 
 # Restart the broker underneath the pledged daemon. The daemon's
 # reconnect resolves localhost and opens a fresh socket after the
-# pledge point; a promise or unveil row missing on that path aborts
-# the daemon or strands MQTT, and either fails the poll below.
+# pledge point. A missing promise or unveil row on that path aborts
+# the daemon or strands MQTT. Either failure fails the poll below.
 system('rcctl restart mosquitto >/dev/null 2>&1');
 die "mosquitto did not come back\n" unless $env->ensure_mqtt_running;
 $env->{mqtt} = undef;    # the cached test client died with the broker
 
-# The daemon retries every 30 seconds; publish OFF repeatedly on a
-# fresh client until the flip is visible through HAP, well past one
-# retry interval before giving up
+# The daemon retries every 30 seconds. Publish OFF repeatedly on a
+# fresh client until the flip is visible through HAP. The loop waits
+# well past one retry interval before it gives up.
 $deadline = time + 120;
 my $recovered = 0;
 while (time < $deadline) {

--- a/t/openhap/integration/mqtt.t
+++ b/t/openhap/integration/mqtt.t
@@ -78,7 +78,7 @@ eval {
 };
 ok($received || !$@, 'MQTT publish/subscribe works');
 
-# Test 9: Multiple MQTT messages handled
+# Test 9: The broker accepts multiple MQTT messages
 my $multiple_ok = 1;
 eval {
 	for my $i (1..5) {

--- a/t/openhap/integration/pairing.t
+++ b/t/openhap/integration/pairing.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Integration test: complete HAP pairing workflow against the live
-# daemon, driven by OpenHAP::Test::Controller.
+# Integration test: the complete HAP pairing workflow against the
+# live daemon. OpenHAP::Test::Controller drives the workflow.
 
 use v5.36;
 use Test::More tests => 18;
@@ -19,8 +19,9 @@ $env->ensure_unpaired or die "Cannot reset pairing state\n";
 my $storage_dir = '/var/db/openhapd';
 ok(-d $storage_dir && -r $storage_dir, 'pairing storage directory exists');
 
-# Test 2: Pair-setup M1 rejects a stale "0x"-prefixed public key
-# (regression guard: Math::BigInt->as_hex once leaked its 0x prefix)
+# Test 2: Pair-setup M1 rejects a stale "0x"-prefixed public key.
+# This is a regression guard: Math::BigInt->as_hex once leaked its
+# 0x prefix.
 my $response = $env->http_request('POST', '/pair-setup',
 	"\x06\x01\x01\x00\x01\x00",
 	{'Content-Type' => 'application/pairing+tlv8'});
@@ -31,8 +32,8 @@ my $hex = unpack('H*', $body);
 unlike($hex, qr/03..0130783078/,
     '[HAP-Pairing §2.4] M2 public key does not contain ASCII "0x" prefix');
 
-# Close the raw M1 probe's connection now instead of leaving it
-# registered with the daemon until teardown
+# Close the raw M1 probe's connection now. Do not leave it
+# registered with the daemon until teardown.
 $env->close_sockets;
 
 # Restart cleanly so the M1 probe above does not hold the pairing lock
@@ -72,7 +73,8 @@ is(scalar @$pairings, 1, 'extra pairing removed');
 ok($controller->remove_pairing('ghost-ctrl'),
    '[HAP-Pairing §7.4] removing nonexistent pairing succeeds');
 
-# Test 8: Wrong-PIN attempt is rejected and counted after unpairing
+# Test 8: The daemon rejects and counts a wrong-PIN attempt after
+# unpairing.
 $controller->close;
 $env->ensure_unpaired or die "Cannot reset pairing state\n";
 

--- a/t/openhap/integration/sandbox.t
+++ b/t/openhap/integration/sandbox.t
@@ -12,7 +12,7 @@
 # view. It asserts that startup still succeeds in the configurations
 # that worked before the sandbox existed. If you remove the pledge
 # or unveil call from bin/openhapd, the corresponding syscall is
-# simply absent from the trace.
+# absent from the trace.
 #
 # The forked children of t/fugulib/sandbox.t prove the enforcement
 # semantics: a violation aborts, and a path outside the view is

--- a/t/openhap/integration/sandbox.t
+++ b/t/openhap/integration/sandbox.t
@@ -2,23 +2,24 @@
 # ex:ts=8 sw=4:
 # Integration test: the daemon really pledges and unveils.
 #
-# A pledge violation kills the process, so "the daemon is alive and its
-# trace shows no violation" is satisfied identically by a correctly
-# pledged daemon and a completely unpledged one - a null test. What is
-# observable is the syscall itself: this file traces the daemon from
-# exec with ktrace(1) and asserts that pledge(2) is called with exactly
-# the production promise set, that unveil(2) is called for the
-# inventory and then locked, and that startup still succeeds in the
-# configurations that worked before the sandbox existed. Remove the
-# pledge or unveil call from bin/openhapd and the corresponding
-# syscall is simply absent from the trace.
+# A pledge violation kills the process. Thus a correctly pledged
+# daemon and a completely unpledged one both satisfy "the daemon is
+# alive and its trace shows no violation". That check is a null
+# test. The syscall itself is observable. This file traces the
+# daemon from exec with ktrace(1). It asserts that the daemon calls
+# pledge(2) with exactly the production promise set. It asserts that
+# the daemon calls unveil(2) for the inventory and then locks the
+# view. It asserts that startup still succeeds in the configurations
+# that worked before the sandbox existed. If you remove the pledge
+# or unveil call from bin/openhapd, the corresponding syscall is
+# simply absent from the trace.
 #
-# Enforcement semantics (a violation aborts; a path outside the view
-# is unreachable) are proven by t/fugulib/sandbox.t's forked children.
-# No operator-supplied read path exists to probe enforcement through
-# the running daemon itself, so this file deliberately does not
-# pretend to: the trace proves the daemon's participation, the unit
-# tier proves the kernel's.
+# The forked children of t/fugulib/sandbox.t prove the enforcement
+# semantics: a violation aborts, and a path outside the view is
+# unreachable. No operator-supplied read path exists to probe
+# enforcement through the running daemon itself. Thus this file
+# deliberately makes no such probe. The trace proves the daemon's
+# participation. The unit tier proves the kernel's.
 
 use v5.36;
 use Test::More;
@@ -37,15 +38,15 @@ my $daemon      = -x '/usr/local/bin/openhapd'
     ? '/usr/local/bin/openhapd'
     : '/usr/local/sbin/openhapd';
 
-# The traced instance needs the HAP port, so stop the rc daemon first
+# The traced instance needs the HAP port. Stop the rc daemon first.
 system('rcctl stop openhapd >/dev/null 2>&1');
 sleep 1;
 
-# Run the daemon in the foreground under ktrace; -i follows any
-# children (there must be none, and that is asserted below). Invoke
-# perl on the script directly: the daemon's #!/usr/bin/env shebang
-# would put env in the trace, and env pledges "stdio exec" itself,
-# which would poison the promise assertions below.
+# Run the daemon in the foreground under ktrace. The -i flag follows
+# any children. There must be none, and the test asserts that below.
+# Invoke perl on the script directly. The daemon's #!/usr/bin/env
+# shebang would put env in the trace. env pledges "stdio exec"
+# itself, and that would poison the promise assertions below.
 my $pid = fork // die "fork: $!";
 if ($pid == 0) {
 	exec 'ktrace', '-i', '-f', $trace, $^X, $daemon, '-f', '-c',
@@ -56,8 +57,8 @@ if ($pid == 0) {
 ok($env->wait_for_hap_port, 'traced daemon serves HAP')
     or diag 'daemon did not open the HAP port under ktrace';
 
-# No child processes while it runs (phase 2's contract; what keeps
-# proc/exec out of the promise set)
+# No child processes while it runs. This is phase 2's contract. It
+# keeps proc/exec out of the promise set.
 chomp(my $children = `pgrep -P $pid 2>/dev/null`);
 is($children, '', 'traced daemon has no child processes');
 
@@ -68,17 +69,18 @@ my $kdump = `kdump -f $trace 2>&1`;
 ok(length $kdump, 'kdump produced a trace');
 
 # kdump folds long string records at the screen width with a
-# backslash-newline-tab continuation; the 49-byte promise string folds
-# mid-word, so joined lines are what the assertions must see
+# backslash-newline-tab continuation. The 49-byte promise string
+# folds mid-word. Thus the assertions must see joined lines.
 $kdump =~ s/\\\n\t//g;
 
-# The pledge syscall, with the promise-string argument exactly the
-# production set: an empty string, a typo, or a stray "proc exec"
-# all fail here. The kernel ktraces the copied-in promise string as a
-# structure record, which kdump renders as STRU promise="..."
-# (sys/kern/kern_pledge.c parsepledges, usr.bin/kdump/ktrstruct.c).
-# OpenBSD::Pledge dedupes and sorts the promises before the syscall,
-# so the on-the-wire string is the sorted form of the production set.
+# The pledge syscall must have exactly the production set as its
+# promise-string argument. An empty string, a typo, or a stray
+# "proc exec" all fail here. The kernel ktraces the copied-in
+# promise string as a structure record. kdump renders the record as
+# STRU promise="..." (sys/kern/kern_pledge.c parsepledges,
+# usr.bin/kdump/ktrstruct.c). OpenBSD::Pledge dedupes and sorts the
+# promises before the syscall. Thus the on-the-wire string is the
+# sorted form of the production set.
 my $promises = join ' ',
     sort qw(stdio rpath wpath cpath fattr flock inet dns unix);
 like($kdump, qr/CALL\s+pledge\(/, 'pledge(2) is called');
@@ -87,10 +89,10 @@ like($kdump, qr/STRU\s+promise="\Q$promises\E"/,
 unlike($kdump, qr/STRU\s+promise="[^"]*\b(?:proc|exec)\b[^"]*"/,
        'no promise set in the trace grants proc, exec or prot_exec');
 
-# The unveil syscalls: the daemon really builds a view (the permission
-# strings appear as STRU flags= records, and db_path's rwc is unique
-# to unveil - unlike a NAMI, which any open(2) would also leave), and
-# a final unveil(2) with both arguments NULL locks it
+# The unveil syscalls: the daemon really builds a view, and a final
+# unveil(2) with both arguments NULL locks it. The permission
+# strings appear as STRU flags= records. db_path's rwc is unique to
+# unveil. A NAMI is not, because any open(2) also leaves one.
 my @unveils = $kdump =~ /CALL\s+unveil\(([^)]*)\)/g;
 cmp_ok(scalar @unveils, '>=', 3,
        'unveil(2) called for the inventory');
@@ -99,8 +101,8 @@ like($kdump, qr/STRU\s+flags="rwc"/,
 like($kdump, qr/CALL\s+unveil\(0,0\)/, 'the view is locked');
 is($unveils[-1], '0,0', 'the lock is the last unveil call');
 
-# pledge comes after the lock, closing the ordering the call site
-# promises
+# pledge comes after the lock. This closes the ordering that the
+# call site promises.
 my ($lock_pos, $pledge_pos) = (-1, -1);
 while ($kdump =~ /CALL\s+unveil\(0,0\)/g) { $lock_pos   = $-[0] }
 while ($kdump =~ /CALL\s+pledge\(/g)      { $pledge_pos = $-[0] }
@@ -111,14 +113,15 @@ unlink $trace;
 
 # Permanent negative control: the identical trace pipeline over a
 # perl process that deliberately does not pledge or unveil must show
-# neither syscall. This is what proves the positive assertions above
-# can fail - the demonstration plan 005 required - without the
-# test-only daemon override it forbids: if the pledge or unveil call
-# were dropped from bin/openhapd, its trace would look exactly like
-# this one, and the assertions above would go red. It also pins the
-# detector itself: a kdump format drift that made the regexes match
-# ambient records would fail here. ktrace(1) itself calls neither
-# syscall, so any such record in this trace is a defect.
+# neither syscall. This control proves that the positive assertions
+# above can fail. Plan 005 required that demonstration. The control
+# needs no test-only daemon override, which plan 005 forbids. If
+# bin/openhapd dropped the pledge or unveil call, its trace would
+# look exactly like this one, and the assertions above would go red.
+# The control also pins the detector itself: a kdump format drift
+# that made the regexes match ambient records would fail here.
+# ktrace(1) itself calls neither syscall. Thus any such record in
+# this trace is a defect.
 my $neg_trace = "/tmp/openhapd-negctl-$$";
 system('ktrace', '-i', '-f', $neg_trace, $^X, '-e', 'exit 0');
 my $neg = `kdump -f $neg_trace 2>&1`;
@@ -135,8 +138,8 @@ unlike($neg, qr/CALL\s+unveil\(/,
 unlink $neg_trace;
 
 # Startup still succeeds in every configuration that worked before
-# the sandbox: a missing config file must be an optional unveil entry,
-# never a refusal to boot ...
+# the sandbox. A missing config file must be an optional unveil
+# entry, never a refusal to boot.
 my $absent_conf = "/tmp/absent-openhapd-$$.conf";
 $pid = fork // die "fork: $!";
 if ($pid == 0) {
@@ -149,9 +152,10 @@ ok($env->wait_for_hap_port, 'daemon serves with no config file at all');
 kill 'TERM', $pid;
 waitpid $pid, 0;
 
-# ... and -f on a host with no daemon log file (the row is optional;
-# -f never creates it). The rc daemon holds its own fd, so removing
-# the file underneath it is safe, and rcctl start recreates it below.
+# Startup also succeeds with -f on a host that has no daemon log
+# file. The log row is optional, and -f never creates the file. The
+# rc daemon holds its own fd. Thus the test can safely remove the
+# file underneath it. rcctl start recreates the file below.
 unlink '/var/log/openhapd.log';
 $pid = fork // die "fork: $!";
 if ($pid == 0) {

--- a/t/openhap/integration/tasmota-protocol.t
+++ b/t/openhap/integration/tasmota-protocol.t
@@ -1,8 +1,9 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Integration test: MQTT <-> HAP round trips for Tasmota devices. Each
-# simulated device message is published on the real broker and its
-# effect asserted through the paired HAP data plane, and vice versa.
+# Integration test: MQTT <-> HAP round trips for Tasmota devices.
+# The test publishes each simulated device message on the real
+# broker and asserts its effect through the paired HAP data plane.
+# The test also covers the opposite direction.
 
 use v5.36;
 use Test::More tests => 11;

--- a/t/openhap/mqtt.t
+++ b/t/openhap/mqtt.t
@@ -104,14 +104,14 @@ SKIP: {
 {
     my $mqtt = OpenHAP::MQTT->new();
     
-    # Should not die, just return early
+    # The publish must not die. It returns early.
     eval {
         $mqtt->publish('test/topic', 'test payload');
     };
     ok(!$@, 'Publish when not connected does not die');
 }
 
-# Test topic matching - exact match
+# Test topic matching: exact match
 {
     my $mqtt = OpenHAP::MQTT->new();
     
@@ -121,7 +121,7 @@ SKIP: {
         'Different topic no match');
 }
 
-# Test topic matching - single level wildcard (+)
+# Test topic matching: single level wildcard (+)
 {
     my $mqtt = OpenHAP::MQTT->new();
     
@@ -135,7 +135,7 @@ SKIP: {
         'Single wildcard only matches one level');
 }
 
-# Test topic matching - multi level wildcard (#)
+# Test topic matching: multi level wildcard (#)
 {
     my $mqtt = OpenHAP::MQTT->new();
     
@@ -149,7 +149,7 @@ SKIP: {
         'Multi wildcard prefix must match');
 }
 
-# Test topic matching - combined wildcards
+# Test topic matching: combined wildcards
 {
     my $mqtt = OpenHAP::MQTT->new();
     
@@ -233,10 +233,11 @@ SKIP: {
     is($result, 0, 'tick returns 0 when not connected');
 }
 
-# The internal buffer callback registered with Net::MQTT::Simple must
-# tolerate extra arguments: since 1.33 the library passes a retain flag
-# as a third argument, and a two-argument signature dies on every
-# incoming message (regression from the integration suite)
+# The internal buffer callback that the module registers with
+# Net::MQTT::Simple must accept extra arguments. Since 1.33 the
+# library passes a retain flag as a third argument. A two-argument
+# signature dies on every incoming message. The integration suite
+# found this regression.
 {
     package StubMQTTClient;
 
@@ -265,7 +266,8 @@ SKIP: {
         [['stat/device/POWER', 'ON']],
         'message buffered without the retain flag');
 
-    # resubscribe re-registers callbacks with the same tolerance
+    # A resubscribe registers the callbacks again. They also accept
+    # a third argument.
     $mqtt->{pending_messages} = [];
     $stub->{callbacks}        = {};
     $mqtt->resubscribe();
@@ -290,26 +292,28 @@ SKIP: {
     skip 'Net::MQTT::Simple not available', 2 unless eval { require Net::MQTT::Simple; 1 };
     
     my $mqtt = OpenHAP::MQTT->new(
-        host => '192.0.2.1',  # TEST-NET-1 (guaranteed unreachable)
+        host => '192.0.2.1',  # TEST-NET-1, always unreachable
         port => 9999,
     );
     
-    # Capture STDERR to ensure no warnings leak through
+    # Capture STDERR to make sure that no warnings leak through
     my $stderr = '';
     {
         local *STDERR;
         open STDERR, '>', \$stderr or die "Cannot redirect STDERR: $!";
         
-        # Try to connect with short timeout - should fail silently
+        # Try to connect with a short timeout. The attempt must
+        # fail silently.
         $mqtt->mqtt_connect(1);
     }
     
-    # No warnings should have leaked to STDERR (they should be logged instead)
+    # No warnings must leak to STDERR. The module logs them instead.
     ok(!$stderr, 'Connection failures do not print to STDERR')
         or diag("Leaked to STDERR: $stderr");
     
-    # Note: This may or may not succeed depending on whether 192.0.2.1:9999
-    # is actually reachable, so we just check that warnings were captured
+    # Note: the connect can succeed or fail, because 192.0.2.1:9999
+    # can be reachable or not. Thus the test only makes sure that
+    # the warnings are captured.
     pass('Connection attempt completed');
 }
 

--- a/t/openhap/pairing.t
+++ b/t/openhap/pairing.t
@@ -110,7 +110,7 @@ SKIP: {
     
     my $session = OpenHAP::Session->new(socket => 'dummy');
     
-    # Create TLV with invalid state (99)
+    # Create a TLV with an invalid state (99)
     require OpenHAP::TLV;
     my $body = OpenHAP::TLV::encode(
         OpenHAP::Pairing::kTLVType_State(), pack('C', 99),
@@ -140,7 +140,7 @@ SKIP: {
     
     my $session = OpenHAP::Session->new(socket => 'dummy');
     
-    # Create TLV with invalid state (99)
+    # Create a TLV with an invalid state (99)
     require OpenHAP::TLV;
     my $body = OpenHAP::TLV::encode(
         OpenHAP::Pairing::kTLVType_State(), pack('C', 99),
@@ -175,7 +175,7 @@ SKIP: {
     my $storage = OpenHAP::Storage->new(db_path => $temp_dir);
     my ($ltsk, $ltpk) = OpenHAP::Crypto::generate_keypair_ed25519();
     
-    # Reset global state for clean test
+    # Reset the global state for a clean test
     OpenHAP::Pairing->clear_pairing_state();
     OpenHAP::Pairing->reset_auth_attempts();
     
@@ -188,7 +188,7 @@ SKIP: {
     
     my $session = OpenHAP::Session->new(socket => 'dummy1');
     
-    # Create TLV with invalid method (99)
+    # Create a TLV with an invalid method (99)
     require OpenHAP::TLV;
     my $body = OpenHAP::TLV::encode(
         OpenHAP::Pairing::kTLVType_State(), pack('C', 1),
@@ -198,7 +198,7 @@ SKIP: {
     my $response = $pairing->handle_pair_setup($body, $session);
     ok(defined $response, 'Invalid method returns response');
     
-    # Decode response to check for error
+    # Decode the response to check for an error
     my %resp_tlv = OpenHAP::TLV::decode($response);
     my $error = unpack('C', $resp_tlv{ OpenHAP::Pairing::kTLVType_Error() } // '');
     is($error, OpenHAP::Pairing::kTLVError_Unknown(),
@@ -218,7 +218,7 @@ SKIP: {
     my $storage = OpenHAP::Storage->new(db_path => $temp_dir);
     my ($ltsk, $ltpk) = OpenHAP::Crypto::generate_keypair_ed25519();
     
-    # Reset global state
+    # Reset the global state
     OpenHAP::Pairing->clear_pairing_state();
     OpenHAP::Pairing->reset_auth_attempts();
     
@@ -246,7 +246,8 @@ SKIP: {
     is($error, OpenHAP::Pairing::kTLVError_Unavailable(),
         '[HAP-Pairing §2.4] already paired returns kTLVError_Unavailable in M2');
     
-    # But PairSetupWithAuth (method=1) should be allowed even when paired
+    # The accessory must allow PairSetupWithAuth (method=1) even
+    # when paired
     OpenHAP::Pairing->clear_pairing_state();
     my $session2 = OpenHAP::Session->new(socket => 'dummy3');
     my $body_auth = OpenHAP::TLV::encode(
@@ -274,7 +275,7 @@ SKIP: {
     my $storage = OpenHAP::Storage->new(db_path => $temp_dir);
     my ($ltsk, $ltpk) = OpenHAP::Crypto::generate_keypair_ed25519();
     
-    # Reset global state
+    # Reset the global state
     OpenHAP::Pairing->clear_pairing_state();
     OpenHAP::Pairing->reset_auth_attempts();
     
@@ -291,13 +292,13 @@ SKIP: {
         OpenHAP::Pairing::kTLVType_Method(), pack('C', 0),
     );
     
-    # First session starts pairing
+    # The first session starts the pairing
     my $session1 = OpenHAP::Session->new(socket => 'dummy4');
     my $response1 = $pairing->handle_pair_setup($body, $session1);
     my %resp1 = OpenHAP::TLV::decode($response1);
     my $state1 = unpack('C', $resp1{ OpenHAP::Pairing::kTLVType_State() } // '');
     
-    # Second session tries to start pairing - should get Busy
+    # The second session tries to start the pairing and must get Busy
     my $session2 = OpenHAP::Session->new(socket => 'dummy5');
     my $response2 = $pairing->handle_pair_setup($body, $session2);
     my %resp2 = OpenHAP::TLV::decode($response2);
@@ -315,7 +316,7 @@ SKIP: {
         '[HAP-Pairing §8] failed attempt counter starts at 0');
 }
 
-# Test M2 response doesn't contain '0x' prefix in public key (Bug fix)
+# Test that the M2 public key does not contain a '0x' prefix (bug fix)
 SKIP: {
     eval {
         require Crypt::Ed25519;
@@ -326,7 +327,7 @@ SKIP: {
     my $storage = OpenHAP::Storage->new(db_path => $temp_dir);
     my ($ltsk, $ltpk) = OpenHAP::Crypto::generate_keypair_ed25519();
     
-    # Reset global state
+    # Reset the global state
     OpenHAP::Pairing->clear_pairing_state();
     OpenHAP::Pairing->reset_auth_attempts();
     
@@ -353,12 +354,13 @@ SKIP: {
     my $public_key = $resp{ OpenHAP::Pairing::kTLVType_PublicKey() };
     my $hex = unpack('H*', $public_key);
     
-    # Check that the hex doesn't start with '30' which is ASCII '0'
-    # If the bug existed, we'd see '307830...' (0x30='0', 0x78='x')
+    # Make sure that the hex does not start with '30', which is
+    # ASCII '0'. With the bug, the hex would start with '307830...'
+    # (0x30='0', 0x78='x').
     isnt(substr($hex, 0, 4), '3078',
         '[HAP-Pairing §2.4] public key does not start with ASCII "0x"');
 
-    # The public key should be 384 bytes (3072 bits)
+    # The public key must be 384 bytes (3072 bits)
     is(length($public_key), 384,
         '[HAP-Pairing §2.4] M2 public key B is 384 bytes (3072 bits)');
     

--- a/t/openhap/pin.t
+++ b/t/openhap/pin.t
@@ -9,7 +9,7 @@ $OpenHAP::logger = FuguLib::Log->new(mode => 'quiet', ident => 'test');
 
 use_ok('OpenHAP::PIN');
 
-# Test normalize_pin - basic functionality
+# Test normalize_pin: basic operation
 {
 	my $pin = OpenHAP::PIN::normalize_pin('1234-5678');
 	is($pin, '12345678',
@@ -36,7 +36,7 @@ use_ok('OpenHAP::PIN');
 	is($pin, '12345678', 'Normalize PIN with spaces and dashes');
 }
 
-# Test normalize_pin - invalid formats
+# Test normalize_pin: invalid formats
 {
 	my $pin = OpenHAP::PIN::normalize_pin('123-4567');
 	is($pin, undef,
@@ -73,7 +73,7 @@ use_ok('OpenHAP::PIN');
 	is($pin, undef, 'Reject incomplete PIN');
 }
 
-# Test validate_pin - valid PINs
+# Test validate_pin: valid PINs
 {
 	ok(OpenHAP::PIN::validate_pin('9876-5432'), 'Valid PIN with dash');
 }
@@ -90,8 +90,8 @@ use_ok('OpenHAP::PIN');
 	ok(OpenHAP::PIN::validate_pin('0000-0001'), 'Valid PIN starting with zeros');
 }
 
-# Test validate_pin - trivial setup codes disallowed by HAP
-# (Apple HAP R2 5.3; the trivial-code blacklist is not in spec/)
+# Test validate_pin: HAP disallows trivial setup codes (Apple HAP R2
+# 5.3). The trivial-code blacklist is not in spec/.
 {
 	ok(!OpenHAP::PIN::validate_pin('00000000'), 'Reject 00000000');
 }
@@ -140,7 +140,7 @@ use_ok('OpenHAP::PIN');
 	ok(!OpenHAP::PIN::validate_pin('87654321'), 'Reject 87654321');
 }
 
-# Test validate_pin - invalid PINs with dashes (should still be rejected)
+# Test validate_pin: it must also reject invalid PINs with dashes
 {
 	ok(!OpenHAP::PIN::validate_pin('0000-0000'), 'Reject 0000-0000');
 }
@@ -157,7 +157,7 @@ use_ok('OpenHAP::PIN');
 	ok(!OpenHAP::PIN::validate_pin('8765-4321'), 'Reject 8765-4321 (reverse sequential)');
 }
 
-# Test validate_pin - malformed input
+# Test validate_pin: malformed input
 {
 	ok(!OpenHAP::PIN::validate_pin('123-4567'), 'Reject malformed PIN (7 digits)');
 }

--- a/t/openhap/service.t
+++ b/t/openhap/service.t
@@ -105,7 +105,8 @@ use_ok('OpenHAP::Service');
     my $service = OpenHAP::Service->new(type => 'Switch', iid => 10);
     my $json = $service->to_json();
 
-    # Switch UUID is 00000049-0000-1000-8000-0026BB765291, short form is "49"
+    # The Switch UUID is 00000049-0000-1000-8000-0026BB765291. The
+    # short form is "49".
     is($json->{type}, '49', 'Service type is in short form');
 
     # Test AccessoryInformation (3E)
@@ -119,7 +120,7 @@ use_ok('OpenHAP::Service');
     is($therm_json->{type}, '4A', 'Thermostat type is 4A in short form');
 }
 
-# Test custom UUID is preserved (not shortened)
+# Test that the module does not shorten a custom UUID
 {
     my $custom_uuid = '12345678-1234-1234-1234-123456789012';
     my $service = OpenHAP::Service->new(type => $custom_uuid, iid => 30);

--- a/t/openhap/session.t
+++ b/t/openhap/session.t
@@ -67,7 +67,7 @@ SKIP: {
     ok(defined $encrypted, 'Data encrypted');
     isnt($encrypted, $plaintext, 'Encrypted data differs from plaintext');
     
-    # Create new session with same keys for decryption
+    # Create a new session with the same keys for decryption
     my $session2 = OpenHAP::Session->new(socket => 'dummy');
     $session2->set_encryption($key, $key);
     

--- a/t/openhap/srp.t
+++ b/t/openhap/srp.t
@@ -25,7 +25,7 @@ use_ok('OpenHAP::SRP');
     my $bytes = OpenHAP::SRP::_bigint_to_bytes($n);
     is(unpack('H*', $bytes), '05', '_bigint_to_bytes converts 5 correctly');
 
-    # Test that 0x prefix is stripped
+    # Test that the function removes the 0x prefix
     my $n2 = Math::BigInt->new(255);
     my $bytes2 = OpenHAP::SRP::_bigint_to_bytes($n2);
     is(unpack('H*', $bytes2), 'ff', '_bigint_to_bytes strips 0x prefix');
@@ -36,8 +36,8 @@ use_ok('OpenHAP::SRP');
     is(unpack('H*', $bytes3), '00000005', '_bigint_to_bytes pads to 4 bytes');
     is(length($bytes3), 4, 'Padded output is 4 bytes');
 
-    # Test odd-length hex gets padded with leading zero
-    my $n4 = Math::BigInt->new(4095);  # 0xFFF - 3 hex digits
+    # Test that the function pads odd-length hex with a leading zero
+    my $n4 = Math::BigInt->new(4095);  # 0xFFF has 3 hex digits
     my $bytes4 = OpenHAP::SRP::_bigint_to_bytes($n4);
     is(unpack('H*', $bytes4), '0fff', '_bigint_to_bytes pads odd-length hex');
 
@@ -76,7 +76,7 @@ use_ok('OpenHAP::SRP');
     isa_ok($srp->{N}, 'Math::BigInt', 'N is BigInt');
     isa_ok($srp->{g}, 'Math::BigInt', 'g is BigInt');
 
-    # g should be 5
+    # The g parameter must be 5
     is($srp->{g}->numify(), 5, 'g parameter is 5');
 }
 
@@ -126,7 +126,7 @@ use_ok('OpenHAP::SRP');
     $srp->compute_verifier($salt, '123-45-678');
     $srp->generate_server_public();
 
-    # Create dummy client public key (32 bytes)
+    # Create a dummy client public key (32 bytes)
     my $A = 'A' x 32;
 
     my $K = $srp->compute_session_key($A);
@@ -142,12 +142,12 @@ use_ok('OpenHAP::SRP');
     $srp->compute_verifier($salt, '123-45-678');
     $srp->generate_server_public();
 
-    # Test with A = 0 (should be rejected)
+    # Test with A = 0. The module must reject it.
     my $A_zero = "\x00" x 384;  # 3072 bits = 384 bytes
     my $K = $srp->compute_session_key($A_zero);
     ok(!defined $K, '[HAP-Pairing §2.6] session key rejected when A is zero');
 
-    # Test with A = N (should be rejected since A mod N == 0)
+    # Test with A = N. The module must reject it because A mod N == 0.
     # Get N as bytes
     my $N_hex = $srp->{N}->as_hex();
     $N_hex =~ s/^0x//;
@@ -183,7 +183,7 @@ use_ok('OpenHAP::SRP');
     my $A = 'A' x 32;
     $srp->compute_session_key($A);
 
-    # generate_server_proof should die because verify_client_proof was not called
+    # generate_server_proof must die without a verify_client_proof call
     eval {
         $srp->generate_server_proof();
     };
@@ -198,7 +198,7 @@ use_ok('OpenHAP::SRP');
     $srp->compute_verifier($salt, '123-45-678');
     $srp->generate_server_public();
 
-    # generate_server_proof should die because compute_session_key was not called
+    # generate_server_proof must die without a compute_session_key call
     eval {
         $srp->generate_server_proof();
     };

--- a/t/openhap/srp_padding.t
+++ b/t/openhap/srp_padding.t
@@ -92,7 +92,7 @@ use_ok('OpenHAP::Crypto');
         . 'wire encodings derive the same session key');
 }
 
-# Test full SRP exchange with known values to verify padding
+# Test full SRP exchange with known values to check the padding
 {
     # Set up SRP with known parameters
     my $password = '123-45-678';

--- a/t/openhap/srp_padding.t
+++ b/t/openhap/srp_padding.t
@@ -19,11 +19,13 @@ BEGIN {
 use_ok('OpenHAP::SRP');
 use_ok('OpenHAP::Crypto');
 
-# Test that A and B are correctly padded to N_len (384 bytes) when computing
-# u, M1, and M2. This is critical for SRP-6a compatibility with HomeKit.
+# Test that the module pads A and B to N_len (384 bytes) when it
+# computes u, M1, and M2. This padding is critical for SRP-6a
+# compatibility with HomeKit.
 #
-# Bug: The original implementation did not pad A and B to 384 bytes before
-# hashing, causing proof verification failures with iOS Home app.
+# Bug: the original implementation did not pad A and B to 384 bytes
+# before hashing. This caused proof verification failures with the
+# iOS Home app.
 
 # Test padding of A and B in u computation
 {
@@ -32,21 +34,22 @@ use_ok('OpenHAP::Crypto');
     $srp->compute_verifier($salt, '123-45-678');
     my $B = $srp->generate_server_public();
 
-    # Create a client public key A that's shorter than 384 bytes when encoded
-    # For example, a small value like 256 (0x100) would be 2 bytes unpadded
+    # Create a client public key A that encodes to less than 384
+    # bytes. For example, a small value such as 256 (0x100) is 2
+    # bytes without padding.
     my $A_small = Math::BigInt->new(256);
     my $A_bytes_unpadded = OpenHAP::SRP::_bigint_to_bytes($A_small);
 
-    # Without padding, this would be 2 bytes
+    # Without padding, the value is 2 bytes
     ok(length($A_bytes_unpadded) < 384,
         'Small A is less than 384 bytes without padding');
 
-    # With padding, it should be 384 bytes
+    # With padding, the value must be 384 bytes
     my $A_bytes_padded = OpenHAP::SRP::_bigint_to_bytes($A_small, 384);
     is(length($A_bytes_padded), 384,
         '[HAP-Pairing §2.5] small A is left-padded to 384 bytes');
 
-    # Verify padding is with leading zeros
+    # Make sure the padding uses leading zeros
     is(unpack('H*', $A_bytes_padded), ('00' x 382) . '0100',
         '[HAP-Pairing §2.5] A is padded with leading zeros');
 }
@@ -58,8 +61,8 @@ use_ok('OpenHAP::Crypto');
     $srp->compute_verifier($salt, '123-45-678');
     $srp->generate_server_public();
     
-    # Create two different encodings of the same A value
-    # One with minimal encoding, one padded to 384 bytes
+    # Create two different encodings of the same A value. One
+    # encoding is minimal. The other one has padding to 384 bytes.
     my $A_val = Math::BigInt->new(12345);
     my $A_bytes_unpadded = OpenHAP::SRP::_bigint_to_bytes($A_val);
     my $A_bytes_padded = OpenHAP::SRP::_bigint_to_bytes($A_val, 384);
@@ -67,15 +70,15 @@ use_ok('OpenHAP::Crypto');
     isnt(length($A_bytes_unpadded), length($A_bytes_padded),
         'Padded and unpadded A have different lengths');
 
-    # Both should produce the same session key because internally
-    # compute_session_key pads A to 384 bytes before computing u
+    # Both encodings must give the same session key. Internally,
+    # compute_session_key pads A to 384 bytes before it computes u.
     my $K1 = $srp->compute_session_key($A_bytes_unpadded);
 
-    # Need a fresh SRP instance for second test
+    # Use a fresh SRP instance for the second test
     my $srp2 = OpenHAP::SRP->new(password => '123-45-678');
     $srp2->generate_salt();
     $srp2->compute_verifier($salt, '123-45-678');
-    # Copy the same b and B to ensure identical server state
+    # Copy the same b and B to keep the server state identical
     $srp2->{b} = $srp->{b};
     $srp2->{B} = $srp->{B};
     $srp2->{v} = $srp->{v};
@@ -95,34 +98,36 @@ use_ok('OpenHAP::Crypto');
     my $password = '123-45-678';
     my $srp = OpenHAP::SRP->new(password => $password);
     
-    # Generate a known salt (for reproducibility, use a fixed value in real test)
+    # Generate a known salt. For reproducibility, use a fixed value
+    # in a real test.
     my $salt = $srp->generate_salt();
     $srp->compute_verifier($salt, $password);
     my $B = $srp->generate_server_public();
     
-    # Create a valid client public key A (must be non-zero mod N)
-    # For testing, use a small valid value
+    # Create a valid client public key A. It must be non-zero mod N.
+    # For the test, use a small valid value.
     my $A_int = Math::BigInt->new(2)->bmodpow(Math::BigInt->new(256), $srp->{N});
     my $A_bytes = OpenHAP::SRP::_bigint_to_bytes($A_int, 384);
     
-    # Compute session key (this internally computes u = H(PAD(A) | PAD(B)))
+    # Compute the session key. This internally computes
+    # u = H(PAD(A) | PAD(B)).
     my $K = $srp->compute_session_key($A_bytes);
     ok(defined $K, 'Session key computed successfully');
     is(length($K), 64,
         '[HAP-Pairing §2.6] session key K = H(S) is 64 bytes (SHA-512)');
     
-    # Verify internal A is stored correctly
+    # Make sure the object stores the internal A
     ok(defined $srp->{A}, 'A is stored in SRP object');
     
-    # Compute client proof M1
-    # The client would compute this, but we can verify our verification works
-    # For now, just test that verify_client_proof uses padded values
+    # Compute the client proof M1. The client usually computes this
+    # value, but the test can make sure that the verification works.
+    # For now, only test that verify_client_proof uses padded values.
     my $M1_dummy = 'X' x 64;  # Wrong proof for this test
     my $result = $srp->verify_client_proof($M1_dummy);
     ok(!$result, '[HAP-Pairing §2.6] wrong client proof M1 is rejected');
 }
 
-# Test N_len constant matches our padding expectation
+# Test that the N_len constant matches the padding expectation
 {
     # N is 3072 bits = 384 bytes
     my $N_len = length($OpenHAP::Crypto::N_3072);

--- a/t/openhap/storage.t
+++ b/t/openhap/storage.t
@@ -9,7 +9,7 @@ use File::Temp qw(tempdir);
 
 use_ok('OpenHAP::Storage');
 
-# Create temporary directory for testing
+# Create a temporary directory for the tests
 my $temp_dir = tempdir(CLEANUP => 1);
 
 # Test storage initialization

--- a/t/openhap/tasmota.t
+++ b/t/openhap/tasmota.t
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
 # Unit tests for the Tasmota device modules: constructors, initial
-# state, and helper math. Protocol behavior (topics, payloads, message
-# handling) is covered by the spec-cited tests in t/conformance/.
+# state, and helper math. The spec-cited tests in t/conformance/
+# cover the protocol behavior (topics, payloads, message handling).
 
 use v5.36;
 use Test::More;

--- a/t/openhap/test-controller.t
+++ b/t/openhap/test-controller.t
@@ -1,8 +1,9 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
 # Unit tests for OpenHAP::Test::Controller: constructor, transport
-# injection and error paths. Full protocol exchanges are covered by
-# t/conformance/hap-pairing-exchange.t.
+# injection and error paths. The conformance tests in
+# t/conformance/hap-pairing-exchange.t cover the full protocol
+# exchanges.
 
 use v5.36;
 use Test::More;
@@ -60,7 +61,7 @@ use_ok('OpenHAP::Pairing');
 		2, 'headers parsed and lowercased' );
 }
 
-# Connection refused: pair_setup fails with last_error set
+# Connection refused: pair_setup fails and sets last_error
 {
 	my $controller = OpenHAP::Test::Controller->new(
 		host    => '127.0.0.1',
@@ -74,7 +75,8 @@ use_ok('OpenHAP::Pairing');
 		'error mentions the connection failure' );
 }
 
-# Malformed TLV response: error recorded, no crash
+# Malformed TLV response: the controller records the error and does
+# not crash
 {
 	my $transport = sub ($request) {
 		my $body = "\x06\xFF\x01";    # length past end of buffer
@@ -92,7 +94,7 @@ use_ok('OpenHAP::Pairing');
 	ok( defined $controller->last_error, 'last_error set' );
 }
 
-# TLV error response: the error code is exposed via last_error
+# TLV error response: last_error exposes the error code
 {
 	my $transport = sub ($request) {
 		my $body = OpenHAP::TLV::encode(

--- a/t/openhap/tlv.t
+++ b/t/openhap/tlv.t
@@ -29,16 +29,17 @@ use_ok('OpenHAP::TLV');
 
 # Test TLV order preservation
 {
-    # Encode with specific order (State before PublicKey before Salt)
-    # Use values that don't conflict with type bytes
+    # Encode with a specific order: State before PublicKey before
+    # Salt. Use values that do not conflict with the type bytes.
     my $encoded = OpenHAP::TLV::encode(
         0x06, pack('C', 0xAA),       # State = 0xAA (unique)
         0x03, 'public_key_data',     # PublicKey
         0x02, 'salt_data_here',      # Salt
     );
 
-    # Verify order is preserved by checking TLV header positions
-    # Look for type-length pairs to find the start of each TLV item
+    # Check the TLV header positions to make sure the encoder keeps
+    # the order. Look for type-length pairs to find the start of
+    # each TLV item.
     my $state_pos = index($encoded, pack('CC', 0x06, 1));   # Type 0x06, length 1
     my $pubkey_pos = index($encoded, pack('CC', 0x03, 15)); # Type 0x03, length 15
     my $salt_pos = index($encoded, pack('CC', 0x02, 14));   # Type 0x02, length 14
@@ -98,7 +99,7 @@ use_ok('OpenHAP::TLV');
 
     ok(length($encoded) > 0, 'Multiple pairing entries encoded');
 
-    # Verify separator is in the encoded data
+    # Make sure the separator is in the encoded data
     my $sep_found = 0;
     my $pos = 0;
     while ($pos < length($encoded)) {

--- a/t/scripts/conventions.t
+++ b/t/scripts/conventions.t
@@ -2,10 +2,10 @@
 # ex:ts=8 sw=4:
 # Guards for scripts/ that no single script's own test would catch
 #
-# Names in scripts/ carry no extension, so nothing but the shebang says
-# what language a file is in, and several call sites - the Makefile,
-# vm-up, vm-provision, Image.pm - invoke them as bare paths.  A lost
-# exec bit or a broken shebang therefore fails at use, not at build.
+# Names in scripts/ carry no extension. Thus only the shebang says
+# what language a file is in. Several call sites invoke them as bare
+# paths: the Makefile, vm-up, vm-provision, Image.pm. A lost exec bit
+# or a broken shebang thus fails at use, not at build.
 
 use v5.36;
 use Test::More;
@@ -13,8 +13,8 @@ use FindBin qw($RealBin);
 
 my $dir = "$RealBin/../../scripts";
 
-# Named, not globbed: a script that disappears has to fail here rather
-# than shrink the list silently.
+# Named, not globbed: a script that disappears must fail here. The
+# list must not shrink silently.
 my @scripts =
     qw(deps deps-key ftp integration spec-coverage vm-provision vm-up);
 
@@ -35,8 +35,8 @@ for my $name (@scripts) {
 		"scripts/$name has an sh or perl shebang" );
 }
 
-# Every Perl script compiles. make lint and make tidy already read them,
-# but neither runs the compiler, and CI's perl -cw sweep covers only
+# Every Perl script compiles. make lint and make tidy already read
+# them, but neither runs the compiler. CI's perl -cw sweep covers only
 # lib/ and bin/.
 for my $name (@scripts) {
 	my $path = "$dir/$name";

--- a/t/scripts/deps-key.t
+++ b/t/scripts/deps-key.t
@@ -2,10 +2,10 @@
 # ex:ts=8 sw=4:
 # Unit tests for scripts/deps-key against fixture trees
 #
-# The provisioning key is consumed by scripts/vm-up (which restores the
-# snapshot named after it) and scripts/vm-provision (which saves it), so
-# the framing is a contract, not an implementation detail. These tests
-# pin it.
+# Two scripts consume the provisioning key: scripts/vm-up restores
+# the snapshot named after it, and scripts/vm-provision saves that
+# snapshot. Thus the framing is a contract, not an implementation
+# detail. These tests pin it.
 
 use v5.36;
 use Test::More;
@@ -18,8 +18,8 @@ my $script = "$RealBin/../../scripts/deps-key";
 ok( -x $script, 'deps-key script is executable' );
 
 # A deps layer whose markers are indented, as they are in the real
-# scripts/vm-provision: they sit inside an 'else' block. Anchoring the
-# extraction on '^#' once matched nothing at all, which silently dropped
+# scripts/vm-provision: they sit inside an 'else' block. An extraction
+# anchored on '^#' once matched nothing at all. That silently dropped
 # this input from the digest.
 my $PROVISION = <<'EOF';
 #!/bin/sh
@@ -46,8 +46,9 @@ sub write_file ( $path, $content )
 }
 
 # build_fixture(%override):
-#	A minimal project root. Any of the four digest inputs can be
-#	overridden; passing undef for cpanfile omits the file entirely.
+#	A minimal project root. The caller can override any of the four
+#	digest inputs. Pass undef for cpanfile to omit the file
+#	entirely.
 sub build_fixture (%override)
 {
 	my %file = (
@@ -92,8 +93,9 @@ sub key_for ($root)
 		'prints exactly 12 lowercase hex characters' );
 }
 
-# Golden vector: the framing contract, recomputed independently so a
-# change to it fails with a readable diff rather than a mystery hex
+# Golden vector: the test recomputes the framing contract
+# independently. Thus a change to the contract fails with a readable
+# diff, not a mystery hex.
 {
 	my $root = build_fixture();
 	my $expected = substr sha256_hex(
@@ -115,8 +117,8 @@ sub key_for ($root)
 		'key matches an independently computed SHA-256 of the framing' );
 }
 
-# Determinism and path independence. Path independence is what lets
-# vm-up and vm-provision agree wherever the checkout lives.
+# Determinism and path independence. Path independence lets vm-up
+# and vm-provision agree wherever the checkout lives.
 {
 	my $root = build_fixture();
 	is( key_for($root), key_for($root), 'same tree gives the same key' );
@@ -143,9 +145,9 @@ sub key_for ($root)
 		'an absent cpanfile is tolerated and gives a distinct key' );
 }
 
-# Only the deps layer of vm-provision counts: the OpenHAP layer runs on
-# every provision and never enters the snapshot, so editing it must not
-# invalidate the cached dependencies.
+# Only the deps layer of vm-provision counts: the OpenHAP layer runs
+# on every provision and never enters the snapshot. Thus an edit to it
+# must not invalidate the cached dependencies.
 {
 	my $base = key_for( build_fixture() );
 
@@ -160,8 +162,8 @@ sub key_for ($root)
 		'a change outside the markers leaves the key alone' );
 }
 
-# The labels exist so a boundary shift between two inputs cannot
-# silently produce the same digest
+# The labels make sure that a boundary shift between two inputs
+# cannot silently produce the same digest
 {
 	my $shifted = key_for(
 		build_fixture(
@@ -174,7 +176,7 @@ sub key_for ($root)
 }
 
 # Fail closed. A digest over silently-missing inputs is worse than no
-# digest: it looks valid and caches a stale layer forever.
+# digest. It looks valid and caches a stale layer forever.
 {
 	my $no_begin = $PROVISION;
 	$no_begin =~ s/^\t# BEGIN deps layer\n//m;
@@ -189,7 +191,8 @@ sub key_for ($root)
 		'no key is printed when the markers are missing' );
 }
 
-# BEGIN with no END: the case the shell version's line count let through
+# BEGIN with no END: the case that the shell version's line count let
+# through
 {
 	my $no_end = $PROVISION;
 	$no_end =~ s/^\t# END deps layer\n//m;
@@ -220,8 +223,9 @@ sub key_for ($root)
 	isnt( $exit, 0, 'a nonexistent root exits non-zero' );
 }
 
-# The real tree is well-formed, so a marker accidentally deleted from
-# scripts/vm-provision fails here rather than at provisioning time
+# The real tree is well-formed. Thus, if a marker is deleted from
+# scripts/vm-provision by accident, the test fails here, not at
+# provisioning time.
 {
 	my ( $exit, $output ) = run_tool();
 	is( $exit, 0, 'the real project tree produces a key' );

--- a/t/scripts/deps.t
+++ b/t/scripts/deps.t
@@ -2,8 +2,9 @@
 # ex:ts=8 sw=4:
 # Unit tests for scripts/deps against fixture manifests
 #
-# Everything runs under --dry-run, so no package manager is ever
-# invoked; --os drives all three platform branches from one runner.
+# Everything runs under --dry-run. Thus the tests never invoke a
+# package manager. --os drives all three platform branches from one
+# runner.
 
 use v5.36;
 use Test::More;
@@ -24,8 +25,9 @@ sub write_file ( $path, $content )
 }
 
 # fixture($os, $manifest):
-#	A directory holding deps/<os>.txt. deps reads the manifest
-#	relative to the current directory, so tests chdir into this.
+#	A directory that holds deps/<os>.txt. deps reads the manifest
+#	relative to the current directory. Thus tests chdir into this
+#	directory.
 sub fixture ( $os, $manifest )
 {
 	my $dir = tempdir( CLEANUP => 1 );
@@ -77,7 +79,7 @@ EOF
 	unlike( $output, qr/cpanm/, 'no cpanm run when a tier has no modules' );
 }
 
-# Comments and blank lines are skipped, including an indented comment
+# deps skips comments and blank lines, including an indented comment
 {
 	my ( $exit, $output ) =
 	    run_in( fixture( 'OpenBSD', $MANIFEST ), '--os OpenBSD --dry-run develop' );
@@ -115,9 +117,9 @@ EOF
 	like( $output, qr/Unknown OS: Plan9/, 'and says which OS' );
 }
 
-# List-form exec: a name containing a space stays one argument. The
-# shell version built a string and let word splitting have it, so this
-# installed two wrong packages.
+# List-form exec: a name that contains a space stays one argument.
+# The shell version built a string and let word splitting have it.
+# Thus it installed two wrong packages.
 {
 	my ( $exit, $output ) = run_in(
 		fixture( 'OpenBSD', "runtime pkg foo bar\n" ),
@@ -128,10 +130,11 @@ EOF
 		'and is passed as a single argument' );
 }
 
-# CPAN options. Both cases pin PERL_LOCAL_LIB_ROOT rather than inherit
-# it: CI sets it (.github/actions/setup-perl exports it for local::lib)
-# and a developer shell usually does not, so an inherited value makes
-# the same test assert opposite things in the two places.
+# CPAN options. Both cases pin PERL_LOCAL_LIB_ROOT rather than
+# inherit it. CI sets it: .github/actions/setup-perl exports it for
+# local::lib. A developer shell usually does not set it. Thus an
+# inherited value makes the same test assert opposite things in the
+# two places.
 {
 	my $dir = fixture( 'OpenBSD', "runtime cpan Foo::Bar\n" );
 
@@ -160,8 +163,8 @@ EOF
 	like( $output, qr/usage: deps/, 'and prints usage' );
 }
 
-# An environment that is not one of the three selects nothing, which the
-# shell version reported as a successful install.
+# An environment that is not one of the three selects nothing. The
+# shell version reported this as a successful install.
 {
 	my ( $exit, $output ) =
 	    run_in( fixture( 'OpenBSD', $MANIFEST ), '--os OpenBSD --dry-run bogus' );
@@ -190,9 +193,9 @@ EOF
 	like( $output, qr/Unknown type 'deb'/, 'and names the type' );
 }
 
-# A malformed line in another environment still fails: the shell version
-# filtered before validating, so this stayed hidden until someone ran
-# that tier.
+# A malformed line in another environment still fails: the shell
+# version filtered before it validated. Thus the bad line stayed
+# hidden until someone ran that tier.
 {
 	my ( $exit, $output ) = run_in(
 		fixture( 'OpenBSD', "runtime pkg alpha\ndevelop deb gamma\n" ),
@@ -201,7 +204,7 @@ EOF
 	isnt( $exit, 0, 'a bad line in an unselected environment still fails' );
 }
 
-# A missing manifest is not an error - most platforms have none
+# A missing manifest is not an error. Most platforms have none.
 {
 	my ( $exit, $output ) =
 	    run_in( tempdir( CLEANUP => 1 ), '--os Nosuchos --dry-run runtime' );
@@ -209,8 +212,8 @@ EOF
 	like( $output, qr/No dependencies for Nosuchos/, 'and says so' );
 }
 
-# The real manifests parse, so a typo in one fails here rather than on
-# somebody's laptop halfway through an install
+# The real manifests parse. Thus a typo in one fails here, not on
+# somebody's laptop halfway through an install.
 for my $os (qw(OpenBSD Linux Darwin)) {
 	for my $env (qw(runtime test develop)) {
 		my ( $exit, $output ) =

--- a/t/scripts/spec-coverage.t
+++ b/t/scripts/spec-coverage.t
@@ -46,14 +46,15 @@ More text.
 Nothing cites this.
 EOF
 
-# Index file (stem without '-'): listed but not counted
+# Index file (stem without '-'): the tool lists it but does not count
+# it
 write_file( "$spec_dir/HAP.md", <<'EOF' );
 # Index
 
 ## 1. Glossary
 EOF
 
-# Unnumbered file: tolerated, nothing to cover
+# Unnumbered file: the tool tolerates it. It has nothing to cover.
 write_file( "$spec_dir/IMPLEMENTATIONS.md", <<'EOF' );
 # Implementations
 
@@ -62,7 +63,8 @@ write_file( "$spec_dir/IMPLEMENTATIONS.md", <<'EOF' );
 No numbered anchors here.
 EOF
 
-# A second topic family covering the MDNS branch of the citation regex
+# A second topic family that covers the MDNS branch of the citation
+# regex
 write_file( "$spec_dir/MDNS-Fixture1.md", <<'EOF' );
 # MDNS Fixture
 
@@ -75,9 +77,10 @@ Text.
 Nothing cites this.
 EOF
 
-# Citation strings are assembled at runtime so this file's own source
-# never matches the citation grep when the tool runs on the real tree.
-# The stem carries a digit to cover stems like HAP-TLV8.
+# The test assembles the citation strings at runtime. Thus this
+# file's own source never matches the citation grep when the tool runs
+# on the real tree. The stem carries a digit to cover stems like
+# HAP-TLV8.
 my $STEM      = 'HAP-' . 'Fixture8';
 my $MDNS_STEM = 'MDNS-' . 'Fixture1';
 
@@ -96,7 +99,7 @@ sub run_tool (@args)
 	return ( $? >> 8, $output );
 }
 
-# Basic run: citations parsed and joined
+# Basic run: the tool parses and joins the citations
 {
 	my ( $exit, $output ) = run_tool();
 	is( $exit, 0, 'exits 0 with no stale citations' );
@@ -163,7 +166,7 @@ EOF
 	unlink "$test_dir/stale2.t";
 }
 
-# Citation in a .pm helper under t/ is scanned too
+# The tool also scans a citation in a .pm helper under t/
 {
 	write_file( "$test_dir/Helper.pm", <<EOF );
 # [$STEM §3] helper-level citation

--- a/t/web/site.t
+++ b/t/web/site.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # ex:ts=8 sw=4:
-# Tests for the static website produced by 'make web'
+# Tests for the static website that 'make web' produces
 
 use v5.36;
 use Test::More;
@@ -29,7 +29,7 @@ plan skip_all => 'lowdown not found' unless have('lowdown');
 plan skip_all => 'mandoc not found'  unless have('mandoc');
 
 # Build the whole site into a scratch directory.  WEBOUT points outside the
-# repository so the build cannot quietly rely on its default location.
+# repository. Thus the build cannot quietly rely on its default location.
 my $default_build = -e "$ROOT/web/build";
 my $OUT           = tempdir( CLEANUP => 1 );
 my $build_log     = `cd $ROOT && make web WEBOUT=$OUT 2>&1`;
@@ -57,25 +57,26 @@ my @NAV = (
 	'https://github.com/dickolsson/openhap',
 );
 
-# Manual sources in the tree, and the page each one must produce.  The list
-# is discovered rather than written down, so a manual that is added without
-# being published fails here instead of silently going missing.
+# Manual sources in the tree, and the page each one must produce.  The test
+# discovers the list rather than writes it down. Thus a manual that is
+# added but not published fails here. It does not silently go missing.
 my %MANUAL;
 for my $src ( sort glob("$ROOT/man/*/*") ) {
 	next unless $src =~ m{/man/([^/]+)/([^/]+)\.(1|3p|5|8)$};
 	my ( $dir, $stem, $section ) = ( $1, $2, $3 );
 
 	# FuguLib pages are module manuals: the source drops the namespace
-	# because make cannot have a colon in a target, the page keeps it
+	# because make cannot have a colon in a target. The page keeps the
+	# namespace.
 	my $name = $dir eq 'fugulib' ? "FuguLib::$stem" : $stem;
 	$MANUAL{$src} = "$name.$section.html";
 }
 
 ok( scalar keys %MANUAL, 'manual sources found in man/' );
 
-# The POD sidecars, and the page each one must produce.  Discovered the
-# same way the build discovers them, so a sidecar that is added without
-# being published shows up here as a missing file.
+# The POD sidecars, and the page each one must produce.  The test
+# discovers them the same way the build discovers them. Thus a sidecar
+# that is added but not published shows up here as a missing file.
 my %POD;
 File::Find::find(
 	sub {
@@ -101,8 +102,8 @@ for my $file ( @PAGES, @ASSETS ) {
 	ok( -s "$OUT/$file", "$file exists and is not empty" );
 }
 
-# Nothing outside WEBOUT is written: the default output directory must not
-# appear as a side effect of building somewhere else
+# The build writes nothing outside WEBOUT. The default output directory
+# must not appear as a side effect of a build somewhere else.
 SKIP: {
 	skip 'web/build predates this test', 1 if $default_build;
 	ok( !-e "$ROOT/web/build",
@@ -120,24 +121,25 @@ for my $page (@PAGES) {
 	my ($title) = $html =~ m{<title>([^<]*)</title>};
 	ok( defined $title && length $title, "$page has a title" );
 
-	# mkpage.sh substitutes the title with sed, so a title containing a
-	# slash, an ampersand or a newline would be mangled rather than
-	# escaped.  Assert no title ever does.
+	# mkpage.sh substitutes the title with sed. Thus sed would mangle,
+	# not escape, a title that contains a slash, an ampersand or a
+	# newline.  Assert that no title contains these characters.
 	unlike( $title // '', qr{[/&\n]}, "$page title is sed-safe" );
 
 	for my $link (@NAV) {
 		like( $html, qr/href="\Q$link\E"/, "$page links to $link" );
 	}
 
-	# Nothing may be root-absolute: the site is served from a project
-	# path, where a leading slash leaves the site entirely
+	# Nothing may be root-absolute: the host serves the site from a
+	# project path. There a leading slash leaves the site entirely.
 	my @refs = $html =~ m{(?:href|src)="([^"]+)"}g;
 	my @rooted = grep { m{^/} } @refs;
 	is( scalar @rooted, 0, "$page has no root-absolute reference" )
 	    or diag "offenders: @rooted";
 
-	# Every relative reference must resolve to a file that was built,
-	# and every fragment to an id that exists on the target page
+	# Every relative reference must resolve to a file that the build
+	# made. Every fragment must resolve to an id that exists on the
+	# target page.
 	for my $ref (@refs) {
 		unlike( $ref, qr{^file:}i, "$page: $ref is not a file: URL" );
 		next if $ref =~ m{^[a-z]+:};    # absolute: http, https, mailto
@@ -154,7 +156,7 @@ for my $page (@PAGES) {
 	}
 }
 
-# install.html is rendered from INSTALL.md, not retyped
+# The build renders install.html from INSTALL.md, not from retyped text
 {
 	my $html = slurp("$OUT/install.html");
 	like( $html, qr/Create the system user/,
@@ -182,7 +184,7 @@ for my $page (@PAGES) {
 		like( $index, qr{href="(?:\./)?\Q$page\E"},
 			"manuals.html links to $page" );
 
-		# '=head1 NAME' is followed by 'Module - description'
+		# 'Module - description' follows '=head1 NAME'
 		my ($desc) = slurp("$ROOT/$src")
 		    =~ m{^=head1\s+NAME\s*\n\s*\n\S+\s+-\s+(.+?)\s*$}m;
 		ok( defined $desc, "$src has a NAME description" ) or next;
@@ -192,8 +194,9 @@ for my $page (@PAGES) {
 	}
 }
 
-# The module reference covers every sidecar and nothing else.  FuguLib is
-# documented in mdoc, so its pages are not counted here.
+# The module reference covers every sidecar and nothing else.  The
+# FuguLib documentation is in mdoc. Thus the test does not count FuguLib
+# pages here.
 {
 	opendir my $dh, $OUT or die "Cannot read $OUT: $!";
 	my @module_pages =
@@ -204,9 +207,10 @@ for my $page (@PAGES) {
 		'one module page per .pod sidecar, and no more' );
 }
 
-# Cross-references: local pages link locally, everything else leaves for
-# man.openbsd.org.  mandoc decides this by looking in its working directory,
-# so this is the assertion that the staging directory is doing its job.
+# Cross-references: local pages link locally. Everything else leaves for
+# man.openbsd.org.  mandoc decides this from the contents of its working
+# directory. Thus this assertion shows that the staging directory does
+# its job.
 {
 	my $hapctl = slurp("$OUT/hapctl.8.html");
 	like( $hapctl, qr{<a class="Xr" href="\./openhapd\.8\.html">},
@@ -214,14 +218,14 @@ for my $page (@PAGES) {
 	like( $hapctl, qr{<a class="Xr" href="https://man\.openbsd\.org/rc\.8">},
 		'.Xr rc 8 leaves for man.openbsd.org' );
 
-	# Sibling module manuals cross-link, which only works because the
-	# staging directory holds them under their FuguLib:: names
+	# Sibling module manuals cross-link. This only works because the
+	# staging directory holds them under their FuguLib:: names.
 	my $daemon = slurp("$OUT/FuguLib::Daemon.3p.html");
 	like( $daemon, qr{<a class="Xr" href="\./FuguLib::State\.3p\.html">},
 		'.Xr FuguLib::State 3p links to the local page' );
 
-	# A relative URL whose first segment holds a colon is read as a
-	# scheme, so links to module manuals must keep their './'
+	# A browser reads a relative URL whose first segment holds a colon
+	# as a scheme. Thus links to module manuals must keep their './'.
 	for my $page (@PAGES) {
 		my @hrefs = slurp("$OUT/$page") =~ m{href="([^"]+)"}g;
 		my @bad   = grep {
@@ -244,7 +248,7 @@ for my $page (@PAGES) {
 	}
 }
 
-# Every page must be reachable by following links from the front page.
+# Every page must be reachable through links from the front page.
 # 404.html is the exception: the host serves it for unknown paths.
 {
 	my %seen  = ( 'index.html' => 1 );
@@ -285,8 +289,8 @@ for my $page (@PAGES) {
 	    or diag "unexpected: @unexpected";
 }
 
-# External links are collected and reported, never fetched: the build and
-# its tests touch no network
+# The test collects and reports external links. It never fetches them.
+# The build and its tests touch no network.
 {
 	my %external;
 	for my $page (@PAGES) {

--- a/web/mkindex.sh
+++ b/web/mkindex.sh
@@ -14,9 +14,9 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-# Emit the body of manuals.html from manual sources.  Grouping is by source
-# directory, which is already how the tree is organised, so the index cannot
-# drift as manuals are added.
+# Emit the body of manuals.html from manual sources.  The groups follow
+# the source directories, which is already how the tree is organised.
+# Thus the index cannot drift when you add manuals.
 # Usage: mkindex.sh <manpage|podfile>...
 
 set -eu
@@ -24,9 +24,10 @@ set -eu
 [ $# -gt 0 ] || { echo "usage: mkindex.sh <manpage|podfile>..." >&2; exit 1; }
 
 # describe <path>
-#	One-line description: the .Nd macro of an mdoc page, or the
-#	"Module - description" line of a POD =head1 NAME block.  Never
-#	retyped here -- the source page is the only copy.
+#	Print the one-line description: the .Nd macro of an mdoc page,
+#	or the "Module - description" line of a POD =head1 NAME block.
+#	This script never retypes the text.  The source page is the
+#	only copy.
 describe()
 {
 	case $1 in
@@ -53,10 +54,10 @@ describe()
 }
 
 # manual_name <path> <namespace>
-#	mdoc pages take their name from the file name, prefixed by the
-#	group's module namespace if it has one.  POD sidecars take theirs
-#	from the path under lib/, so lib/OpenHAP/Tasmota/Heater.pod is
-#	OpenHAP::Tasmota::Heater.
+#	An mdoc page takes its name from the file name, with the
+#	group's module namespace as a prefix if the group has one.  A
+#	POD sidecar takes its name from the path under lib/, so
+#	lib/OpenHAP/Tasmota/Heater.pod is OpenHAP::Tasmota::Heater.
 manual_name()
 {
 	case $1 in
@@ -86,8 +87,9 @@ manual_section()
 }
 
 # emit_entry <path> <namespace>
-#	The './' matters: a page is named FuguLib::Daemon.3p.html, and a
-#	relative URL whose first segment holds a colon reads as a scheme.
+#	The './' matters.  A page has a name such as
+#	FuguLib::Daemon.3p.html, and a relative URL whose first segment
+#	holds a colon reads as a scheme.
 emit_entry()
 {
 	name=$(manual_name "$1" "$2")
@@ -99,8 +101,9 @@ emit_entry()
 }
 
 # emit_group <heading> <anchor> <path prefix> <namespace> <path>...
-#	Emits nothing at all when no argument belongs to the group, so a
-#	group that has no manuals yet leaves no empty heading behind.
+#	The function emits nothing at all when no argument belongs to
+#	the group.  Thus a group that has no manuals yet leaves no
+#	empty heading behind.
 emit_group()
 {
 	heading=$1

--- a/web/mkindex.sh
+++ b/web/mkindex.sh
@@ -15,7 +15,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 # Emit the body of manuals.html from manual sources.  The groups follow
-# the source directories, which is already how the tree is organised.
+# the source directories, which is already how the tree is organized.
 # Thus the index cannot drift when you add manuals.
 # Usage: mkindex.sh <manpage|podfile>...
 

--- a/web/mkpage.sh
+++ b/web/mkpage.sh
@@ -14,14 +14,16 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
-# Wrap an HTML body fragment read from stdin in the shared page chrome.
+# Read an HTML body fragment from stdin.  Wrap it in the shared page
+# chrome.
 # Usage: mkpage.sh <title>
 
 set -eu
 
 [ $# -eq 1 ] && [ -n "$1" ] || { echo "usage: mkpage.sh <title>" >&2; exit 1; }
 
-# The chrome lives beside this script, so callers may run from anywhere
+# The chrome lives beside this script, so callers can run it from any
+# directory
 web=$(dirname "$0")
 
 sed "s/@TITLE@/$1/" "$web/head.html"

--- a/web/style.css
+++ b/web/style.css
@@ -148,10 +148,10 @@ footer {
 /*
  * Manual pages.
  *
- * mandoc(1) emits its own class names; the rules below adopt them into the
- * site's typography instead of shipping mandoc's default stylesheet.  Bold,
- * italic and monospace are the whole vocabulary: the target is a manual
- * page, not a syntax-highlighted document.
+ * mandoc(1) emits its own class names.  The rules below adopt them into
+ * the site's typography instead of shipping mandoc's default stylesheet.
+ * Bold, italic and monospace are the whole vocabulary.  The target is a
+ * manual page, not a syntax-highlighted document.
  */
 
 /* Running header and footer bars */
@@ -182,8 +182,8 @@ td.foot-os {
 	text-align: right;
 }
 
-/* Section and subsection headings.  As in a terminal, SECTION is flush
- * left, Subsection is half-indented, and the text is indented past both. */
+/* Section and subsection headings.  As in a terminal, SECTION sits flush
+ * left, Subsection sits at a half indent, and the text sits past both. */
 
 h1.Sh,
 h2.Ss {
@@ -222,7 +222,7 @@ a.permalink:visited {
 	display: none;
 }
 
-/* The SYNOPSIS is a two-cell table: name, then everything else */
+/* The SYNOPSIS is a two-cell table: the name, then everything else */
 
 table.Nm td {
 	vertical-align: top;
@@ -241,7 +241,8 @@ dl.Bl-tag > dd {
 	margin-left: 2em;
 }
 
-/* Inline semantics: bold for what you type, italic for what you substitute */
+/* Inline semantics.  Bold marks what you type, and italic marks what
+ * you substitute. */
 
 .Nm,
 .Cm,

--- a/web/style.css
+++ b/web/style.css
@@ -32,7 +32,7 @@ hr {
 	margin: 1em 0;
 }
 
-/* Links: openbsd.org uses one colour for visited and unvisited alike */
+/* Links: openbsd.org uses one color for visited and unvisited alike */
 
 a:link,
 a:visited {


### PR DESCRIPTION
## Summary

Rewrite the inline code comments so that they obey ASD-STE100
Simplified Technical English, as #27 did for the documentation.

- The sweep covers lib/, bin/, t/, scripts/, the Makefile, the CI
  workflows, the web tooling, the rc.d script, the sample
  configurations, and the expect scripts (156 files).
- The comments use the active voice and short sentences. Technical
  names, commands, spec citations, license headers, test
  descriptions, and code stay unchanged. A mechanical diff audit
  confirms that only comment text changed.
- A follow-up pass aligns the vocabulary: American spelling, no
  "via"/"e.g."/"etc.", "check" for an action, "make sure" before a
  condition. The verify family stays only where it names a protocol
  or crypto operation.
- One factual fix rides along: the trailing comments in
  FuguLib/Privdrop.pm labeled the real and effective IDs backwards.

Note: the comment edits in scripts/vm-provision rotate the provision
cache key. The next integration run rebuilds that layer once.

## Test plan

- `make check` passes (lint, full test suite, tidy).
- `make prettier` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqqiGT97Ld78nGWAomh93X

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqqiGT97Ld78nGWAomh93X)_