### PR TITLE
docs(plans): add plan 006 for FuguLib consolidation

### DIFF
--- a/plans/006-fugulib-consolidation/design.md
+++ b/plans/006-fugulib-consolidation/design.md
@@ -9,8 +9,9 @@ two, three, or four times:
 
 - Three config parsers read the same `key = value` plus block grammar
   (`OpenHAP::Config`, `FuguVM::Config`, `OpenHAP::Test::Integration`).
-- Three HTTP codecs exist, and only the test client frames messages correctly
-  (`OpenHAP::HTTP`, `Test::Controller`, `Test::Integration`).
+- Three HTTP codecs exist, and only the two test clients frame messages by
+  `Content-Length`; the server does not (`OpenHAP::HTTP`, `Test::Controller`,
+  `Test::Integration`).
 - Two newline-JSON socket clients share ~120 identical lines (`FuguVM::QMP`,
   `FuguVM::QGA`).
 - Three PID-file implementations exist, and two of them have no `flock` and
@@ -52,7 +53,7 @@ users yet, so a clean break is possible: no shims, no compatibility layers.
 
 ### Target FuguLib
 
-Twenty modules. Bold names are new; the others exist and are redesigned.
+Twenty-two modules. Bold names are new; the others exist and are redesigned.
 
 | Module         | Source of the code                       | Function                                                            |
 | -------------- | ---------------------------------------- | ------------------------------------------------------------------- |
@@ -78,8 +79,6 @@ Twenty modules. Bold names are new; the others exist and are redesigned.
 | **Proxy**      | `FuguVM::Proxy{,::Cache,::MetaCache}`    | caching HTTP proxy; cache and metadata as packages in the same file |
 | **EventLoop**  | `OpenHAP::HAP::run`                      | IO::Select fd handlers, timers, signal-aware stop                   |
 | **Control**    | new, over Imsg                           | UNIX control socket: server handlers and a request/response client  |
-
-(The table lists 22 rows because Proxy carries two extra packages in one file.)
 
 ### Target OpenHAP
 
@@ -117,19 +116,28 @@ graph TD
     VM[FuguVM::VM] --> FLV[FuguLib: Process JSONSocket SSH Proxy Store Util]
 ```
 
-`hapctl` gets a live channel: `openhapd` serves `status`, `devices`, and
-`pairings` over a FuguLib::Control socket. `hapctl` falls back to the PID file
-when the socket is absent.
+`hapctl` gets a live channel: `openhapd` serves `status` and `devices` over a
+FuguLib::Control socket. `hapctl` keeps its offline `check` command and falls
+back to the PID file when the socket is absent.
 
 ## Contracts
 
 - FuguLib does not know OpenHAP or FuguVM. No names, paths, or defaults leak.
 - FuguLib loads with core Perl only. Modules that wrap CPAN libraries (MQTT,
   SSH, Crypto signatures, Proxy) `require` them lazily and fail with a clear
-  message.
-- Interface convention, applied to every FuguLib module: `Class->new(%args)`
-  with named arguments; named `$class`/`$self` invocants; `die` for programming
-  errors; `undef` return plus an `error` accessor for recoverable failures.
+  message. A pledge-constrained daemon must preload the shared objects of every
+  lazily loaded module before it pledges; `openhapd` keeps `prot_exec` out of
+  its promise set, so it warms up the Crypt::\* and MQTT modules first.
+- The install target ships `lib/FuguLib/*.pm` and all 3p pages wholesale.
+  Modules whose CPAN library sits in the test or develop dependency tier (SSH,
+  Proxy) install too; without the library they are inert and fail with the clear
+  lazy-require message. The dependency manifests do not change.
+- Interface convention: object modules use `Class->new(%args)` with named
+  arguments and named `$class`/`$self` invocants; stateless helpers (File, Util,
+  Process, Sandbox, Privdrop, Daemon) use class methods. Everything `die`s for
+  programming errors. Recoverable failures return `undef`, with an `error`
+  accessor on object modules and an error field in hashref results where a
+  method returns one (Process).
 - Logger convention: modules take `log => $logger` and fall back to
   `FuguLib::Log->default`, which always returns a logger. Library code never
   dies for the lack of a logger.
@@ -137,11 +145,18 @@ when the socket is absent.
   and a `t/fugulib/` test. Moved OpenHAP and FuguVM modules keep `.pod` sidecars
   next to the `.pm`.
 - HAP wire behavior is unchanged, except these deliberate fixes: the server
-  buffers per connection and frames requests by `Content-Length`; `openhapd`
-  writes its PID file; `hapctl status` reports real state.
+  buffers per connection, frames requests by `Content-Length`, and enforces
+  request-size limits; `openhapd` writes its PID file; `hapctl status` reports
+  real state.
+- The PID file is a trust anchor: root writes `/var/run/openhapd.pid` before the
+  privilege drop and keeps it root-owned, so the unprivileged daemon cannot
+  rewrite it. The daemon does not remove it at exit — unlink in root-owned
+  `/var/run` is impossible after the drop — and `Pidfile` stale detection covers
+  leftovers.
 - Security fixes ride along: PID files lock before truncate; liveness checks
   reap zombies; secret files get mode 0600 before the write, not after; the
-  Privdrop re-escalation check fails loudly.
+  Privdrop re-escalation check fails loudly; Privdrop clears supplementary
+  groups by default.
 - `make check` and `make spec-coverage` stay green after every phase.
 
 ## Strategy

--- a/plans/006-fugulib-consolidation/design.md
+++ b/plans/006-fugulib-consolidation/design.md
@@ -1,0 +1,166 @@
+# FuguLib consolidation — Design
+
+## Problem
+
+The repository has three namespaces. FuguLib is the generic daemon library, but
+it holds only a part of the generic code. OpenHAP and FuguVM each carry
+infrastructure that is not specific to their domain. The same concerns exist
+two, three, or four times:
+
+- Three config parsers read the same `key = value` plus block grammar
+  (`OpenHAP::Config`, `FuguVM::Config`, `OpenHAP::Test::Integration`).
+- Three HTTP codecs exist, and only the test client frames messages correctly
+  (`OpenHAP::HTTP`, `Test::Controller`, `Test::Integration`).
+- Two newline-JSON socket clients share ~120 identical lines (`FuguVM::QMP`,
+  `FuguVM::QGA`).
+- Three PID-file implementations exist, and two of them have no `flock` and
+  count zombies as live processes (`FuguLib::State`, `FuguVM::State` twice).
+- Four file read/write helpers exist (`FuguVM::CLI`, `FuguVM::ImageCache`,
+  `FuguVM::State`, `OpenHAP::Storage`).
+- Two alarm guards exist, and a comment in `FuguVM::VM::_bounded` admits the
+  duplication with `OpenHAP::MQTT`.
+- Three logger conventions exist (`$OpenHAP::logger`, `FuguVM::Output`,
+  `FuguVM::CLI`).
+
+The duplicates drift, and the weakest copy usually wins. The project has no
+users yet, so a clean break is possible: no shims, no compatibility layers.
+
+## Goals
+
+1. FuguLib holds all generic code: daemon lifecycle, files, state, config, CLI,
+   sockets, HTTP, MQTT, SSH, crypto primitives, event loop, control socket.
+2. OpenHAP holds only the HAP protocol, the accessory data model, the Tasmota
+   drivers, and openhapd policy. `bin/openhapd` and `bin/hapctl` become thin
+   wiring over FuguLib.
+3. FuguVM holds only QEMU, disk, image, and OpenBSD-install logic, plus its
+   caching policy. Everything else comes from FuguLib.
+4. Each concern has exactly one implementation.
+5. FuguLib gets one consistent interface convention (see Contracts).
+6. Known bugs in the duplicated code die with the duplicates (see Contracts).
+
+## Non-goals
+
+- Backward compatibility. Old interfaces are removed, not deprecated.
+- New protocol features: no mDNS browse or resolve, no chunked HTTP, no
+  multi-service mDNS publication, no MQTT v5.
+- Changes to the HAP wire behavior, other than the listed bug fixes.
+- Changes to `rc.d`, packaging layout, or the dependency manifests.
+- A generic plugin registry. `OpenHAP::DeviceLoader` keeps its dispatch, but
+  collapses its three copies of the type table into one.
+
+## Architecture
+
+### Target FuguLib
+
+Twenty modules. Bold names are new; the others exist and are redesigned.
+
+| Module         | Source of the code                       | Function                                                            |
+| -------------- | ---------------------------------------- | ------------------------------------------------------------------- |
+| Daemon         | FuguLib::Daemon                          | fork, setsid, chdir, umask, fd redirect, PID file                   |
+| Privdrop       | FuguLib::Privdrop, `bin/openhapd` chown  | drop privileges, prepare the state directory before the drop        |
+| Sandbox        | FuguLib::Sandbox, `OpenHAP::Daemon`      | pledge, unveil, standard system paths, Perl library paths           |
+| Signal         | FuguLib::Signal                          | per-object handlers, cleanups, interrupt flag                       |
+| Log            | FuguLib::Log                             | syslog/stderr/quiet, `reopen`, process default instance             |
+| Process        | FuguLib::Process, `FuguVM::SSH`          | spawn, capture output, terminate, reap, wait                        |
+| Pidfile        | FuguLib::State                           | locked PID file; rename says what it is                             |
+| Imsg           | FuguLib::Imsg                            | imsg framing with peerid, `close`, `is_dead`                        |
+| MDNS           | FuguLib::MDNS                            | one-call publish, withdraw on destroy                               |
+| **File**       | 4 copies, see Problem                    | slurp, spew, atomic write, JSON files, dirs, `~`, share paths       |
+| **Util**       | `FuguVM::VM`, `OpenHAP::MQTT`, 3 pollers | `bounded`, `wait_until`, `format_size`                              |
+| **Crypto**     | `OpenHAP::Crypto`, `FuguVM::Util`        | random bytes/password; Ed25519, X25519, ChaCha20-Poly1305, HKDF     |
+| **Config**     | 3 parsers, see Problem                   | one grammar; ordered block list and named block hash                |
+| **Store**      | `FuguVM::State`, `OpenHAP::Storage`      | atomic JSON state file with typed accessors                         |
+| **CLI**        | `FuguVM::CLI`, `bin/hapctl`              | subcommand dispatch, option layers, exit codes, usage               |
+| **JSONSocket** | `FuguVM::QMP`, `FuguVM::QGA`             | newline-JSON client over a UNIX socket                              |
+| **SSH**        | `FuguVM::SSH`                            | Net::SSH2 runner, SFTP write, availability poll                     |
+| **MQTT**       | `OpenHAP::MQTT`                          | subscriptions, wildcard match, reconnect, `tick`                    |
+| **HTTP**       | 3 codecs, see Problem                    | request/response parse and build, with Content-Length framing       |
+| **Proxy**      | `FuguVM::Proxy{,::Cache,::MetaCache}`    | caching HTTP proxy; cache and metadata as packages in the same file |
+| **EventLoop**  | `OpenHAP::HAP::run`                      | IO::Select fd handlers, timers, signal-aware stop                   |
+| **Control**    | new, over Imsg                           | UNIX control socket: server handlers and a request/response client  |
+
+(The table lists 22 rows because Proxy carries two extra packages in one file.)
+
+### Target OpenHAP
+
+`HAP` (endpoints, events, mDNS TXT policy, on EventLoop), `TLV`, `SRP` (gains
+the RFC 5054 group constants), `Pairing`, `Session`, `PIN`, `Accessory`,
+`Service`, `Characteristic`, `Bridge`, `Storage` (pairing format and `c#`
+semantics over Store), `DeviceLoader` (one table), `Tasmota::*`, `Test::*`.
+
+Deleted: `OpenHAP::Config`, `OpenHAP::Crypto`, `OpenHAP::Daemon`,
+`OpenHAP::HTTP`, `OpenHAP::MQTT`. The `$OpenHAP::logger` global is deleted; code
+uses `FuguLib::Log->default`.
+
+### Target FuguVM
+
+`VM`, `Disk`, `Image`, `ImageCache`, `Expect`, `Config` (VM defaults over
+FuguLib::Config), `State` (pure persistence over Store and Pidfile), `CLI`
+(subcommand bodies over FuguLib::CLI), `QMP` and `QGA` (command sets over
+JSONSocket), `Proxy` (OpenBSD mirror policy over FuguLib::Proxy).
+
+Deleted: `FuguVM::Output` (unreferenced), `FuguVM::Util`, `FuguVM::SSH`,
+`FuguVM::Proxy::Cache`, `FuguVM::Proxy::MetaCache`. The `State` to `Proxy`
+require cycle is removed: proxy lifecycle moves to `VM`.
+
+### Wiring after the change
+
+```mermaid
+graph TD
+    openhapd[bin/openhapd] --> HAP
+    openhapd --> FL[FuguLib: Daemon Privdrop Sandbox Signal Log Config Control]
+    hapctl[bin/hapctl] --> FLC[FuguLib: CLI Control Pidfile Config]
+    HAP[OpenHAP::HAP] --> EL[FuguLib::EventLoop]
+    HAP --> HTTPC[FuguLib::HTTP]
+    HAP --> MQ[FuguLib::MQTT]
+    fuguvm[bin/fuguvm] --> VMCLI[FuguVM::CLI] --> VM
+    VM[FuguVM::VM] --> FLV[FuguLib: Process JSONSocket SSH Proxy Store Util]
+```
+
+`hapctl` gets a live channel: `openhapd` serves `status`, `devices`, and
+`pairings` over a FuguLib::Control socket. `hapctl` falls back to the PID file
+when the socket is absent.
+
+## Contracts
+
+- FuguLib does not know OpenHAP or FuguVM. No names, paths, or defaults leak.
+- FuguLib loads with core Perl only. Modules that wrap CPAN libraries (MQTT,
+  SSH, Crypto signatures, Proxy) `require` them lazily and fail with a clear
+  message.
+- Interface convention, applied to every FuguLib module: `Class->new(%args)`
+  with named arguments; named `$class`/`$self` invocants; `die` for programming
+  errors; `undef` return plus an `error` accessor for recoverable failures.
+- Logger convention: modules take `log => $logger` and fall back to
+  `FuguLib::Log->default`, which always returns a logger. Library code never
+  dies for the lack of a logger.
+- Every FuguLib module ships a `man/fugulib/<Module>.3p` page, a `MAN3P` entry,
+  and a `t/fugulib/` test. Moved OpenHAP and FuguVM modules keep `.pod` sidecars
+  next to the `.pm`.
+- HAP wire behavior is unchanged, except these deliberate fixes: the server
+  buffers per connection and frames requests by `Content-Length`; `openhapd`
+  writes its PID file; `hapctl status` reports real state.
+- Security fixes ride along: PID files lock before truncate; liveness checks
+  reap zombies; secret files get mode 0600 before the write, not after; the
+  Privdrop re-escalation check fails loudly.
+- `make check` and `make spec-coverage` stay green after every phase.
+
+## Strategy
+
+Six phases, each independently shippable:
+
+1. **Harden the existing nine** — redesign Daemon, Privdrop, Sandbox, Signal,
+   Log, Process, Pidfile (rename from State), Imsg, MDNS; `openhapd` writes its
+   PID file.
+2. **Foundation modules** — add File, Util, Crypto, Config, Store, CLI,
+   JSONSocket, with pages and tests; no consumers change.
+3. **FuguVM conversion** — move SSH and Proxy into FuguLib; QMP/QGA onto
+   JSONSocket; State, Config, CLI onto the foundations; delete Output, Util.
+4. **OpenHAP conversion** — move MQTT, HTTP, Crypto into FuguLib; Storage onto
+   Store; delete Config, Daemon, the logger global; fix request framing.
+5. **Event loop** — extract FuguLib::EventLoop; `HAP::run` becomes
+   registrations; shutdown honors the interrupt flag.
+6. **Control socket** — add FuguLib::Control; `openhapd` serves it; rewrite
+   `hapctl` on FuguLib::CLI with live status.
+
+Once a phase lands, the code, tests, and man pages are the source of truth; this
+document records intent at the time of writing.

--- a/plans/006-fugulib-consolidation/plan-1.md
+++ b/plans/006-fugulib-consolidation/plan-1.md
@@ -1,0 +1,148 @@
+# Phase 1 — Harden the existing nine modules
+
+This phase redesigns the nine FuguLib modules in place. It fixes the known bugs,
+applies the interface convention from the design, and renames `FuguLib::State`
+to `FuguLib::Pidfile`. Consumers get mechanical updates only. No new subsystems
+appear.
+
+## Tasks
+
+### 1.1 FuguLib::Daemon
+
+- `daemonize` also does `chdir('/')` and sets a configurable `umask` (default
+  `022`), as `daemon(3)` does.
+- New `pidfile => $path` argument. The child writes the PID file through
+  `FuguLib::Pidfile->acquire` after `setsid` and holds the lock for life.
+  `on_fork` stays for callers that need more.
+- Add the missing `t/fugulib/daemon.t` (fork-free tests where possible; skip
+  gracefully where not).
+
+### 1.2 FuguLib::Pidfile (rename of FuguLib::State)
+
+- Rename file, package, man page, and test. The old name said "state"; the
+  module manages a PID file and nothing else. The rename frees the name for the
+  phase 2 `FuguLib::Store`.
+- Constructor becomes `FuguLib::Pidfile->new(path => $path)`, in line with the
+  convention; the positional form goes away.
+- Fix the lock order: open with `O_CREAT|O_RDWR`, `flock`, then truncate and
+  write. Today the open truncates before the lock, so a concurrent writer loses
+  its content.
+- New `acquire` method: write the PID and keep the locked handle open, so "am I
+  already running" has an authoritative answer. `release` drops it.
+- Update the call sites: `OpenHAP::Daemon->check_running` and `bin/hapctl`.
+
+### 1.3 FuguLib::Privdrop
+
+- Fix the re-escalation check: the verification runs in a discarded `eval`, so a
+  successful `setuid(0)` is not detected. Make the check die on failure.
+- New `prepare_statedir(path => ..., user => ..., group => ...)`: chown a state
+  directory and its files before the drop. This replaces the 25 hand-rolled
+  lines in `bin/openhapd:117-141` and the phantom `chown_runtime_files` example
+  in the module comment.
+- Supplementary groups: keep the current OpenBSD-relevant behavior, add a
+  `clear_groups => 1` option that calls `setgroups`, and document the default.
+- Remove the `_openhap` example from the module and make the man page examples
+  consistent (`_myapp` throughout).
+
+### 1.4 FuguLib::Sandbox
+
+- Move `_perl_lib_dirs` from `OpenHAP::Daemon` here as `perl_lib_dirs` (reads
+  `%Config` for `privlibexp`, `archlibexp`, `sitelibexp`, `sitearchexp`).
+- New `system_paths` class method: the standard read-only unveil inventory every
+  daemon repeats (`/etc/resolv.conf`, `/etc/hosts`, `/etc/services`,
+  `/etc/protocols`, `/etc/localtime`, `/dev/urandom`).
+- Use the named `$class` invocant, like the other modules.
+
+### 1.5 FuguLib::Signal
+
+- Make state per-object: the interrupt flag and the cleanup list move into the
+  instance, and the installed handlers close over it. Two managers in one
+  process no longer share state.
+- `interrupted` and `reset_interrupted` become methods. A package-level
+  `FuguLib::Signal::check_interrupted()` remains for code without the object,
+  reading the flags of all live instances.
+- Cleanups survive a second signal: do not empty the list while running it.
+- New `exit_status => $n` option; the default stays 130.
+
+### 1.6 FuguLib::Log
+
+- New `reopen` method: close and reopen syslog with the same settings. This
+  replaces the `$logger = undef` then re-create dance after privilege drop, and
+  serves SIGHUP.
+- New process default: `FuguLib::Log->default` returns the default instance and
+  creates a stderr logger on first use; `FuguLib::Log->set_default($log)`
+  replaces it. This is the target for the phase 4 logger convention.
+- Autoflush stderr output. Add a `level` getter.
+- Drop the `warn`/`err` aliases; the levels are `debug`, `info`, `notice`,
+  `warning`, `error`, `crit`. Document the `MODE_*` constants; FuguVM already
+  uses them.
+
+### 1.7 FuguLib::Process
+
+- `check_alive` default becomes 0, and the check uses an exec-error pipe
+  (`close-on-exec`) instead of `sleep 1`, so spawn failures report exactly and
+  immediately.
+- A child that exits fast with status 0 is not a failure: the result becomes
+  `{success => 1, pid => ..., exited => 1, exit_code => 0}`.
+- New `run(cmd => \@argv, timeout => $s)`: run a child and capture stdout,
+  stderr, and the exit code through pipes. This replaces backticks and `system`
+  string forms in FuguVM (phase 3) and `rcctl` calls in the test harness (phase
+  4).
+- Move `_exit_code` (the `$?` mapping) here from `FuguVM::SSH`.
+- `terminate` polls with sub-second granularity.
+- `is_alive` stays reaping (documented); callers that need the status use `run`
+  or `waitpid` directly.
+
+### 1.8 FuguLib::Imsg
+
+- `send` accepts `peerid`; `recv` returns `type`, `peerid`, `pid`, and `data`.
+- New `close` method and `is_dead` predicate. `FuguLib::MDNS` stops reaching
+  into `$self->{imsg}{fh}`.
+- Cite `spec/MDNS-Imsg.md` as a repository document, not as an installed one.
+
+### 1.9 FuguLib::MDNS
+
+- New one-call `publish(%args)`: connect on demand, then publish. The
+  connect/publish split remains available, but `bin/openhapd` shrinks its 26
+  lines of nested error handling to one call and one error report.
+- Add `DESTROY`: withdraw on object destruction, since the held socket is the
+  advertisement lifetime.
+- `_encode_service` returns undef and sets `error` instead of dying, like the
+  rest of the module. Validate the struct size expectation in `new`.
+
+### 1.10 Consumers and documentation
+
+- `bin/openhapd` passes `pidfile => '/var/run/openhapd.pid'` to `daemonize`.
+  Today nothing writes that file, so `hapctl status` always reports "not
+  running". Keep the privdrop chown of the PID file so `remove` works later.
+- `bin/openhapd` uses `Privdrop->prepare_statedir`, `Log->reopen`,
+  `Sandbox->system_paths` plus `perl_lib_dirs`, and `MDNS->publish`.
+- `OpenHAP::Daemon` keeps working on the renamed modules; its deletion waits for
+  phase 4.
+- Update all nine man pages; rename `State.3p` to `Pidfile.3p`; update the
+  `MAN3P` list in the `Makefile`.
+- Update `man/openhap/openhapd.8` FILES with `/var/run/openhapd.pid`.
+- Update `web/fugulib.body.html` module descriptions where behavior changed.
+
+## Deliverables
+
+- Reworked
+  `lib/FuguLib/{Daemon,Privdrop,Sandbox,Signal,Log,Process,Imsg,MDNS}.pm`
+- `lib/FuguLib/Pidfile.pm` (renamed from `State.pm`)
+- Updated `bin/openhapd`, `lib/OpenHAP/Daemon.pm`, `bin/hapctl` call sites
+- Updated `man/fugulib/*.3p` (nine pages, one renamed), `Makefile`,
+  `man/openhap/openhapd.8`, `web/fugulib.body.html`
+- New `t/fugulib/daemon.t`; extended tests for every changed module
+
+## Acceptance criteria
+
+- `make check` is green; `mandoc -Tlint` passes on all changed pages.
+- `t/fugulib/pidfile.t` proves the lock precedes truncation and that `acquire`
+  blocks a second acquire.
+- A spawned child that fails to exec reports the exec error without a one-second
+  delay; a fast clean exit reports `exited`, not failure.
+- Two Signal objects with separate cleanups do not run each other's cleanups.
+- `openhapd` on OpenBSD writes the PID file, and `hapctl status` finds the
+  running daemon by PID.
+- Grep finds no `FuguLib::State` reference and no `$self->{imsg}{fh}` access
+  outside `FuguLib::Imsg`.

--- a/plans/006-fugulib-consolidation/plan-1.md
+++ b/plans/006-fugulib-consolidation/plan-1.md
@@ -12,7 +12,11 @@ appear.
 - `daemonize` also does `chdir('/')` and sets a configurable `umask` (default
   `022`), as `daemon(3)` does.
 - New `pidfile => $path` argument. The child writes the PID file through
-  `FuguLib::Pidfile->acquire` after `setsid` and holds the lock for life.
+  `FuguLib::Pidfile->acquire` after `setsid`, while still root, and holds the
+  lock for life. The file stays root-owned: it is the trust anchor that `hapctl`
+  reads, and the dropped daemon must not be able to rewrite it. The daemon does
+  not remove it at exit — unlink in root-owned `/var/run` needs directory write
+  permission the dropped process lacks — and `is_stale` covers leftovers.
   `on_fork` stays for callers that need more.
 - Add the missing `t/fugulib/daemon.t` (fork-free tests where possible; skip
   gracefully where not).
@@ -29,18 +33,24 @@ appear.
   its content.
 - New `acquire` method: write the PID and keep the locked handle open, so "am I
   already running" has an authoritative answer. `release` drops it.
-- Update the call sites: `OpenHAP::Daemon->check_running` and `bin/hapctl`.
+- Update every rename site: `OpenHAP::Daemon` (the one direct caller;
+  `bin/hapctl` reaches it only through `check_running`), the `.Xr`
+  cross-references in the other 3p pages, and `t/web/site.t`, which asserts the
+  rendered `FuguLib::State.3p.html` link by name.
 
 ### 1.3 FuguLib::Privdrop
 
 - Fix the re-escalation check: the verification runs in a discarded `eval`, so a
   successful `setuid(0)` is not detected. Make the check die on failure.
-- New `prepare_statedir(path => ..., user => ..., group => ...)`: chown a state
-  directory and its files before the drop. This replaces the 25 hand-rolled
-  lines in `bin/openhapd:117-141` and the phantom `chown_runtime_files` example
-  in the module comment.
-- Supplementary groups: keep the current OpenBSD-relevant behavior, add a
-  `clear_groups => 1` option that calls `setgroups`, and document the default.
+- New `prepare_statedir(path => ..., user => ..., group => ..., mode => ...)`:
+  create the directory when it is absent (root runs this before the drop, so
+  directories under `/var/run` reappear after boot), then chown it and its
+  files. This replaces the 25 hand-rolled lines in `bin/openhapd:117-141` and
+  the phantom `chown_runtime_files` example in the module comment.
+- Supplementary groups: clear them with `setgroups` by default — today no code
+  calls `setgroups`, so the dropped process keeps root's groups, which is
+  fail-open. A `keep_groups => 1` opt-out preserves the mdnsd-socket use case;
+  the man page documents both.
 - Remove the `_openhap` example from the module and make the man page examples
   consistent (`_myapp` throughout).
 
@@ -67,15 +77,18 @@ appear.
 ### 1.6 FuguLib::Log
 
 - New `reopen` method: close and reopen syslog with the same settings. This
-  replaces the `$logger = undef` then re-create dance after privilege drop, and
-  serves SIGHUP.
+  replaces the `$logger = undef` then re-create dance after privilege drop. (No
+  SIGHUP claim here: openhapd treats HUP as graceful exit today; phase 5 rewires
+  it.)
 - New process default: `FuguLib::Log->default` returns the default instance and
   creates a stderr logger on first use; `FuguLib::Log->set_default($log)`
   replaces it. This is the target for the phase 4 logger convention.
 - Autoflush stderr output. Add a `level` getter.
 - Drop the `warn`/`err` aliases; the levels are `debug`, `info`, `notice`,
   `warning`, `error`, `crit`. Document the `MODE_*` constants; FuguVM already
-  uses them.
+  uses them. Update the `->warn` call sites in `lib/FuguVM/Proxy.pm` in this
+  phase — they are live code that `make check` does not exercise, and the Proxy
+  rework only comes in phase 3.
 
 ### 1.7 FuguLib::Process
 
@@ -88,7 +101,9 @@ appear.
   stderr, and the exit code through pipes. This replaces backticks and `system`
   string forms in FuguVM (phase 3) and `rcctl` calls in the test harness (phase
   4).
-- Move `_exit_code` (the `$?` mapping) here from `FuguVM::SSH`.
+- Add a public `exit_code` class method (the `$?` mapping) from
+  `FuguVM::SSH::_exit_code`, and switch `FuguVM::SSH` and `t/fuguvm/ssh.t` to it
+  in this phase, so no copy remains behind.
 - `terminate` polls with sub-second granularity.
 - `is_alive` stays reaping (documented); callers that need the status use `run`
   or `waitpid` directly.
@@ -114,35 +129,47 @@ appear.
 
 - `bin/openhapd` passes `pidfile => '/var/run/openhapd.pid'` to `daemonize`.
   Today nothing writes that file, so `hapctl status` always reports "not
-  running". Keep the privdrop chown of the PID file so `remove` works later.
+  running". The file stays root-owned and is never chowned (see 1.1); the unveil
+  inventory needs no entry for it, because the daemon holds the locked handle
+  and never touches the path again.
 - `bin/openhapd` uses `Privdrop->prepare_statedir`, `Log->reopen`,
   `Sandbox->system_paths` plus `perl_lib_dirs`, and `MDNS->publish`.
 - `OpenHAP::Daemon` keeps working on the renamed modules; its deletion waits for
   phase 4.
+- `t/openhap/integration/daemon.t` changes expectation: the PID file exists and
+  holds the daemon PID while running, and remains as a stale file after stop —
+  it no longer asserts removal. `t/openhap/integration/hapctl.t` gains an
+  assertion that distinguishes "running" from "not running" output.
 - Update all nine man pages; rename `State.3p` to `Pidfile.3p`; update the
   `MAN3P` list in the `Makefile`.
 - Update `man/openhap/openhapd.8` FILES with `/var/run/openhapd.pid`.
-- Update `web/fugulib.body.html` module descriptions where behavior changed.
+- Update `web/fugulib.body.html` module descriptions where behavior changed, and
+  the startup-ordering notes in `.claude/skills/openhapd/SKILL.md`.
 
 ## Deliverables
 
 - Reworked
   `lib/FuguLib/{Daemon,Privdrop,Sandbox,Signal,Log,Process,Imsg,MDNS}.pm`
 - `lib/FuguLib/Pidfile.pm` (renamed from `State.pm`)
-- Updated `bin/openhapd`, `lib/OpenHAP/Daemon.pm`, `bin/hapctl` call sites
+- Updated call sites: `bin/openhapd`, `lib/OpenHAP/Daemon.pm`,
+  `lib/FuguVM/SSH.pm` (`exit_code`), `lib/FuguVM/Proxy.pm` (`warning`)
 - Updated `man/fugulib/*.3p` (nine pages, one renamed), `Makefile`,
-  `man/openhap/openhapd.8`, `web/fugulib.body.html`
-- New `t/fugulib/daemon.t`; extended tests for every changed module
+  `man/openhap/openhapd.8`, `web/fugulib.body.html`,
+  `.claude/skills/openhapd/SKILL.md`
+- New `t/fugulib/daemon.t`; extended tests for every changed module; updated
+  `t/fuguvm/ssh.t`, `t/web/site.t`, `t/openhap/integration/{daemon,hapctl}.t`
 
 ## Acceptance criteria
 
 - `make check` is green; `mandoc -Tlint` passes on all changed pages.
 - `t/fugulib/pidfile.t` proves the lock precedes truncation and that `acquire`
   blocks a second acquire.
-- A spawned child that fails to exec reports the exec error without a one-second
-  delay; a fast clean exit reports `exited`, not failure.
+- A spawned child that fails to exec reports the exec error through the pipe
+  mechanism, not through a sleep; the test asserts the error content. A fast
+  clean exit reports `exited`, not failure.
 - Two Signal objects with separate cleanups do not run each other's cleanups.
-- `openhapd` on OpenBSD writes the PID file, and `hapctl status` finds the
-  running daemon by PID.
+- The integration tier proves it: `t/openhap/integration/daemon.t` sees the
+  root-owned PID file with the daemon's PID, and
+  `t/openhap/integration/hapctl.t` sees `status` report the running daemon.
 - Grep finds no `FuguLib::State` reference and no `$self->{imsg}{fh}` access
   outside `FuguLib::Imsg`.

--- a/plans/006-fugulib-consolidation/plan-2.md
+++ b/plans/006-fugulib-consolidation/plan-2.md
@@ -49,8 +49,12 @@ Class methods over paths; no object state.
 - Signature and AEAD wrappers, moved from `OpenHAP::Crypto`: `ed25519_keypair`,
   `ed25519_sign`, `ed25519_verify`, `x25519_keypair`, `x25519_shared_secret`,
   `hkdf_sha512`, `chacha20poly1305_encrypt`, `chacha20poly1305_decrypt`.
-- The Crypt::* modules load lazily per function group with a clear failure
+- The Crypt::\* modules load lazily per function group with a clear failure
   message; `random_bytes` and `random_password` stay core-Perl.
+- A `preload` class method loads every Crypt::\* module eagerly. A daemon that
+  pledges without `prot_exec` calls it before the pledge, because a lazy
+  `require` after pledge dlopens shared objects and dies. `bin/openhapd` relies
+  on this in phase 4; its promise set keeps `prot_exec` absent.
 - The RFC 5054 SRP group constants do not move here; they are HAP policy and go
   to `OpenHAP::SRP` in phase 4.
 
@@ -100,6 +104,8 @@ The dispatch skeleton shared by `fuguvm` and `hapctl`.
 
 The newline-delimited JSON client duplicated by QMP and QGA.
 
+- The codec is JSON::PP (core), so the module keeps the core-Perl load contract;
+  the current copies use JSON::XS, which is CPAN.
 - `new(path => $socket, timeout => $s, greeting => 0|1)`; `connect` reads the
   greeting when asked (QMP) and skips it otherwise (QGA).
 - `request($hashref)` returns the decoded response or undef with `error`.
@@ -134,6 +140,8 @@ The newline-delimited JSON client duplicated by QMP and QGA.
   its final mode before it has content.
 - `t/fugulib/store.t` proves `load` survives a corrupt file and `save` is atomic
   (no partial file after a simulated failure).
-- FuguLib still loads with core Perl only: a test walks `lib/FuguLib` and
-  compiles every module without CPAN modules installed, or skips where the
-  environment cannot express that.
+- FuguLib still loads with core Perl only: a new `t/fugulib/coreperl.t` walks
+  `lib/FuguLib` and compiles every module in a subprocess whose `@INC` holds
+  only the core paths (`privlibexp`, `archlibexp`) plus `lib/`. The test runs
+  under `make check` on every platform and does not skip — the pruned `@INC`
+  simulates the missing-CPAN environment deterministically.

--- a/plans/006-fugulib-consolidation/plan-2.md
+++ b/plans/006-fugulib-consolidation/plan-2.md
@@ -1,0 +1,139 @@
+# Phase 2 — Foundation modules
+
+This phase adds seven new FuguLib modules with man pages and tests. No consumer
+changes; the modules ship unused and the conversions follow in phases 3 and 4.
+Each module merges the strongest existing implementation of its concern, as
+mapped in the design.
+
+All modules follow the phase 1 conventions: `new(%args)`, named invocants, `die`
+for programming errors, `undef` plus `error` for recoverable failures,
+`log => $logger` with the `FuguLib::Log->default` fallback.
+
+## Tasks
+
+### 2.1 FuguLib::File
+
+Class methods over paths; no object state.
+
+- `read($path)` / `write($path, $data, mode => ...)` — slurp and spew; the mode
+  applies to the open, before any byte is written.
+- `write_atomic($path, $data, mode => ...)` — temp file plus `rename` in the
+  same directory.
+- `read_json($path)` / `write_json($path, $ref, mode => ...)` — JSON::PP with
+  the same atomic, mode-first discipline. This kills the
+  `FuguVM::ImageCache::_write_json` window where a secret is world-readable.
+- `ensure_dir($path)` — refuse symlinks, refuse non-directories, `make_path`
+  with a sanitized error (from `FuguVM::State::_ensure_dir`).
+- `expand_tilde($path)` — one copy instead of three.
+- `share_path($relative)` — resolve a shipped data file against the install
+  root; one strategy instead of the three in `Expect`, `Image`, `ImageCache`.
+- `atomic_dir($target, $code)` — build in a `.tmp.$$` sibling, publish by
+  rename, sweep leftovers; from `FuguVM::ImageCache`, with the `END` and
+  signal-cleanup guards.
+- `valid_name($string)` — safe path-component check (length, `/`, NUL), from
+  `FuguVM::State` and `ImageCache::valid_snapshot_name`.
+
+### 2.2 FuguLib::Util
+
+- `bounded($seconds, $code)` — `alarm` guard; one copy for the two admitted
+  duplicates in `FuguVM::VM` and `OpenHAP::MQTT`.
+- `wait_until($timeout, $interval, $code)` — bounded poll; replaces the three
+  hand-rolled TCP/port/SSH wait loops. Honors `FuguLib::Signal` interruption.
+- `format_size($bytes)` — human-readable bytes, from `FuguVM::CLI`.
+
+### 2.3 FuguLib::Crypto
+
+- `random_bytes($n)` — `/dev/urandom` with short-read and failure checks (the
+  `FuguVM::Util` copy checks neither).
+- `random_password($n)` — URL-safe base64 over `random_bytes`.
+- Signature and AEAD wrappers, moved from `OpenHAP::Crypto`: `ed25519_keypair`,
+  `ed25519_sign`, `ed25519_verify`, `x25519_keypair`, `x25519_shared_secret`,
+  `hkdf_sha512`, `chacha20poly1305_encrypt`, `chacha20poly1305_decrypt`.
+- The Crypt::* modules load lazily per function group with a clear failure
+  message; `random_bytes` and `random_password` stay core-Perl.
+- The RFC 5054 SRP group constants do not move here; they are HAP policy and go
+  to `OpenHAP::SRP` in phase 4.
+
+### 2.4 FuguLib::Config
+
+One parser for the OpenBSD-style grammar, replacing three.
+
+- Accepts `key value` and `key = value`; strips quotes; skips comment and blank
+  lines.
+- Blocks: `<type> <arg> ... {` up to `}`; one nesting level, as today.
+- Both views: `blocks($type)` returns the ordered list (the OpenHAP device case)
+  and `block($type, $name)` returns the named entry (the FuguVM case).
+- `get($key, $default)` for top-level values; `bool($key, $default)` accepting
+  yes/no, true/false, on/off, 1/0.
+- Errors carry file and line: unreadable file and malformed line both return
+  undef with `error` set. Today OpenHAP ignores bad lines silently; the design
+  says fail closed.
+- `find_project_root($marker)` — walk up to the directory holding the marker
+  file, from `FuguVM::Config`.
+
+### 2.5 FuguLib::Store
+
+A file-backed JSON state store; the generic half of `FuguVM::State` and
+`OpenHAP::Storage`.
+
+- `new(path => $file, mode => 0600)`, `load` (tolerates a missing or corrupt
+  file), `save` (atomic via `FuguLib::File`).
+- `get($key)`, `set($key, $value)` with save; `increment($key)` for counters
+  (the `c#` and auth-attempt cases).
+- No PID logic and no subprocess logic; `Pidfile` and the callers own those.
+
+### 2.6 FuguLib::CLI
+
+The dispatch skeleton shared by `fuguvm` and `hapctl`.
+
+- `new(name => ..., commands => {...}, options => {...})`; each command declares
+  its options, usage line, and code.
+- `run(@argv)`: parse global options once, dispatch, parse command options — the
+  block `FuguVM::CLI` repeats five times.
+- Exit-code constants: `EXIT_SUCCESS`, `EXIT_ERROR`, `EXIT_INVALID_ARGS`,
+  `EXIT_CONFIG_ERROR`, `EXIT_TIMEOUT`. Domain codes stay in the applications;
+  today `FuguVM::CLI` and `FuguVM::VM` define the same numbers twice.
+- Usage and help generation to stdout; diagnostics go to the logger on stderr.
+  Command data output stays on stdout (the `snapshot list --names` contract).
+
+### 2.7 FuguLib::JSONSocket
+
+The newline-delimited JSON client duplicated by QMP and QGA.
+
+- `new(path => $socket, timeout => $s, greeting => 0|1)`; `connect` reads the
+  greeting when asked (QMP) and skips it otherwise (QGA).
+- `request($hashref)` returns the decoded response or undef with `error`.
+- `read_line` keeps the wall-clock deadline and the buffered-remainder handling
+  of the current copies; `disconnect`; `is_connected`.
+
+### 2.8 Documentation and build
+
+- New pages: `man/fugulib/{File,Util,Crypto,Config,Store,CLI,JSONSocket}.3p`;
+  extend `MAN3P` in the `Makefile`.
+- New tests: `t/fugulib/{file,util,crypto,config,store,cli,jsonsocket}.t`.
+  Crypto tests skip gracefully when Crypt::* modules are absent.
+- Update `web/fugulib.body.html`: the module list grows and the "nine modules,
+  only core Perl" sentence becomes "core Perl at load time; some modules load
+  optional CPAN libraries on use".
+
+## Deliverables
+
+- `lib/FuguLib/{File,Util,Crypto,Config,Store,CLI,JSONSocket}.pm`
+- `man/fugulib/{File,Util,Crypto,Config,Store,CLI,JSONSocket}.3p` and the
+  `Makefile` `MAN3P` additions
+- `t/fugulib/{file,util,crypto,config,store,cli,jsonsocket}.t`
+- Updated `web/fugulib.body.html`
+
+## Acceptance criteria
+
+- `make check` is green with the new modules present but unconsumed;
+  `mandoc -Tlint` passes on the seven new pages.
+- `t/fugulib/config.t` parses fixtures for both grammars: an OpenHAP-style
+  device list and a FuguVM-style named-VM file, through the same parser.
+- `t/fugulib/file.t` proves `write_json` never exposes a secret: the file has
+  its final mode before it has content.
+- `t/fugulib/store.t` proves `load` survives a corrupt file and `save` is atomic
+  (no partial file after a simulated failure).
+- FuguLib still loads with core Perl only: a test walks `lib/FuguLib` and
+  compiles every module without CPAN modules installed, or skips where the
+  environment cannot express that.

--- a/plans/006-fugulib-consolidation/plan-3.md
+++ b/plans/006-fugulib-consolidation/plan-3.md
@@ -8,14 +8,18 @@ command surface and `.fuguvmrc` grammar are unchanged.
 
 ### 3.1 Move FuguVM::SSH to FuguLib::SSH
 
-- The module moves nearly as-is; nothing in it is QEMU-aware.
-- `_exit_code` already moved to `FuguLib::Process` in phase 1; call it there.
+- The module moves nearly as-is; nothing in it is QEMU-aware. One structural
+  change: the compile-time `use Net::SSH2` becomes a lazy `require` at
+  `_connect` time, to keep the design's core-Perl load contract and the phase 2
+  `coreperl.t` walk green.
+- `FuguLib::Process->exit_code` replaced `_exit_code` in phase 1; nothing to
+  move here.
 - `wait_available` becomes a thin use of `FuguLib::Util::wait_until`.
-- Fix during the move: check the `read` return value; today a short read of
-  `/dev/urandom`-derived data passes silently (`FuguVM::Util` had the same bug
-  and dies with the module).
-- New `man/fugulib/SSH.3p`, `t/fugulib/ssh.t` (skips without Net::SSH2); delete
-  `lib/FuguVM/SSH.pm` and its test moves.
+- Fix during the move: check the return value of the SFTP
+  `$remote_fh->write($content)` call in `write_file`; it is unchecked today (the
+  channel reads already check theirs).
+- New `man/fugulib/SSH.3p`; `t/fuguvm/ssh.t` moves to `t/fugulib/ssh.t` (skips
+  without Net::SSH2); delete `lib/FuguVM/SSH.pm`.
 
 ### 3.2 Move the proxy to FuguLib::Proxy
 
@@ -67,6 +71,9 @@ command surface and `.fuguvmrc` grammar are unchanged.
 
 - The five repeated option-parse blocks and the dispatcher go; the subcommand
   bodies stay.
+- The `cache` subcommand bodies construct `FuguVM::Proxy::Cache` directly; they
+  move to the new `FuguLib::Proxy::Cache` name deleted by task 3.2 — the two
+  tasks land together.
 - Exit codes: generic constants from `FuguLib::CLI`; the domain codes
   (`EXIT_VM_NOT_FOUND` and friends) are defined once in `FuguVM::CLI` and
   `FuguVM::VM` uses them from there.
@@ -100,6 +107,15 @@ command surface and `.fuguvmrc` grammar are unchanged.
 - `man/fuguvm/fuguvm.1` needs no interface change; verify and adjust the FILES
   and DIAGNOSTICS sections where messages changed.
 - Update `web/fugulib.body.html` for the two new modules.
+- Test-file fates, stated so nothing dangles: `t/fuguvm/util.t` is deleted (its
+  coverage lives in `t/fugulib/crypto.t`); `t/fuguvm/ssh.t` moves to
+  `t/fugulib/ssh.t`; `t/fuguvm/{proxy-cache,proxy-metacache}.t` fold into the
+  new `t/fugulib/proxy.t`, and `t/fuguvm/proxy.t` keeps only the FuguVM policy
+  (patterns, prune, guest URL); `t/fuguvm/{cli,vm,state,config}.t` update in
+  place.
+- Net::SSH2 and HTTP::Daemon stay in the test and develop dependency tiers; the
+  installed FuguLib modules are inert without them, per the design's packaging
+  contract.
 
 ## Deliverables
 
@@ -114,12 +130,17 @@ command surface and `.fuguvmrc` grammar are unchanged.
 
 ## Acceptance criteria
 
-- `make check` is green; `make integration` provisions a VM end to end (install,
-  cache store, restore, snapshot, destroy) on a development host.
+- `make check` is green. `make integration` passes twice in sequence on a
+  development host: a cold run that installs and stores the base image, then a
+  warm run (after `fuguvm destroy`) that restores from the cache — the two runs
+  together exercise install, store, restore, and destroy.
 - Grep proves the deletions: no `FuguVM::Output`, `FuguVM::Util`, `FuguVM::SSH`,
   `Proxy::MetaCache` references; no bare `kill(0,` liveness checks under
   `lib/FuguVM`; no `$state->{` internals access outside `FuguVM::State`.
-- A VM whose QEMU became a zombie is reported as stopped, not running.
-- The proxy cache file layout on disk is unchanged; an existing cache populated
-  before this phase still hits after it.
-- `fuguvm` exit codes are unchanged for every documented failure.
+- A VM whose QEMU became a zombie is reported as stopped, not running
+  (unit-tested with an unreaped child).
+- The proxy cache file layout on disk is unchanged. One-time procedure before
+  merge: populate the cache with a pre-phase build, run the post-phase
+  `fuguvm up`, and record the cache hit in the pull request.
+- The exit codes that `t/fuguvm/cli.t` asserts today (0, 1, 2, 3, 5, 11) are
+  unchanged, and the constants keep the values `man/fuguvm/fuguvm.1` documents.

--- a/plans/006-fugulib-consolidation/plan-3.md
+++ b/plans/006-fugulib-consolidation/plan-3.md
@@ -1,0 +1,125 @@
+# Phase 3 — FuguVM conversion
+
+This phase makes FuguVM a thin wrapper: QEMU, disk, image, and OpenBSD-install
+logic stay; every generic concern moves to FuguLib or is deleted. The `fuguvm`
+command surface and `.fuguvmrc` grammar are unchanged.
+
+## Tasks
+
+### 3.1 Move FuguVM::SSH to FuguLib::SSH
+
+- The module moves nearly as-is; nothing in it is QEMU-aware.
+- `_exit_code` already moved to `FuguLib::Process` in phase 1; call it there.
+- `wait_available` becomes a thin use of `FuguLib::Util::wait_until`.
+- Fix during the move: check the `read` return value; today a short read of
+  `/dev/urandom`-derived data passes silently (`FuguVM::Util` had the same bug
+  and dies with the module).
+- New `man/fugulib/SSH.3p`, `t/fugulib/ssh.t` (skips without Net::SSH2); delete
+  `lib/FuguVM/SSH.pm` and its test moves.
+
+### 3.2 Move the proxy to FuguLib::Proxy
+
+- `lib/FuguLib/Proxy.pm` holds three packages in one file, per house style:
+  `FuguLib::Proxy` (supervisor and serve loop), `FuguLib::Proxy::Cache`
+  (URL-to-file store), `FuguLib::Proxy::Meta` (stat-validated metadata with
+  ETag).
+- Generic content: the `HTTP::Daemon` plus `IO::Select` loop with the self-pipe
+  SIGTERM trick, forward, streaming with partial-write handling, port scan,
+  readiness wait (now `Util::wait_until`), atomic cache store (now
+  `File::write_atomic`), one shared directory walker instead of two.
+- Cacheability is a callback: `cacheable => sub ($url) {...}`. Content types
+  come from a table with an override hook.
+- `FuguVM::Proxy` remains as policy: the OpenBSD mirror patterns, the
+  version-scoped `prune`, the QEMU SLIRP `guest_url` (`10.0.2.2`), and the port
+  range. `Proxy::Cache` and `Proxy::MetaCache` files are deleted.
+- `stop` uses `FuguLib::Process->terminate` instead of the hand-rolled
+  TERM/sleep/KILL ladder.
+- `FuguVM::Image` stops hardcoding the cache layout: it asks the cache for the
+  path (`cache_path`), removing the hidden coupling.
+
+### 3.3 QMP and QGA onto FuguLib::JSONSocket
+
+- Both modules keep only their command sets (`query_status`, `powerdown`,
+  `quit`; `sync`, `fsfreeze`, `ping`, `shutdown`) and their handshake choice.
+- The duplicated connect, read-line, deadline, and buffer code is deleted.
+
+### 3.4 FuguVM::State becomes pure persistence
+
+- The JSON blob rides on `FuguLib::Store`; the two PID-file copies become two
+  `FuguLib::Pidfile` objects (`vm.pid`, `proxy.pid`). This removes the
+  missing-`flock` and zombie-is-alive defects in one pass.
+- Proxy lifecycle (`ensure_proxy`, `get_proxy`, `stop_proxy`) moves to
+  `FuguVM::VM`; the lazy `require` cycle between State and Proxy disappears.
+- Directory hygiene and name validation come from `FuguLib::File` (`ensure_dir`,
+  `valid_name`).
+- `VM.pm` and `CLI.pm` stop reaching into `$state->{...}` internals; the
+  accessors exist and become the only path.
+
+### 3.5 FuguVM::Config onto FuguLib::Config
+
+- The module keeps the `DEFAULT_*` constants, `load_vm` merging, and the
+  `image_cache` switch; parsing, `find_project_root`, bool handling, and `~`
+  expansion come from FuguLib.
+- Behavior note in the `.pod`: bad lines now fail with file and line instead of
+  being skipped.
+
+### 3.6 FuguVM::CLI onto FuguLib::CLI
+
+- The five repeated option-parse blocks and the dispatcher go; the subcommand
+  bodies stay.
+- Exit codes: generic constants from `FuguLib::CLI`; the domain codes
+  (`EXIT_VM_NOT_FOUND` and friends) are defined once in `FuguVM::CLI` and
+  `FuguVM::VM` uses them from there.
+- `_format_size` and `_write_file` are deleted in favor of `FuguLib::Util` and
+  `FuguLib::File`.
+
+### 3.7 FuguVM::VM and Expect cleanup
+
+- `_bounded` becomes `FuguLib::Util::bounded`; `_wait_exit` becomes
+  `FuguLib::Process->wait_exit`; `_wait_console_ready` becomes a `wait_until`
+  with the pid-death early abort kept.
+- Every bare `kill(0, $pid)` liveness check becomes `FuguLib::Process->is_alive`
+  (zombie fix).
+- `FuguVM::Disk` invocations normalize on `FuguLib::Process->run` — one style
+  instead of backticks, string `system`, and list `system`.
+- `Expect` resolves scripts via `FuguLib::File::share_path` and runs them via
+  `FuguLib::Process->run`; the unused `install_ssh_key` and `halt_system` are
+  deleted.
+- `ImageCache` uses `File::atomic_dir`, `File::read_json`, `File::write_json`
+  (mode-before-content fix), and `File::valid_name`.
+- Delete `FuguVM::Output` (unreferenced) and `FuguVM::Util` (moved).
+
+### 3.8 Documentation
+
+- Add or update `.pod` sidecars for every FuguVM module this phase touches:
+  `VM`, `State`, `Config`, `CLI`, `Proxy`, `QMP`, `QGA`, `Expect`, `Disk`,
+  `Image`, `ImageCache`. FuguVM keeps sidecars; it is development-only and is
+  not installed.
+- New `man/fugulib/{SSH,Proxy}.3p`; `Proxy.3p` documents the three packages.
+  Extend `MAN3P`.
+- `man/fuguvm/fuguvm.1` needs no interface change; verify and adjust the FILES
+  and DIAGNOSTICS sections where messages changed.
+- Update `web/fugulib.body.html` for the two new modules.
+
+## Deliverables
+
+- `lib/FuguLib/SSH.pm`, `lib/FuguLib/Proxy.pm` (+ pages, tests)
+- Reworked
+  `lib/FuguVM/{VM,State,Config,CLI,Proxy,QMP,QGA,Expect,Disk,Image,ImageCache}.pm`
+  with `.pod` sidecars
+- Deleted: `lib/FuguVM/{Output,Util,SSH}.pm`,
+  `lib/FuguVM/Proxy/{Cache,MetaCache}.pm`
+- Updated `t/fuguvm/*.t`, new `t/fugulib/{ssh,proxy}.t`
+- Updated `Makefile`, `web/fugulib.body.html`
+
+## Acceptance criteria
+
+- `make check` is green; `make integration` provisions a VM end to end (install,
+  cache store, restore, snapshot, destroy) on a development host.
+- Grep proves the deletions: no `FuguVM::Output`, `FuguVM::Util`, `FuguVM::SSH`,
+  `Proxy::MetaCache` references; no bare `kill(0,` liveness checks under
+  `lib/FuguVM`; no `$state->{` internals access outside `FuguVM::State`.
+- A VM whose QEMU became a zombie is reported as stopped, not running.
+- The proxy cache file layout on disk is unchanged; an existing cache populated
+  before this phase still hits after it.
+- `fuguvm` exit codes are unchanged for every documented failure.

--- a/plans/006-fugulib-consolidation/plan-4.md
+++ b/plans/006-fugulib-consolidation/plan-4.md
@@ -14,7 +14,7 @@ unchanged except one deliberate fix: the server frames requests by
 - `bin/openhapd` calls `FuguLib::Log->set_default(...)` at startup and after the
   privilege drop (`reopen`).
 - Tests set a quiet default once through a small shared test helper instead of
-  assigning a global in ~20 files.
+  assigning a global in each file (34 test files assign it today).
 - Library code never dies for a missing logger; `Test::Integration` drops its
   injected-logger workaround.
 
@@ -34,13 +34,19 @@ unchanged except one deliberate fix: the server frames requests by
 - One codec replaces three: server-side `parse_request`, client-side
   `parse_response`, `build_request`, `build_response`, and
   `message_complete($buffer)` for `Content-Length` framing (the correct loop
-  exists today only in `Test::Controller`).
+  exists today only in the test clients, `Test::Controller` and
+  `Test::Integration`; the server has none).
 - The HAP-isms move out: status `470` and the default `Connection: keep-alive`
   become caller-supplied values in `OpenHAP::HAP`.
 - `OpenHAP::HAP::_handle_client` gets a per-connection input buffer and consumes
   exactly one framed request per pass. Today one `sysread` is parsed as a whole
   message, so split or pipelined requests break. This is the one wire-behavior
   fix in this phase.
+- The buffer is bounded: the server enforces a maximum request size (header
+  block plus `Content-Length`) and closes the connection when a client exceeds
+  it. Today the single 64 KB `sysread` bounds input implicitly; the buffered
+  server must bound it explicitly, since unpaired clients reach `/pair-setup`.
+  The limit is a `FuguLib::HTTP` argument; `OpenHAP::HAP` picks the value.
 - `Test::Controller` and `Test::Integration` use the same codec; their two
   private HTTP parsers are deleted. The controller's independent crypto stays —
   the codec is transport, not oracle.
@@ -49,16 +55,22 @@ unchanged except one deliberate fix: the server frames requests by
 
 ### 4.4 Crypto onto FuguLib::Crypto
 
-- `OpenHAP::Crypto` is deleted. `Session`, `Pairing`, `SRP`, and the test
-  controller call `FuguLib::Crypto` (moved in phase 2).
+- `OpenHAP::Crypto` is deleted. Every consumer moves to `FuguLib::Crypto` (phase
+  2): `HAP` (identity generation), `Session`, `Pairing`, `SRP`,
+  `Test::Controller`, and `Test::Controller::SRP`.
 - The RFC 5054 3072-bit group constants move into `OpenHAP::SRP`; they are HAP
-  policy, not a primitive.
+  policy, not a primitive. The conformance tests that read
+  `$OpenHAP::Crypto::N_3072` follow them there.
+- `bin/openhapd` calls `FuguLib::Crypto->preload` before it pledges: the promise
+  set has no `prot_exec`, so no shared object may load after the pledge. The
+  warm-up comment at `bin/openhapd:191-254` extends to say so.
 - The HAP nonce and AAD conventions stay in `OpenHAP::Session`, as today.
 
 ### 4.5 OpenHAP::Storage onto FuguLib::Store and FuguLib::File
 
-- The six read-int/write-int accessor pairs and the flock/umask/chmod block
-  become `FuguLib::Store` and `FuguLib::File` calls.
+- The six small read/write accessors (three pairs: config number, config digest,
+  auth attempts) and the flock/umask/chmod block become `FuguLib::Store` and
+  `FuguLib::File` calls.
 - `Storage` keeps what is HAP: the LTSK/LTPK key files, the pairings format
   (`controller_id:ltpk_hex:permissions`), and the rule that every pairing change
   increments `c#`.
@@ -101,6 +113,16 @@ unchanged except one deliberate fix: the server frames requests by
   statements about module layout and correct them.
 - Dependency manifests do not change: the same CPAN modules are required, and
   only their loading site moves.
+- Test-file fates, stated so nothing dangles: `t/openhap/mqtt.t` moves to
+  `t/fugulib/mqtt.t`; `t/openhap/http.t` folds into `t/fugulib/http.t`;
+  `t/openhap/{config,crypto}.t` are deleted (their coverage lives in
+  `t/fugulib/{config,crypto}.t`); `t/openhap/daemon.t` is deleted with the
+  module, and its `unveil_paths` coverage follows the inventory into a
+  `bin/openhapd` test or the integration tier.
+- The five conformance files that call `OpenHAP::HTTP` and `OpenHAP::Crypto`
+  (`hap-http.t`, `hap-pairing.t`, `hap-pairing-exchange.t`, `hap-encryption.t`,
+  `hap-encryption-exchange.t`) migrate to the FuguLib names. Their spec
+  citations and asserted bytes do not change.
 
 ## Deliverables
 
@@ -110,19 +132,21 @@ unchanged except one deliberate fix: the server frames requests by
 - Reworked `lib/OpenHAP/{HAP,Storage,SRP,Session,Pairing,DeviceLoader}.pm`,
   `lib/OpenHAP/Test/{Controller,Integration}.pm`, `bin/openhapd`, `bin/hapctl`,
   with sidecar updates
-- Updated `t/openhap/*.t`, `t/conformance/*.t` (logger helper), moved MQTT and
-  HTTP tests
+- Updated `t/openhap/*.t` and `t/conformance/*.t` (logger helper plus the
+  call-site migration named in 4.8); moved and deleted tests per 4.8
 - Updated `man/openhap/openhapd.conf.5`, `Makefile`, `web/fugulib.body.html`
 
 ## Acceptance criteria
 
-- `make check` and `make spec-coverage` are green; the conformance tier passes
-  unchanged — pairing, session encryption, and TLV behavior are byte-identical.
+- `make check` and `make spec-coverage` are green. The conformance tier passes
+  with its call sites migrated; the cited behavior — pairing bytes, session
+  encryption, TLV — is unchanged.
 - `t/fugulib/http.t` proves a request split across two reads and two pipelined
-  requests in one read are both handled; `t/conformance` exercises the HAP
-  server through the fixed path.
-- A `/var/db/openhapd` directory written before this phase loads without
-  migration; `c#` semantics are unchanged.
+  requests in one read are both handled, and an over-limit request closes the
+  connection; `t/conformance` exercises the HAP server through the fixed path.
+- A storage fixture in the current on-disk format is checked in under `t/`; the
+  Storage tests load it and prove `c#` semantics are unchanged, so a paired
+  installation from before this phase keeps working.
 - Grep finds no `$OpenHAP::logger`, no `OpenHAP::Config`, `OpenHAP::Crypto`,
   `OpenHAP::Daemon`, `OpenHAP::HTTP`, or `OpenHAP::MQTT` references.
 - `hapctl` no longer loads JSON::XS or any Tasmota class for `status`.

--- a/plans/006-fugulib-consolidation/plan-4.md
+++ b/plans/006-fugulib-consolidation/plan-4.md
@@ -1,0 +1,128 @@
+# Phase 4 — OpenHAP conversion
+
+This phase moves the generic OpenHAP modules into FuguLib, deletes the glue
+modules, and removes the `$OpenHAP::logger` global. HAP wire behavior is
+unchanged except one deliberate fix: the server frames requests by
+`Content-Length` over a per-connection buffer.
+
+## Tasks
+
+### 4.1 The logger convention
+
+- Delete the `$OpenHAP::logger` global (166 references). Library modules take
+  `log => $logger` or call `FuguLib::Log->default`.
+- `bin/openhapd` calls `FuguLib::Log->set_default(...)` at startup and after the
+  privilege drop (`reopen`).
+- Tests set a quiet default once through a small shared test helper instead of
+  assigning a global in ~20 files.
+- Library code never dies for a missing logger; `Test::Integration` drops its
+  injected-logger workaround.
+
+### 4.2 Move OpenHAP::MQTT to FuguLib::MQTT
+
+- The module is generic already; it moves with the logger change applied.
+- The `site_perl` `@INC` workaround stays, documented as OpenBSD packaging
+  behavior; `Sandbox->perl_lib_dirs` (phase 1) covers the unveil side.
+- The connect alarm guard becomes `FuguLib::Util::bounded`.
+- `bin/openhapd` keeps the pre-unveil `require Net::MQTT::Simple` warm-up, now
+  against the new module name.
+- New `man/fugulib/MQTT.3p`; the `.pod` sidecar is deleted with the module;
+  `t/openhap/mqtt.t` moves to `t/fugulib/mqtt.t`.
+
+### 4.3 Move OpenHAP::HTTP to FuguLib::HTTP
+
+- One codec replaces three: server-side `parse_request`, client-side
+  `parse_response`, `build_request`, `build_response`, and
+  `message_complete($buffer)` for `Content-Length` framing (the correct loop
+  exists today only in `Test::Controller`).
+- The HAP-isms move out: status `470` and the default `Connection: keep-alive`
+  become caller-supplied values in `OpenHAP::HAP`.
+- `OpenHAP::HAP::_handle_client` gets a per-connection input buffer and consumes
+  exactly one framed request per pass. Today one `sysread` is parsed as a whole
+  message, so split or pipelined requests break. This is the one wire-behavior
+  fix in this phase.
+- `Test::Controller` and `Test::Integration` use the same codec; their two
+  private HTTP parsers are deleted. The controller's independent crypto stays —
+  the codec is transport, not oracle.
+- New `man/fugulib/HTTP.3p`; `t/fugulib/http.t` covers framing (split,
+  pipelined, oversized).
+
+### 4.4 Crypto onto FuguLib::Crypto
+
+- `OpenHAP::Crypto` is deleted. `Session`, `Pairing`, `SRP`, and the test
+  controller call `FuguLib::Crypto` (moved in phase 2).
+- The RFC 5054 3072-bit group constants move into `OpenHAP::SRP`; they are HAP
+  policy, not a primitive.
+- The HAP nonce and AAD conventions stay in `OpenHAP::Session`, as today.
+
+### 4.5 OpenHAP::Storage onto FuguLib::Store and FuguLib::File
+
+- The six read-int/write-int accessor pairs and the flock/umask/chmod block
+  become `FuguLib::Store` and `FuguLib::File` calls.
+- `Storage` keeps what is HAP: the LTSK/LTPK key files, the pairings format
+  (`controller_id:ltpk_hex:permissions`), and the rule that every pairing change
+  increments `c#`.
+- The on-disk layout under `/var/db/openhapd` is unchanged; a paired
+  installation from before this phase still loads.
+
+### 4.6 Delete OpenHAP::Config and OpenHAP::Daemon
+
+- `bin/openhapd`, `bin/hapctl`, `DeviceLoader`, and `Test::Integration` parse
+  configuration through `FuguLib::Config`; the device blocks use the ordered
+  `blocks('device')` view. `Test::Integration`'s third parser is deleted.
+- `OpenHAP::Daemon`'s pass-through shims die; two are already dead. The
+  unveil-path inventory moves into `bin/openhapd` next to the pledge policy it
+  belongs to; `perl_lib_dirs` already lives in `Sandbox`.
+- `bin/hapctl` calls `FuguLib::Pidfile` directly for `status`.
+- `Test::Integration` replaces `system('rcctl ...')` and log tailing shells with
+  `FuguLib::Process->run`.
+
+### 4.7 DeviceLoader: one table
+
+- The three copies of the type/subtype table (`_is_supported_device`,
+  `_instantiate_device`, `_device_type_name`) collapse into one declarative map
+  entry per device class. Adding a device type means one line plus one `use`.
+- Delete the unused `OpenHAP::DeviceLoader` import in `bin/hapctl`; it drags
+  four Tasmota classes and JSON::XS into a CLI that reads config only.
+
+### 4.8 Documentation
+
+- Delete the `.pod` sidecars of removed modules
+  (`Config,Crypto,Daemon,HTTP,MQTT`); update the sidecars of every changed
+  OpenHAP module (`HAP`, `Storage`, `SRP`, `Session`, `DeviceLoader`,
+  `Test::*`).
+- New `man/fugulib/{MQTT,HTTP}.3p`; extend `MAN3P`.
+- `man/openhap/openhapd.conf.5`: document the grammar as FuguLib::Config defines
+  it — `key value` and `key = value` both parse, and malformed lines are now
+  hard errors with file and line.
+- `man/openhap/openhapd.8` and `hapctl.8`: no user-visible flag changes; verify
+  FILES and DIAGNOSTICS.
+- Update `web/fugulib.body.html`; check `README.md` and `INSTALL.md` for
+  statements about module layout and correct them.
+- Dependency manifests do not change: the same CPAN modules are required, and
+  only their loading site moves.
+
+## Deliverables
+
+- `lib/FuguLib/{MQTT,HTTP}.pm` with pages and tests
+- Deleted: `lib/OpenHAP/{Config,Crypto,Daemon,HTTP,MQTT}.pm` and their `.pod`
+  sidecars
+- Reworked `lib/OpenHAP/{HAP,Storage,SRP,Session,Pairing,DeviceLoader}.pm`,
+  `lib/OpenHAP/Test/{Controller,Integration}.pm`, `bin/openhapd`, `bin/hapctl`,
+  with sidecar updates
+- Updated `t/openhap/*.t`, `t/conformance/*.t` (logger helper), moved MQTT and
+  HTTP tests
+- Updated `man/openhap/openhapd.conf.5`, `Makefile`, `web/fugulib.body.html`
+
+## Acceptance criteria
+
+- `make check` and `make spec-coverage` are green; the conformance tier passes
+  unchanged — pairing, session encryption, and TLV behavior are byte-identical.
+- `t/fugulib/http.t` proves a request split across two reads and two pipelined
+  requests in one read are both handled; `t/conformance` exercises the HAP
+  server through the fixed path.
+- A `/var/db/openhapd` directory written before this phase loads without
+  migration; `c#` semantics are unchanged.
+- Grep finds no `$OpenHAP::logger`, no `OpenHAP::Config`, `OpenHAP::Crypto`,
+  `OpenHAP::Daemon`, `OpenHAP::HTTP`, or `OpenHAP::MQTT` references.
+- `hapctl` no longer loads JSON::XS or any Tasmota class for `status`.

--- a/plans/006-fugulib-consolidation/plan-5.md
+++ b/plans/006-fugulib-consolidation/plan-5.md
@@ -1,0 +1,67 @@
+# Phase 5 — Event loop
+
+This phase extracts the select loop from `OpenHAP::HAP::run` into
+`FuguLib::EventLoop` and restructures `run` as registrations. It gives the
+daemon a real shutdown path. HAP endpoint behavior does not change.
+
+## Tasks
+
+### 5.1 FuguLib::EventLoop
+
+- `new(log => ...)`; single-threaded, `IO::Select` based, no threads, per the
+  project rules.
+- Handles: `add_fd($fh, read => sub {...})` and `remove_fd($fh)`; the loop
+  dispatches readable handles to their callbacks.
+- Timers: `every($seconds, sub {...})` and `after($seconds, sub {...})` return
+  timer handles; `cancel($handle)`. The select timeout derives from the next
+  timer deadline, not from a hardcoded poll interval.
+- Stop: `stop` method, plus optional integration with a `FuguLib::Signal` object
+  (`signal => $sig`) so an interrupt flag ends the loop after the current pass.
+- `run` loops until stopped; each pass is bounded and timing-tolerant, so tests
+  stay resilient to scheduling variation.
+
+### 5.2 OpenHAP::HAP::run becomes registrations
+
+- The listener socket registers a read callback that accepts and registers the
+  client socket; each client callback owns that connection's buffer and framing
+  (from phase 4).
+- The MQTT tick becomes `every($tick_interval, ...)`; the 30-second reconnect
+  backoff becomes a timer instead of an epoch comparison.
+- Event flushing (`flush_events`, HAP-HTTP coalescing) becomes an `after` timer
+  scheduled on demand; the coalescing policy stays in `OpenHAP::HAP`.
+- `while (1)` dies: the loop stops on the Signal interrupt flag, `run` returns,
+  and `bin/openhapd` exits through the normal cleanup path instead of inside a
+  signal handler.
+- Key client sessions and event subscriptions by `fileno`, not by stringified
+  references, so subscription purge is a delete, not a sweep.
+
+### 5.3 Documentation and tests
+
+- New `man/fugulib/EventLoop.3p`; extend `MAN3P`.
+- New `t/fugulib/eventloop.t`: fd dispatch, timer ordering, `after` versus
+  `every`, stop via signal flag; written against pipes, tolerant of timing
+  variation.
+- Update `lib/OpenHAP/HAP.pod` for the new `run` structure.
+- `man/openhap/openhapd.8`: describe the clean shutdown (signals end the loop
+  and cleanups run), replacing the exit-from-handler behavior.
+
+## Deliverables
+
+- `lib/FuguLib/EventLoop.pm`, `man/fugulib/EventLoop.3p`,
+  `t/fugulib/eventloop.t`
+- Reworked `lib/OpenHAP/HAP.pm` (+ `.pod`), `bin/openhapd`
+- Updated `Makefile`, `man/openhap/openhapd.8`, `web/fugulib.body.html`
+
+## Acceptance criteria
+
+- `make check` and the conformance tier are green: pairing, encrypted sessions,
+  characteristic reads and writes, and event delivery behave as before through
+  the new loop.
+- Event coalescing timing per HAP-HTTP holds under the timer implementation; the
+  conformance tests that cite it pass unchanged.
+- SIGTERM ends `openhapd` through the cleanup path: mDNS withdraws, the PID file
+  is removed, and the exit is visible in the log — verified in the integration
+  tier.
+- MQTT keeps ticking and reconnecting with the same observable cadence (tick
+  interval and backoff values unchanged).
+- No `while (1)` remains in `lib/OpenHAP`.

--- a/plans/006-fugulib-consolidation/plan-5.md
+++ b/plans/006-fugulib-consolidation/plan-5.md
@@ -32,6 +32,10 @@ daemon a real shutdown path. HAP endpoint behavior does not change.
 - `while (1)` dies: the loop stops on the Signal interrupt flag, `run` returns,
   and `bin/openhapd` exits through the normal cleanup path instead of inside a
   signal handler.
+- SIGHUP gets a real meaning: `rc.d` reload sends HUP, which today exits the
+  daemon. `bin/openhapd` now handles HUP through the loop: it calls
+  `FuguLib::Log->default->reopen` and continues. INT and TERM keep the
+  graceful-exit path.
 - Key client sessions and event subscriptions by `fileno`, not by stringified
   references, so subscription purge is a delete, not a sweep.
 
@@ -42,8 +46,9 @@ daemon a real shutdown path. HAP endpoint behavior does not change.
   `every`, stop via signal flag; written against pipes, tolerant of timing
   variation.
 - Update `lib/OpenHAP/HAP.pod` for the new `run` structure.
-- `man/openhap/openhapd.8`: describe the clean shutdown (signals end the loop
-  and cleanups run), replacing the exit-from-handler behavior.
+- `man/openhap/openhapd.8`: describe the clean shutdown (INT and TERM end the
+  loop and cleanups run) and the new HUP behavior (reopen the log and continue),
+  replacing the exit-from-handler behavior.
 
 ## Deliverables
 
@@ -57,11 +62,19 @@ daemon a real shutdown path. HAP endpoint behavior does not change.
 - `make check` and the conformance tier are green: pairing, encrypted sessions,
   characteristic reads and writes, and event delivery behave as before through
   the new loop.
-- Event coalescing timing per HAP-HTTP holds under the timer implementation; the
-  conformance tests that cite it pass unchanged.
-- SIGTERM ends `openhapd` through the cleanup path: mDNS withdraws, the PID file
-  is removed, and the exit is visible in the log — verified in the integration
-  tier.
-- MQTT keeps ticking and reconnecting with the same observable cadence (tick
-  interval and backoff values unchanged).
-- No `while (1)` remains in `lib/OpenHAP`.
+- Event coalescing per HAP-HTTP holds under the timer implementation. The
+  conformance tests that drive `flush_events` by direct call migrate to driving
+  the loop, so they exercise the new `after`-timer path; the cited coalescing
+  behavior and the 250 ms constant are unchanged.
+- SIGTERM ends `openhapd` through the cleanup path — verified in the integration
+  tier by observable state, not logs: the process exits, the mDNS advertisement
+  disappears, and the HAP port closes. (The PID file remains by design; see
+  phase 1.)
+- SIGHUP no longer exits the daemon: the integration tier proves the daemon
+  keeps serving after `rcctl reload openhapd`.
+- The MQTT tick-interval and backoff constants are unchanged, and the existing
+  integration reconnect test still passes; no new wall-clock assertions are
+  added.
+- No `while (1)` remains in `lib/OpenHAP/HAP.pm` or `bin/openhapd`. (The test
+  clients under `lib/OpenHAP/Test/` keep their read loops; they are out of this
+  phase's scope.)

--- a/plans/006-fugulib-consolidation/plan-6.md
+++ b/plans/006-fugulib-consolidation/plan-6.md
@@ -18,36 +18,46 @@ guess-from-files status logic, which is broken today.
     absent" from "request failed".
 - Payloads are JSON (JSON::PP, core); the transport is `FuguLib::Imsg` with
   `peerid` correlation from phase 1.
-- The server creates the socket with mode 0600 before `listen`, removes it on
-  shutdown, and refuses oversized requests. External input is untrusted: unknown
+- An imsg frame carries at most ~16 KB of payload. A reply larger than one frame
+  spans several frames with a continuation flag in the imsg type; the client
+  reassembles by `peerid`. A `devices` reply can exceed one frame, so this is in
+  scope, with a documented total-reply cap.
+- The server creates the socket under a `umask 0177` guard, so it is mode 0600
+  from birth; it removes a stale socket before `bind` and the live one on
+  shutdown. It refuses oversized requests. External input is untrusted: unknown
   commands and malformed payloads get an error reply, never a die.
 
 ### 6.2 openhapd serves the socket
 
 - Socket path: `/var/run/openhapd/control.sock` by default; a `control`
   directive in `openhapd.conf` overrides it, and `control off` disables the
-  server. The parent directory is prepared by `Privdrop->prepare_statedir` so
-  the socket is created after the drop.
+  server. `Privdrop->prepare_statedir` (phase 1) creates `/var/run/openhapd`
+  while still root — OpenBSD clears `/var/run` at boot — with owner `_openhap`
+  and mode 0700, so the dropped daemon can bind and unlink the socket, and the
+  directory mode is the outer access boundary.
 - Commands and their policy live in `bin/openhapd` and `OpenHAP::HAP`: `status`
-  (uptime, paired state, pairing count, config number, mDNS state, MQTT state),
-  `devices` (the loaded accessory list), `config` (the running configuration
-  values).
-- Replies carry no secrets: no keys, no setup code, no pairing LTPKs.
-- Sandbox updates: unveil the socket directory read-write; the `unix` pledge
-  promise is already present.
+  (uptime, paired state, pairing count, config number, mDNS state, MQTT state)
+  and `devices` (the loaded accessory list). There is no command that echoes
+  configuration values: `openhapd.conf` carries `hap_pin` and `mqtt_pass`, and
+  no reply may carry a secret.
+- Replies carry no secrets: no keys, no setup code, no passwords, no pairing
+  LTPKs.
+- Sandbox updates: unveil the socket directory `rwc` — bind and unlink both
+  create and remove directory entries; the `unix` pledge promise is already
+  present.
 
 ### 6.3 hapctl rewrite
 
-- `bin/hapctl` moves onto `FuguLib::CLI` with commands `status`, `devices`,
-  `config`.
+- `bin/hapctl` moves onto `FuguLib::CLI` with commands `check`, `status`, and
+  `devices`. `check` stays what it is today — offline config validation through
+  `FuguLib::Config` — because the integration tests and the operator workflow
+  drive it.
 - `status` asks the daemon over `FuguLib::Control::Client`. When the socket is
   absent, it falls back to `FuguLib::Pidfile` and says which method answered.
 - This retires two live defects: `status` calls methods that do not exist on
   `OpenHAP::Storage`, so the pairing branch is unreachable; and the constructor
   argument mismatch makes a read-only status command create `/var/db/openhapd`.
   `hapctl` stops opening the storage directory at all.
-- `hapctl` keeps working without a running daemon for config validation (`-n`
-  parity) through `FuguLib::Config`.
 
 ### 6.4 Documentation and tests
 
@@ -56,19 +66,26 @@ guess-from-files status logic, which is broken today.
   status distinction, and the socket path.
 - `man/openhap/openhapd.8`: the control socket in FILES; the `control` directive
   cross-reference.
-- `man/openhap/openhapd.conf.5`: the `control` directive.
+- `man/openhap/openhapd.conf.5`: the `control` directive; add it to the shipped
+  example `share/openhap/examples/openhapd.conf.sample` too.
 - New `t/fugulib/control.t` (server and client over a temporary socket, bad
-  input, oversized frames) and `t/openhap/hapctl.t` growth for the fallback
-  path; an integration test drives `hapctl status` against the daemon in the VM.
-- Update `web/fugulib.body.html` for the new module.
+  input, oversized frames, multi-frame replies). The existing
+  `t/openhap/integration/hapctl.t` and `t/openhap/integration/configuration.t`
+  update for the new output and keep driving `check`; a new integration test
+  drives `hapctl status` and `devices` against the daemon in the VM.
+- Update `web/fugulib.body.html` for the new module, and the command notes in
+  `.claude/skills/hapctl/SKILL.md` (it documents `status` reading
+  `/var/db/openhapd` directly, which stops being true).
 
 ## Deliverables
 
 - `lib/FuguLib/Control.pm`, `man/fugulib/Control.3p`, `t/fugulib/control.t`
 - Reworked `bin/hapctl`; updated `bin/openhapd`, `lib/OpenHAP/HAP.pm` (+ `.pod`)
-- Updated `man/openhap/{hapctl.8,openhapd.8,openhapd.conf.5}`, `Makefile`,
-  `web/fugulib.body.html`
-- New integration test under `t/openhap/integration/`
+- Updated `man/openhap/{hapctl.8,openhapd.8,openhapd.conf.5}`,
+  `share/openhap/examples/openhapd.conf.sample`, `Makefile`,
+  `web/fugulib.body.html`, `.claude/skills/hapctl/SKILL.md`
+- New integration test under `t/openhap/integration/`; updated
+  `t/openhap/integration/{hapctl,configuration}.t`
 
 ## Acceptance criteria
 
@@ -76,9 +93,11 @@ guess-from-files status logic, which is broken today.
 - Against a running daemon, `hapctl status` reports live pairing state and
   device count; with the daemon stopped, it reports "not running" from the PID
   file and says so.
-- `hapctl status` as an unprivileged user cannot read the socket (mode 0600) and
-  reports a permission error, not a crash; it never creates files or
-  directories.
+- `hapctl status` as an unprivileged user cannot reach the socket (directory
+  mode 0700, socket mode 0600) and reports a permission error, not a crash — the
+  integration test runs it via `su(1)` to a non-root user. `hapctl status` never
+  creates files or directories, proven by a directory scan before and after the
+  run.
 - A malformed or oversized control request gets an error reply and the daemon
   stays up (fail closed, no die).
 - The integration tier proves the socket appears after privilege drop with owner

--- a/plans/006-fugulib-consolidation/plan-6.md
+++ b/plans/006-fugulib-consolidation/plan-6.md
@@ -1,0 +1,85 @@
+# Phase 6 — Control socket and hapctl
+
+This phase gives `hapctl` a live channel to the running daemon.
+`FuguLib::Control` carries requests over the phase 1 Imsg framing on a UNIX
+socket; `openhapd` answers them from process state. This retires the
+guess-from-files status logic, which is broken today.
+
+## Tasks
+
+### 6.1 FuguLib::Control
+
+- One module, two packages in one file, per house style:
+  - `FuguLib::Control` (server): `new(path => $socket, log => ...)`,
+    `register($command, sub ($args) {...})`, and EventLoop integration — the
+    listener and each accepted client register as fd handlers.
+  - `FuguLib::Control::Client`: `new(path => ...)`, `request($command, $args)`
+    returning the decoded reply or undef with `error`; distinguishes "socket
+    absent" from "request failed".
+- Payloads are JSON (JSON::PP, core); the transport is `FuguLib::Imsg` with
+  `peerid` correlation from phase 1.
+- The server creates the socket with mode 0600 before `listen`, removes it on
+  shutdown, and refuses oversized requests. External input is untrusted: unknown
+  commands and malformed payloads get an error reply, never a die.
+
+### 6.2 openhapd serves the socket
+
+- Socket path: `/var/run/openhapd/control.sock` by default; a `control`
+  directive in `openhapd.conf` overrides it, and `control off` disables the
+  server. The parent directory is prepared by `Privdrop->prepare_statedir` so
+  the socket is created after the drop.
+- Commands and their policy live in `bin/openhapd` and `OpenHAP::HAP`: `status`
+  (uptime, paired state, pairing count, config number, mDNS state, MQTT state),
+  `devices` (the loaded accessory list), `config` (the running configuration
+  values).
+- Replies carry no secrets: no keys, no setup code, no pairing LTPKs.
+- Sandbox updates: unveil the socket directory read-write; the `unix` pledge
+  promise is already present.
+
+### 6.3 hapctl rewrite
+
+- `bin/hapctl` moves onto `FuguLib::CLI` with commands `status`, `devices`,
+  `config`.
+- `status` asks the daemon over `FuguLib::Control::Client`. When the socket is
+  absent, it falls back to `FuguLib::Pidfile` and says which method answered.
+- This retires two live defects: `status` calls methods that do not exist on
+  `OpenHAP::Storage`, so the pairing branch is unreachable; and the constructor
+  argument mismatch makes a read-only status command create `/var/db/openhapd`.
+  `hapctl` stops opening the storage directory at all.
+- `hapctl` keeps working without a running daemon for config validation (`-n`
+  parity) through `FuguLib::Config`.
+
+### 6.4 Documentation and tests
+
+- New `man/fugulib/Control.3p` documenting both packages; extend `MAN3P`.
+- `man/openhap/hapctl.8`: rewritten command reference, the live-versus-file
+  status distinction, and the socket path.
+- `man/openhap/openhapd.8`: the control socket in FILES; the `control` directive
+  cross-reference.
+- `man/openhap/openhapd.conf.5`: the `control` directive.
+- New `t/fugulib/control.t` (server and client over a temporary socket, bad
+  input, oversized frames) and `t/openhap/hapctl.t` growth for the fallback
+  path; an integration test drives `hapctl status` against the daemon in the VM.
+- Update `web/fugulib.body.html` for the new module.
+
+## Deliverables
+
+- `lib/FuguLib/Control.pm`, `man/fugulib/Control.3p`, `t/fugulib/control.t`
+- Reworked `bin/hapctl`; updated `bin/openhapd`, `lib/OpenHAP/HAP.pm` (+ `.pod`)
+- Updated `man/openhap/{hapctl.8,openhapd.8,openhapd.conf.5}`, `Makefile`,
+  `web/fugulib.body.html`
+- New integration test under `t/openhap/integration/`
+
+## Acceptance criteria
+
+- `make check` is green; `mandoc -Tlint` passes on the new and changed pages.
+- Against a running daemon, `hapctl status` reports live pairing state and
+  device count; with the daemon stopped, it reports "not running" from the PID
+  file and says so.
+- `hapctl status` as an unprivileged user cannot read the socket (mode 0600) and
+  reports a permission error, not a crash; it never creates files or
+  directories.
+- A malformed or oversized control request gets an error reply and the daemon
+  stays up (fail closed, no die).
+- The integration tier proves the socket appears after privilege drop with owner
+  `_openhap` and disappears on clean shutdown.


### PR DESCRIPTION
## Summary

Plan 006 makes OpenHAP and FuguVM thin wrappers around a comprehensive,
generic FuguLib. The plan is documents only; no code changes.

- `design.md` defines the target: a 22-module FuguLib. OpenHAP keeps the
  HAP protocol, the data model, and the Tasmota drivers. FuguVM keeps the
  QEMU and OpenBSD-install logic. Each concern gets one implementation.
- Six phase plans, each independently shippable: harden the existing nine
  modules; add the foundation modules; convert FuguVM; convert OpenHAP;
  extract the event loop; add the control socket and rewrite `hapctl`.
- Every phase lists its pod, man page, `MAN3P`, website, and skill-file
  updates.

## Review

Per the project convention, five cold sub-agents reviewed the plan on
separate angles, and two more agents verified all 33 findings against the
code. The second commit applies the confirmed findings: a root-owned PID
file, `/var/run/openhapd` creation before the drop, Crypt::* preload
before pledge, no secret-carrying control command, bounded request
buffers, and repaired acceptance criteria.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUqthm6y3sw1vGJFC79qtX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RUqthm6y3sw1vGJFC79qtX)_