### PR TITLE
docs: make the language about distribution neutral

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ The repo contains three Perl namespaces with distinct concerns:
   imsg framing, mdnsd publishing)
 - `FuguVM::` (`lib/FuguVM/`) — installs and manages OpenBSD VMs under QEMU,
   driven by `bin/fuguvm` and `.fuguvmrc`. Keep it OpenHAP-agnostic: this repo is
-  its first user, not its purpose. Development-only, never shipped
+  its first user, not its purpose
 
 ## Commands
 
@@ -60,7 +60,6 @@ make integration    # provision OpenBSD VM and run integration tests
 - `man/openhap/` — mdoc(7) man pages: `openhapd.8`, `hapctl.8`,
   `openhapd.conf.5`; `man/fugulib/` — `<Module>.3p`, one per `lib/FuguLib/`
   module, installed as `FuguLib::<Module>.3p`; `man/fuguvm/` — `fuguvm.1`
-  (development-only, not installed)
 - `spec/` — curated protocol references, normative for the conformance tier (see
   `spec/CLAUDE.md`)
 - `plans/` — design documents and phased implementation plans (see the Plans
@@ -152,18 +151,15 @@ site-specific framing is hand-written, in `web/*.body.html` — see
 
 Corollaries:
 
-- Rows 2 and 3 are exclusive, and the line is whether the module ships: FuguLib
-  is installed, so it is documented as an installed library is — 3p manuals,
-  found by `man FuguLib::Daemon`. OpenHAP and FuguVM modules are read from the
-  source tree and keep sidecars. The shared `Fugu` prefix does not decide this:
-  FuguVM is reusable but development-only, so it stays on sidecars. No module
-  has both.
+- Rows 2 and 3 are exclusive. FuguLib uses 3p manuals, found by
+  `man FuguLib::Daemon`. OpenHAP and FuguVM keep sidecars. The shared `Fugu`
+  prefix does not group FuguLib and FuguVM here. No module has both.
 - No `README.md` anywhere except the repository root
 - Skills and `CLAUDE.md` files may point to man pages, `.pod` files, `spec/`, or
   each other, but never restate their content
-- A new `lib/FuguLib/` module ships with a `man/fugulib/<Module>.3p` page, a
-  `MAN3P` entry in the `Makefile`, and a test; every other new `lib/` module
-  ships with a `.pod` sidecar and a test
+- A new `lib/FuguLib/` module needs a `man/fugulib/<Module>.3p` page, a `MAN3P`
+  entry in the `Makefile`, and a test; every other new `lib/` module needs a
+  `.pod` sidecar and a test
 - Update the relevant documentation with any change in behavior, options, or
   configuration
 

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ install: install-man
 	install -m 644 lib/OpenHAP/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/
 	install -m 644 lib/OpenHAP/Tasmota/*.pm $(DESTDIR)$(LIBDIR)/OpenHAP/Tasmota/
 	install -m 644 lib/OpenHAP/Tasmota/*.pod $(DESTDIR)$(LIBDIR)/OpenHAP/Tasmota/
-	# The test helper modules ship only in the packaged tree.  The
-	# glob loops accept zero, one, or many matches without stderr noise
+	# The glob loops accept zero, one, or many matches without stderr
+	# noise, because the test helper modules are not always present
 	for f in lib/OpenHAP/Test/*.pm lib/OpenHAP/Test/*.pod; do \
 		[ -e "$$f" ] || continue; \
 		install -m 644 "$$f" $(DESTDIR)$(LIBDIR)/OpenHAP/Test/; \

--- a/man/fuguvm/fuguvm.1
+++ b/man/fuguvm/fuguvm.1
@@ -57,13 +57,6 @@ system without an
 .Ox
 machine on the desk.
 .Pp
-In the OpenHAP source tree,
-.Nm
-is a development tool:
-.Ql make install
-does not install it,
-and it is not part of a release package.
-.Pp
 .Nm
 operates on a project:
 a directory that has an

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -10,8 +10,8 @@ it to build elsewhere). There is no generator, no templating language and no
 JavaScript: two `sh` scripts, a stylesheet, and renderers that read formats
 already in the tree. `plans/004-website/design.md` records why.
 
-Nothing here is installed, packaged, or part of `make check`. `mandoc` and
-`lowdown` are develop-only dependencies.
+Nothing here is part of `make check`. `mandoc` and `lowdown` are develop-only
+dependencies.
 
 `.github/workflows/web.yml` builds and checks the site on every pull request and
 deploys it to GitHub Pages on pushes to `main`. The site is served from

--- a/web/fugulib.body.html
+++ b/web/fugulib.body.html
@@ -63,7 +63,7 @@ socket.</dd>
 
 <h2>Reference</h2>
 
-<p>Each module has a section 3p manual page, installed under its full name
+<p>Each module has a section 3p manual page under its full name
 &mdash; thus <code>man FuguLib::Daemon</code> finds the page.  The pages are
 also listed under
 <a href="manuals.html#fugulib">FuguLib in the manuals</a>.</p>

--- a/web/fugulib.body.html
+++ b/web/fugulib.body.html
@@ -63,9 +63,9 @@ socket.</dd>
 
 <h2>Reference</h2>
 
-<p>Each module has a section 3p manual page, and OpenHAP installs the pages
-&mdash; thus <code>man FuguLib::Daemon</code> finds the page on a machine that has
-OpenHAP.  The pages are also listed under
+<p>Each module has a section 3p manual page, installed under its full name
+&mdash; thus <code>man FuguLib::Daemon</code> finds the page.  The pages are
+also listed under
 <a href="manuals.html#fugulib">FuguLib in the manuals</a>.</p>
 
 <h2>Name</h2>

--- a/web/fuguvm.body.html
+++ b/web/fuguvm.body.html
@@ -50,9 +50,6 @@ tests of <a href="https://man.openbsd.org/pledge.2">pledge(2)</a>,
 and <code>mdnsd</code> are possible only on OpenBSD.  FuguVM does not know
 about OpenHAP; this repository is its first user.</p>
 
-<p>The OpenHAP source includes FuguVM, but OpenHAP does not install it:
-<code>make install</code> ignores it, and no release package has it.</p>
-
 <h2>Reference</h2>
 
 <p>The <a href="manuals.html#fuguvm">manual</a> lists the options, the

--- a/web/index.body.html
+++ b/web/index.body.html
@@ -51,10 +51,10 @@ control utility, and the configuration format.
 There is <a href="manuals.html#modules">a page for each module</a> for
 readers of the source.</p>
 
-<h2>Sub-projects</h2>
+<h2>Related projects</h2>
 
-<p>Two parts of OpenHAP are sub-projects with their own documentation,
-because they are not related to HomeKit.
+<p>Two projects have their own documentation, because they are not related
+to HomeKit.
 <a href="fugulib.html">FuguLib</a> holds the OpenBSD-style daemon utilities
 that the server uses.  <a href="fuguvm.html">FuguVM</a> installs and manages
 OpenBSD virtual machines under QEMU; this project uses it to run the


### PR DESCRIPTION
Remove the statements that say which parts of the tree are installed,
shipped, or packaged. The documents now describe what each part does and
where its manuals are. They do not claim a distribution boundary.

## Changes

- `CLAUDE.md` — drop "development-only, never shipped" from FuguVM, drop
  "not installed" from `man/fuguvm/`, restate the sidecar rule without the
  ships-or-not rationale, and replace "a new module ships with" with "needs"
- `Makefile` — the install rule said the test helper modules are only in the
  packaged tree. The comment now gives the real reason for the glob loops,
  which is that the files are not always present
- `man/fuguvm/fuguvm.1` — remove the paragraph that calls `fuguvm` a
  development tool that `make install` ignores
- `web/fuguvm.body.html` — remove the paragraph that says OpenHAP does not
  install FuguVM
- `web/fugulib.body.html` — the manual pages are found by their full name;
  the note no longer says who installs them
- `web/index.body.html` — rename "Sub-projects" to "Related projects"
- `web/CLAUDE.md` — "Nothing here is installed, packaged, or part of
  `make check`" becomes "Nothing here is part of `make check`"

## Left alone

- `plans/` — plans record intent at the time of writing; the code and the
  regular documentation are the source of truth
- The `install` and `package` rules themselves — this change is about the
  language, not the packaging behavior
- "ships to the VM" in `t/` and `scripts/integration` — that is a copy into
  the test VM, not a distribution claim

## Test plan

`make check` passes: tidy, lint, and every test tier. `t/web/site.t` renders
the pages this change edits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rgt7RuYLnB61pbVFcdR4jn)_