### PR TITLE
docs(plans): add plan 007 for the Protocol::HAP extraction

### DIFF
--- a/plans/007-protocol-hap/design.md
+++ b/plans/007-protocol-hap/design.md
@@ -1,0 +1,193 @@
+# Protocol::HAP extraction — Design
+
+## Problem
+
+OpenHAP mixes two products in one namespace. `lib/OpenHAP/` holds the generic
+HAP protocol and the OpenBSD product that ships it. The protocol code binds to
+FuguLib for logging, crypto, HTTP, and persistence. No other program can reuse
+the protocol without adopting the whole daemon toolkit.
+
+Plan 006 moved the generic daemon code into FuguLib. The opposite extraction did
+not happen: the protocol itself is not a library. The project goal is an
+open-source design that invites more HAP implementations. A reusable protocol
+library, later published to CPAN, is that invitation.
+
+The project has no users. A clean break is possible: no shims, no aliases, no
+compatibility layers. Old names die when their replacement lands.
+
+## Goals
+
+1. `Protocol::HAP` holds the complete HAP protocol: the TLV8 and HTTP codecs,
+   crypto, SRP-6a, pairing, sessions, the accessory data model, the
+   accessory-server engine, and a controller.
+2. `Protocol::HAP` is self-contained. It uses core Perl plus the declared crypto
+   CPAN modules only. It never uses FuguLib, FuguVM, or OpenHAP.
+3. The engine is sans-IO. It consumes bytes and emits bytes. The host owns
+   sockets, timers, logging, and persistence through narrow injected contracts.
+4. OpenHAP becomes the reference host: `openhapd`, `hapctl`, MQTT, Tasmota
+   drivers, and OpenBSD policy.
+5. The repository stays whole. A later CPAN split of the `Protocol-HAP`
+   distribution is mechanical, not architectural.
+6. Wire behavior does not change. Every spec citation in `t/conformance/` keeps
+   its meaning.
+
+## Non-goals
+
+- No CPAN release in this effort. PAUSE registration, `$VERSION` policy, and
+  distribution tooling are release work, recorded in `TODO.md`.
+- No new protocol features.
+- No changes to FuguVM.
+- No repository split.
+
+## Architecture
+
+### Target Protocol::HAP
+
+New namespace under `lib/Protocol/`. Bold names are new; the others move.
+
+| Module            | Source of the code                  | Function                                                                |
+| ----------------- | ----------------------------------- | ----------------------------------------------------------------------- |
+| **Protocol::HAP** | new                                 | umbrella documentation, the null logger, shared HAP constants           |
+| TLV               | OpenHAP::TLV                        | TLV8 codec                                                              |
+| PIN               | OpenHAP::PIN                        | setup-code normalization and rules                                      |
+| Crypto            | FuguLib::Crypto                     | random bytes; Ed25519, X25519, HKDF-SHA-512, ChaCha20-Poly1305; preload |
+| SRP               | OpenHAP::SRP, Test::Controller::SRP | SRP-6a, accessory and controller roles                                  |
+| Pairing           | OpenHAP::Pairing                    | pair-setup and pair-verify state machines, TLV constants                |
+| Session           | OpenHAP::Session                    | per-connection state and the AEAD frame codec; no socket                |
+| HTTP              | FuguLib::HTTP                       | HAP's HTTP/1.1 subset codec, EVENT/1.0 builder                          |
+| Accessory         | OpenHAP::Accessory                  | data model                                                              |
+| Service           | OpenHAP::Service                    | data model                                                              |
+| Characteristic    | OpenHAP::Characteristic             | data model                                                              |
+| Bridge            | OpenHAP::Bridge                     | data model                                                              |
+| **Server**        | OpenHAP::HAP, the protocol half     | endpoint dispatch, pairings management, events, c# digest, mDNS records |
+| **Store::Memory** | new                                 | reference store implementation, for tests and documentation             |
+| Controller        | OpenHAP::Test::Controller           | the controller side; the conformance suite drives it                    |
+
+### Target OpenHAP
+
+The product keeps: **`OpenHAP::Server`** (new, the host half of `OpenHAP::HAP`),
+`Storage`, `DeviceLoader`, `Tasmota::*`, and `Test::Integration`.
+
+Deleted: `OpenHAP::HAP`, `TLV`, `PIN`, `SRP`, `Pairing`, `Session`, `Accessory`,
+`Service`, `Characteristic`, `Bridge`, `Test::Controller`, and
+`Test::Controller::SRP`. Each dies when its replacement lands, in the same
+phase.
+
+### Target FuguLib
+
+- `FuguLib::Crypto` becomes **`FuguLib::Random`**: `random_bytes` and
+  `random_password` only. The Crypt::\* groups move to `Protocol::HAP::Crypto`.
+- `FuguLib::HTTP` moves wholesale to `Protocol::HAP::HTTP`. Only OpenHAP code
+  uses it today; `FuguLib::Proxy` has its own minimal parser.
+- `FuguLib::MDNS` gains `format_txt(%records)`: the sorted, `.`-joined TXT
+  string of mdnsd [MDNS-Control §5]. The join is mdnsd's format, not HAP's.
+- Everything else is unchanged.
+
+### Host contracts
+
+`Protocol::HAP` receives its environment through five contracts. Each is a
+constructor argument.
+
+1. `logger` — an object with `debug`, `info`, `warning`, and `error` methods
+   that take printf-style arguments. The default is the null logger in
+   `Protocol::HAP`. `FuguLib::Log->default` conforms unchanged. Objects that a
+   class creates internally inherit its logger.
+2. `store` — an object with these twelve methods: `load_accessory_keys`,
+   `save_accessory_keys`, `load_pairings`, `save_pairing`, `remove_pairing`,
+   `remove_all_pairings`, `get_config_number`, `increment_config_number`,
+   `get_config_digest`, `save_config_digest`, `get_auth_attempts`,
+   `set_auth_attempts`. `OpenHAP::Storage` conforms unchanged.
+   `Protocol::HAP::Store::Memory` is the reference implementation.
+3. `output` — a code ref `sub ($session, $bytes)`. The engine sends every write
+   through it: responses and EVENT notifications alike. The host writes the
+   bytes to the connection that it filed the session under.
+4. `after` and `cancel` — code refs for one-shot timers, used for event
+   coalescing [HAP-HTTP §14]. `FuguLib::EventLoop` provides both directly. They
+   are optional: without them, the host must call `flush_events`. Conformance
+   tests do that.
+5. `on_pairing_changed` — an optional code ref `sub ($paired)`. The engine calls
+   it when the paired state flips. The host re-advertises the mDNS TXT record
+   [HAP-mDNS §8].
+
+### The connection contract
+
+`Protocol::HAP::Server` owns protocol state; the host owns descriptors.
+
+- `session_open` returns a new `Protocol::HAP::Session`. The server allocates
+  session ids from an instance counter.
+- `receive($session, $bytes)` decrypts, buffers, parses, dispatches, and emits
+  responses through `output`. It returns 1, or undef on a fatal condition: a
+  failed decryption or an over-limit request. On undef the host closes the
+  connection.
+- `session_close($session)` releases the pairing lock and the event
+  subscriptions that the session holds.
+- The request bound (64 KB) and the read buffer live in the engine, because an
+  unauthenticated client reaches `/pair-setup`.
+- `mdns_txt_records` returns the TXT records as a hash [HAP-mDNS §3]. The host
+  formats and publishes them.
+
+### Wiring after the change
+
+```mermaid
+graph TD
+    openhapd[bin/openhapd] --> OS[OpenHAP::Server]
+    openhapd --> FLD[FuguLib: Daemon Privdrop Sandbox Signal Log Config Control]
+    hapctl[bin/hapctl] --> FLC[FuguLib: CLI Control Pidfile Config]
+    OS --> PS[Protocol::HAP::Server]
+    OS --> FLH[FuguLib: EventLoop Log MQTT MDNS]
+    OS --> ST[OpenHAP::Storage] --> FLS[FuguLib: File Store]
+    ST -. store contract .-> PS
+    PS --> P[Protocol::HAP: HTTP TLV SRP Pairing Session Crypto model]
+    DL[OpenHAP::DeviceLoader] --> TAS[OpenHAP::Tasmota::*] --> PA[Protocol::HAP::Accessory]
+    CT[t/conformance] --> PC[Protocol::HAP::Controller] --> P
+```
+
+## Rules
+
+- Dependency direction: `Protocol::HAP` uses core Perl plus `Crypt::Ed25519`,
+  `Crypt::Curve25519`, and `CryptX`, loaded lazily as today. `FuguLib` never
+  uses `Protocol::HAP` or `OpenHAP`. `OpenHAP` uses both.
+  `t/protocol/boundary.t` enforces all three directions.
+- JSON: `Protocol::HAP` uses core `JSON::PP`. HAP payloads are small, so XS
+  speed buys nothing, and one fewer dependency does. OpenHAP and FuguLib keep
+  `JSON::XS`.
+- No package-level mutable state in `Protocol::HAP`. The pairing lock and the
+  attempt counter become `Pairing` instance state. Session ids become a `Server`
+  instance counter. Two servers in one process must not share state.
+- Sans-IO, with two documented exceptions: `Crypto` reads `/dev/urandom`, and
+  `Controller` is a blocking convenience client that owns its socket.
+- Randomness exists twice: `Protocol::HAP::Crypto` and `FuguLib::Random` both
+  read `/dev/urandom` (~30 lines). Accepted: self-containment outranks the
+  single-implementation rule across a future distribution boundary. Inside one
+  namespace the rule still holds.
+- `openhapd` calls `Protocol::HAP::Crypto->preload` before it pledges.
+- Documentation placement follows the root `CLAUDE.md` table: every
+  `Protocol::HAP` module gets a `.pod` sidecar, never a 3p page.
+
+## Testing
+
+- New module tier `t/protocol/`, with the same rules as `t/openhap/`. The
+  `Makefile` test target and the tier table in `t/CLAUDE.md` gain the entry.
+- The conformance tier keeps its location, file names, and citations. Imports
+  retarget mechanically. The exchange tests drive the sans-IO engine through
+  `output` capture and `Protocol::HAP::Controller`.
+- `t/protocol/boundary.t` parses `use` and `require` under `lib/Protocol/` and
+  fails on FuguLib, FuguVM, OpenHAP, or an undeclared CPAN module.
+- Module tests for moved code move with it and keep their coverage.
+
+## Phases
+
+1. Foundation: move `TLV`, `PIN`, `Crypto`, `SRP`; shrink `FuguLib::Crypto` to
+   `FuguLib::Random`; add the boundary test and the `t/protocol/` tier.
+2. Data model: move `Accessory`, `Service`, `Characteristic`, `Bridge`; inject
+   the logger; retarget the Tasmota drivers.
+3. Pairing and session: move `Pairing` and `Session`; define the store contract;
+   add `Store::Memory`; delete the package globals.
+4. Wire engine: move `HTTP`; split `OpenHAP::HAP` into `Protocol::HAP::Server`
+   and `OpenHAP::Server`; add `FuguLib::MDNS::format_txt`; rewire `openhapd`.
+5. Controller: merge the SRP client role; replace `Test::Controller` with
+   `Protocol::HAP::Controller`; retarget the conformance suite; final
+   documentation pass.
+
+Each phase lands whole: the moved module, its callers, its tests, and its
+documentation change together, and `make check` passes at the end of each.

--- a/plans/007-protocol-hap/design.md
+++ b/plans/007-protocol-hap/design.md
@@ -36,7 +36,8 @@ compatibility layers. Old names die when their replacement lands.
 - No CPAN release in this effort. PAUSE registration, `$VERSION` policy, and
   distribution tooling are release work, recorded in `TODO.md`.
 - No new protocol features.
-- No changes to FuguVM.
+- No functional changes to FuguVM. Phase 1 retargets one import line to
+  `FuguLib::Random`.
 - No repository split.
 
 ## Architecture
@@ -96,15 +97,18 @@ constructor argument.
    `save_accessory_keys`, `load_pairings`, `save_pairing`, `remove_pairing`,
    `remove_all_pairings`, `get_config_number`, `increment_config_number`,
    `get_config_digest`, `save_config_digest`, `get_auth_attempts`,
-   `set_auth_attempts`. `OpenHAP::Storage` conforms unchanged.
-   `Protocol::HAP::Store::Memory` is the reference implementation.
+   `set_auth_attempts`. The mutating pairing methods (`save_pairing`,
+   `remove_pairing`, `remove_all_pairings`) increment the configuration number
+   themselves, as `OpenHAP::Storage` does today. `OpenHAP::Storage` conforms
+   unchanged. `Protocol::HAP::Store::Memory` is the reference implementation.
 3. `output` — a code ref `sub ($session, $bytes)`. The engine sends every write
    through it: responses and EVENT notifications alike. The host writes the
    bytes to the connection that it filed the session under.
 4. `after` and `cancel` — code refs for one-shot timers, used for event
    coalescing [HAP-HTTP §14]. `FuguLib::EventLoop` provides both directly. They
-   are optional: without them, the host must call `flush_events`. Conformance
-   tests do that.
+   are optional: without them, the host must call `flush_events`. The
+   conformance suite drives the engine that way, and covers the timer-less path
+   by doing so.
 5. `on_pairing_changed` — an optional code ref `sub ($paired)`. The engine calls
    it when the paired state flips. The host re-advertises the mDNS TXT record
    [HAP-mDNS §8].
@@ -124,7 +128,8 @@ constructor argument.
 - The request bound (64 KB) and the read buffer live in the engine, because an
   unauthenticated client reaches `/pair-setup`.
 - `mdns_txt_records` returns the TXT records as a hash [HAP-mDNS §3]. The host
-  formats and publishes them.
+  formats and publishes them. The record values move unchanged, including
+  `pv=1`, which every current host publishes.
 
 ### Wiring after the change
 
@@ -174,6 +179,12 @@ graph TD
 - `t/protocol/boundary.t` parses `use` and `require` under `lib/Protocol/` and
   fails on FuguLib, FuguVM, OpenHAP, or an undeclared CPAN module.
 - Module tests for moved code move with it and keep their coverage.
+- The user lists in the phase tasks are starting points. The acceptance greps
+  define completeness: retarget every file they match, tests included.
+- Every phase that adds or removes a `.pod` sidecar updates the page
+  expectations in `t/web/site.t`.
+- The `Makefile` install and package targets and the CI path filters ship and
+  watch `lib/Protocol/` and `t/protocol/` from phase 1.
 
 ## Phases
 

--- a/plans/007-protocol-hap/plan-1.md
+++ b/plans/007-protocol-hap/plan-1.md
@@ -75,6 +75,18 @@ enforces the dependency rules for every later phase.
 - Update the Layout section of the root `CLAUDE.md`: add `lib/Protocol/` and the
   `t/protocol/` tier, and correct the stale `lib/OpenHAP/` module list.
 
+### 1.7 Install, package, and CI
+
+- Extend the `Makefile` `install`, `package`, and `uninstall` targets: they name
+  `lib/OpenHAP/` and `lib/FuguLib/` paths explicitly, so `lib/Protocol/` (`.pm`
+  and `.pod`, including the later `Store/` subdirectory) must join them. Without
+  this, the installed daemon dies on a missing `Protocol::HAP::Crypto`.
+- Extend the path filters in `.github/workflows/integration.yml` with
+  `lib/Protocol/**.pm` and `t/protocol/**`; today they watch only
+  `lib/FuguLib/*.pm` and `lib/OpenHAP/**.pm`. `check.yml` already matches
+  `lib/**.pm`; verify its test filters cover `t/protocol/` too.
+- Update the page expectations in `t/web/site.t` for the new `.pod` sidecars.
+
 ## Deliverables
 
 - `lib/Protocol/HAP.pm`, `TLV.pm`, `PIN.pm`, `Crypto.pm`, `SRP.pm`, each with a
@@ -82,12 +94,14 @@ enforces the dependency rules for every later phase.
 - `lib/FuguLib/Random.pm` and `man/fugulib/Random.3p`.
 - `t/protocol/` with `boundary.t`, `tlv.t`, `pin.t`, `crypto.t`, `srp.t`,
   `srp_padding.t`; `t/fugulib/random.t`.
-- Updated `Makefile`, root `CLAUDE.md`, `t/CLAUDE.md`, `TODO.md`,
-  `web/fugulib.body.html`.
+- Updated `Makefile` (test, install, package, uninstall, `MAN3P`), root
+  `CLAUDE.md`, `t/CLAUDE.md`, `TODO.md`, `web/fugulib.body.html`,
+  `.github/workflows/integration.yml`.
 
 ## Acceptance criteria
 
 - `make check` passes.
+- `make package` ships `lib/Protocol/` beside `lib/OpenHAP/` and `lib/FuguLib/`.
 - `grep -r 'OpenHAP::TLV\|OpenHAP::PIN\|OpenHAP::SRP\|FuguLib::Crypto' lib bin t`
   finds nothing.
 - `t/protocol/boundary.t` passes and fails correctly when given a planted

--- a/plans/007-protocol-hap/plan-1.md
+++ b/plans/007-protocol-hap/plan-1.md
@@ -1,0 +1,95 @@
+# Phase 1 — Foundation: pure codecs and primitives
+
+This phase creates the `Protocol::HAP` namespace and moves the modules with no
+protocol state: `TLV`, `PIN`, `Crypto`, and `SRP`. It shrinks `FuguLib::Crypto`
+to `FuguLib::Random`. It adds the `t/protocol/` tier and the boundary test that
+enforces the dependency rules for every later phase.
+
+## Tasks
+
+### 1.1 Protocol::HAP umbrella module
+
+- Create `lib/Protocol/HAP.pm`: the namespace overview comment and the null
+  logger package (`Protocol::HAP::Log::Null`) with no-op `debug`, `info`,
+  `warning`, and `error` methods. Multiple packages in one file follow the style
+  rules.
+- Create the `Protocol/HAP.pod` sidecar: what the library is, the host contracts
+  at a glance, and pointers to the per-module pods.
+- No `$VERSION`. Version policy is release work; record it in `TODO.md` under a
+  new "Protocol::HAP CPAN release" section, with PAUSE registration and the
+  `spec/` redistribution-license review.
+
+### 1.2 Move OpenHAP::TLV to Protocol::HAP::TLV
+
+- `git mv`, rename the package, keep the code as is: the module is already pure.
+- Update the users: `OpenHAP::Pairing`, `OpenHAP::HAP`,
+  `OpenHAP::Test::Controller`, and the tests.
+- Move `t/openhap/tlv.t` to `t/protocol/tlv.t`. Retarget the imports in
+  `t/conformance/hap-tlv8.t`.
+- Move the `.pod` sidecar with the module.
+
+### 1.3 Move OpenHAP::PIN to Protocol::HAP::PIN
+
+- Same procedure. Users: `OpenHAP::SRP`, `OpenHAP::Pairing`, `OpenHAP::HAP`,
+  `OpenHAP::Test::Controller::SRP`.
+- Move `t/openhap/pin.t` to `t/protocol/pin.t`.
+
+### 1.4 Split FuguLib::Crypto
+
+- Create `Protocol::HAP::Crypto` from `FuguLib::Crypto`: `random_bytes`, the
+  Ed25519, X25519, HKDF, and AEAD groups, the lazy `_load`, and `preload`.
+- Shrink `FuguLib::Crypto` to `FuguLib::Random`: `random_bytes` and
+  `random_password` only. Rename the file, the package, and the test.
+- Update the users: `OpenHAP::SRP`, `Session`, `Pairing`, `HAP`,
+  `Test::Controller`, `Test::Controller::SRP` use `Protocol::HAP::Crypto`;
+  `FuguVM::VM` uses `FuguLib::Random`; `bin/openhapd` preloads
+  `Protocol::HAP::Crypto` before it pledges.
+- Split `t/fugulib/crypto.t`: the randomness subtests become
+  `t/fugulib/random.t`; the algorithm and known-answer subtests become
+  `t/protocol/crypto.t`.
+- Replace `man/fugulib/Crypto.3p` with `man/fugulib/Random.3p`, rewritten for
+  the shrunk module. Update `MAN3P` in the `Makefile`, the `.Xr`
+  cross-references in the other 3p pages, `web/fugulib.body.html`, and any
+  page-name assertion in `t/web/site.t`.
+- Write the `Protocol/HAP/Crypto.pod` sidecar.
+
+### 1.5 Move OpenHAP::SRP to Protocol::HAP::SRP
+
+- `git mv`, rename the package and its imports (`Protocol::HAP::Crypto`,
+  `Protocol::HAP::PIN`).
+- Update the users: `OpenHAP::Pairing`, `OpenHAP::Test::Controller::SRP`.
+- Move `t/openhap/srp.t` and `t/openhap/srp_padding.t` to `t/protocol/`.
+- The controller role joins this module in phase 5, not now.
+
+### 1.6 The t/protocol/ tier and the boundary test
+
+- Add `prove -l -v t/protocol/*.t` to the `Makefile` test target, after the
+  `t/fugulib` line.
+- Add the tier row to the table in `t/CLAUDE.md`.
+- Write `t/protocol/boundary.t`. It parses `use` and `require` lines under
+  `lib/Protocol/` and fails on: any `FuguLib::`, `FuguVM::`, or `OpenHAP::`
+  module; any non-core module outside the declared list (`Crypt::Ed25519`,
+  `Crypt::Curve25519`, `Crypt::KeyDerivation`,
+  `Crypt::AuthEnc::ChaCha20Poly1305`). It also fails on `FuguLib::` lines that
+  name `Protocol::HAP` or `OpenHAP`, in both directions of the rule.
+- Update the Layout section of the root `CLAUDE.md`: add `lib/Protocol/` and the
+  `t/protocol/` tier, and correct the stale `lib/OpenHAP/` module list.
+
+## Deliverables
+
+- `lib/Protocol/HAP.pm`, `TLV.pm`, `PIN.pm`, `Crypto.pm`, `SRP.pm`, each with a
+  `.pod` sidecar.
+- `lib/FuguLib/Random.pm` and `man/fugulib/Random.3p`.
+- `t/protocol/` with `boundary.t`, `tlv.t`, `pin.t`, `crypto.t`, `srp.t`,
+  `srp_padding.t`; `t/fugulib/random.t`.
+- Updated `Makefile`, root `CLAUDE.md`, `t/CLAUDE.md`, `TODO.md`,
+  `web/fugulib.body.html`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `grep -r 'OpenHAP::TLV\|OpenHAP::PIN\|OpenHAP::SRP\|FuguLib::Crypto' lib bin t`
+  finds nothing.
+- `t/protocol/boundary.t` passes and fails correctly when given a planted
+  violation (prove the failure mode once, manually, before commit).
+- `make spec-coverage` reports no stale citations.

--- a/plans/007-protocol-hap/plan-2.md
+++ b/plans/007-protocol-hap/plan-2.md
@@ -20,11 +20,17 @@ imports and keep their behavior.
 - Remove `use FuguLib::Log` from `Characteristic` and `Bridge`, the two model
   modules that log.
 - Add the `logger` constructor argument to all four modules. The default is the
-  null logger from `Protocol::HAP`. A `Bridge` passes its logger to the
-  accessories it creates; an `Accessory` passes it to its services and
-  characteristics.
-- `OpenHAP::HAP` passes `FuguLib::Log->default` when it builds the bridge, so
-  the daemon's log output does not change.
+  null logger from `Protocol::HAP`. An object passes its logger only to the
+  objects it creates itself: the `Bridge` to its own `ProtocolInformation`
+  service, an `Accessory` to the services and characteristics it builds.
+  `add_bridged_accessory` never touches the logger of an accessory it receives —
+  no stamping, no fallback.
+- The production log lines live in `Characteristic::set_value` and
+  `enable_events`, and the Tasmota drivers create those characteristics. The
+  drivers and `OpenHAP::DeviceLoader` therefore pass
+  `logger => FuguLib::Log->default` to every accessory, service, and
+  characteristic they create. `OpenHAP::HAP` does the same for the bridge. With
+  both paths wired, the daemon's log output does not change.
 
 ### 2.3 JSON
 
@@ -57,5 +63,7 @@ imports and keep their behavior.
 - `t/protocol/boundary.t` passes: the model modules load no FuguLib code.
 - A model test proves the default logger is silent and an injected logger
   receives the messages.
+- `t/openhap/tasmota.t` asserts that a characteristic a driver creates carries
+  the injected logger, so the write and subscription debug lines survive.
 - `t/openhap/tasmota.t` and `t/openhap/device-loading.t` pass unchanged in what
-  they assert.
+  they assert otherwise.

--- a/plans/007-protocol-hap/plan-2.md
+++ b/plans/007-protocol-hap/plan-2.md
@@ -1,0 +1,61 @@
+# Phase 2 — Data model
+
+This phase moves the accessory data model to `Protocol::HAP` and introduces the
+logger contract. The Tasmota drivers and the device loader retarget their
+imports and keep their behavior.
+
+## Tasks
+
+### 2.1 Move the four model modules
+
+- `git mv` and rename: `OpenHAP::Accessory`, `Service`, `Characteristic`, and
+  `Bridge` become `Protocol::HAP::Accessory`, `Service`, `Characteristic`, and
+  `Bridge`.
+- Move each `.pod` sidecar with its module.
+- Move `t/openhap/accessory.t`, `service.t`, `characteristic.t`, and `bridge.t`
+  to `t/protocol/`.
+
+### 2.2 Inject the logger
+
+- Remove `use FuguLib::Log` from `Characteristic` and `Bridge`, the two model
+  modules that log.
+- Add the `logger` constructor argument to all four modules. The default is the
+  null logger from `Protocol::HAP`. A `Bridge` passes its logger to the
+  accessories it creates; an `Accessory` passes it to its services and
+  characteristics.
+- `OpenHAP::HAP` passes `FuguLib::Log->default` when it builds the bridge, so
+  the daemon's log output does not change.
+
+### 2.3 JSON
+
+- Replace `JSON::XS` with core `JSON::PP` inside the moved modules. The
+  `\1`/`\0` boolean references encode the same way in both.
+- The Tasmota drivers and `DeviceLoader` stay on `JSON::XS`; they remain OpenHAP
+  code.
+
+### 2.4 Retarget the consumers
+
+- Update the imports and `our @ISA` lines: `OpenHAP::Tasmota::Base` extends
+  `Protocol::HAP::Accessory`; the drivers and `DeviceLoader` use
+  `Protocol::HAP::Service` and `Protocol::HAP::Characteristic`.
+- Update `OpenHAP::HAP` and the conformance tests that name the model classes
+  (`hap-categories.t`, `hap-characteristics.t`, `hap-services.t`).
+
+## Deliverables
+
+- `lib/Protocol/HAP/{Accessory,Service,Characteristic,Bridge}.pm` with `.pod`
+  sidecars that document the `logger` argument.
+- `t/protocol/{accessory,service,characteristic,bridge}.t`.
+- Retargeted `OpenHAP::Tasmota::*`, `OpenHAP::DeviceLoader`, `OpenHAP::HAP`, and
+  conformance tests.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `grep -r 'OpenHAP::Accessory\|OpenHAP::Service\|OpenHAP::Characteristic\|OpenHAP::Bridge' lib bin t`
+  finds nothing.
+- `t/protocol/boundary.t` passes: the model modules load no FuguLib code.
+- A model test proves the default logger is silent and an injected logger
+  receives the messages.
+- `t/openhap/tasmota.t` and `t/openhap/device-loading.t` pass unchanged in what
+  they assert.

--- a/plans/007-protocol-hap/plan-3.md
+++ b/plans/007-protocol-hap/plan-3.md
@@ -1,0 +1,66 @@
+# Phase 3 — Pairing, session, and the store contract
+
+This phase moves the pairing state machines and the session codec, defines the
+store contract, and deletes every piece of package-level mutable state.
+
+## Tasks
+
+### 3.1 Define the store contract
+
+- Document the twelve store methods in a `Protocol/HAP/Store.pod` reference:
+  names, arguments, return values, and the c# increment rule.
+- Write `Protocol::HAP::Store::Memory`: the contract over plain hashes, no
+  files. Tests and embedders start here.
+- `OpenHAP::Storage` already provides the twelve methods; it stays in OpenHAP
+  and keeps its on-disk layout. Add a `t/openhap/storage.t` subtest that asserts
+  `can` for every contract method, so drift fails loudly.
+
+### 3.2 Move OpenHAP::Pairing to Protocol::HAP::Pairing
+
+- `git mv`, rename the package, retarget imports to
+  `Protocol::HAP::{TLV,SRP, Crypto,PIN}`.
+- Delete the package globals `$pairing_in_progress`, `$pairing_session_id`, and
+  `$failed_auth_attempts`. They become instance state. Two `Pairing` objects in
+  one process must not share a lock or a counter.
+- `clear_pairing_state` and `reset_auth_attempts` become instance methods.
+  Update the callers in `OpenHAP::HAP`.
+- Rename the `storage` constructor argument to `store`, matching the contract
+  name. The argument is required: the counter rule of [HAP-Pairing §8] needs
+  persistence, and a silent in-memory fallback would fail open.
+- Add the `logger` argument, defaulting to the null logger.
+
+### 3.3 Move OpenHAP::Session to Protocol::HAP::Session
+
+- `git mv`, rename the package, retarget the crypto import.
+- Delete the `socket` member and the `$next_id` package counter. The session id
+  becomes a required `id` constructor argument. `OpenHAP::HAP` keeps an instance
+  counter and files the socket in its own per-connection map, keyed by fileno,
+  next to the session.
+- Add the `logger` argument.
+- Update `OpenHAP::HAP`: `shutdown` and `send_event` read the socket from the
+  connection map, not from the session.
+
+### 3.4 Tests
+
+- Move `t/openhap/pairing.t` and `session.t` to `t/protocol/`, rewritten over
+  `Protocol::HAP::Store::Memory` instead of a temporary directory.
+- Add a `t/protocol/pairing.t` subtest: two `Pairing` instances hold independent
+  locks and counters.
+- Retarget the imports in `t/conformance/hap-pairing.t` and `hap-encryption.t`.
+
+## Deliverables
+
+- `lib/Protocol/HAP/Pairing.pm`, `Session.pm`, `Store/Memory.pm`, with `.pod`
+  sidecars and `Store.pod`.
+- `t/protocol/pairing.t`, `t/protocol/session.t`.
+- Updated `OpenHAP::HAP`, `OpenHAP::Test::Controller`, conformance imports.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `grep -r 'OpenHAP::Pairing\|OpenHAP::Session' lib bin t` finds nothing.
+- `grep -rn '^our ' lib/Protocol/` shows `@ISA` and constants only — no mutable
+  package variables.
+- The two-instance independence subtest passes.
+- `Protocol::HAP::Session` holds no socket: the word `socket` does not appear in
+  the module.

--- a/plans/007-protocol-hap/plan-3.md
+++ b/plans/007-protocol-hap/plan-3.md
@@ -8,9 +8,12 @@ store contract, and deletes every piece of package-level mutable state.
 ### 3.1 Define the store contract
 
 - Document the twelve store methods in a `Protocol/HAP/Store.pod` reference:
-  names, arguments, return values, and the c# increment rule.
+  names, arguments, return values, and the c# increment rule — the mutating
+  pairing methods increment the configuration number themselves, as
+  `OpenHAP::Storage` does today. A store that skips the increment, or an engine
+  that adds one on top, breaks c# in opposite directions.
 - Write `Protocol::HAP::Store::Memory`: the contract over plain hashes, no
-  files. Tests and embedders start here.
+  files, including the increment rule. Tests and embedders start here.
 - `OpenHAP::Storage` already provides the twelve methods; it stays in OpenHAP
   and keeps its on-disk layout. Add a `t/openhap/storage.t` subtest that asserts
   `can` for every contract method, so drift fails loudly.
@@ -27,15 +30,21 @@ store contract, and deletes every piece of package-level mutable state.
 - Rename the `storage` constructor argument to `store`, matching the contract
   name. The argument is required: the counter rule of [HAP-Pairing §8] needs
   persistence, and a silent in-memory fallback would fail open.
+- The instance restores the attempt counter from the store at construction and
+  persists every change, exactly as the global does today. The limit survives
+  restarts and a rebuilt instance over the same store.
 - Add the `logger` argument, defaulting to the null logger.
 
 ### 3.3 Move OpenHAP::Session to Protocol::HAP::Session
 
 - `git mv`, rename the package, retarget the crypto import.
 - Delete the `socket` member and the `$next_id` package counter. The session id
-  becomes a required `id` constructor argument. `OpenHAP::HAP` keeps an instance
-  counter and files the socket in its own per-connection map, keyed by fileno,
-  next to the session.
+  becomes a required `id` constructor argument, allocated by `OpenHAP::HAP` from
+  an instance counter.
+- `OpenHAP::HAP` files each connection in a map keyed by the session id: the
+  session and its socket together. A fileno index resolves reads to the session
+  id. The kernel reuses descriptors; session ids never repeat — the same
+  reasoning the current `$next_id` comment records.
 - Add the `logger` argument.
 - Update `OpenHAP::HAP`: `shutdown` and `send_event` read the socket from the
   connection map, not from the session.
@@ -46,7 +55,17 @@ store contract, and deletes every piece of package-level mutable state.
   `Protocol::HAP::Store::Memory` instead of a temporary directory.
 - Add a `t/protocol/pairing.t` subtest: two `Pairing` instances hold independent
   locks and counters.
-- Retarget the imports in `t/conformance/hap-pairing.t` and `hap-encryption.t`.
+- Update every test that names the deleted API. The full list today:
+  `t/conformance/hap-pairing.t`, `hap-encryption.t`, `hap-tlv8.t`, `hap-http.t`,
+  `hap-pairing-exchange.t`, `hap-encryption-exchange.t`, `t/openhap/hap.t`, and
+  `t/openhap/test-controller.t`. The acceptance grep is the authority, not this
+  list.
+- These are rewrites where they touch deleted API, not import swaps:
+  `Session->new` loses `socket` and requires `id`; `storage` becomes `store`;
+  the class-method `clear_pairing_state` resets between subtests become calls on
+  the pairing instance. The exchange tests keep their in-process transport over
+  `$hap->_dispatch` in this phase; phase 4 replaces that transport.
+- Spec citations do not change; `make spec-coverage` proves it.
 
 ## Deliverables
 

--- a/plans/007-protocol-hap/plan-4.md
+++ b/plans/007-protocol-hap/plan-4.md
@@ -1,0 +1,103 @@
+# Phase 4 — The wire engine
+
+This phase is the split of `OpenHAP::HAP` (1440 lines) into the sans-IO
+`Protocol::HAP::Server` and the host `OpenHAP::Server`. The HTTP codec moves
+into the library first, because the engine is its main consumer.
+
+## Tasks
+
+### 4.1 Move FuguLib::HTTP to Protocol::HAP::HTTP
+
+- `git mv`, rename the package. Only OpenHAP code uses the codec;
+  `FuguLib::Proxy` keeps its own minimal parser.
+- Add `build_event($body)`: the EVENT/1.0 message builder, today an inline
+  string in `OpenHAP::HAP::send_event` [HAP-HTTP §14].
+- Update the users: `OpenHAP::HAP`, `OpenHAP::Test::Controller`,
+  `OpenHAP::Test::Integration`, `t/conformance/hap-http.t` and the two exchange
+  tests.
+- Move `t/fugulib/http.t` to `t/protocol/http.t`. Delete `man/fugulib/HTTP.3p`,
+  remove it from `MAN3P`, update the `.Xr` cross-references,
+  `web/fugulib.body.html`, and any page assertion in `t/web/site.t`. Write the
+  `Protocol/HAP/HTTP.pod` sidecar.
+
+### 4.2 Extract Protocol::HAP::Server
+
+The engine takes the protocol half of `OpenHAP::HAP`:
+
+- Constructor: `name`, `pin`, `setup_id`, `category`, and the host contracts
+  `store`, `logger`, `output`, `after`, `cancel`, `on_pairing_changed` from the
+  design. The engine loads or generates the accessory identity through the
+  store, builds the bridge, and owns the `Pairing` instance.
+- Connection API: `session_open`, `receive`, `session_close`, per the design's
+  connection contract. The read buffer, the 64 KB bound, decryption, HTTP
+  parsing, and dispatch move inside. `receive` emits responses through `output`
+  and returns 1, or undef on a fatal condition.
+- Endpoints: `/pair-setup`, `/pair-verify`, `/identify`, `/pairings` (add,
+  remove, list), `/accessories`, `/characteristics` GET and PUT, `/prepare`. The
+  handlers move as they are; only logging and storage calls change spelling.
+- Events: the subscription registry, coalescing through `after`/`cancel`,
+  `queue_event`, `flush_events`, and `send_event` over `output`.
+- Identity and discovery: `is_paired`, `get_config_number`,
+  `update_config_number`, `get_device_id`, `mdns_txt_records`. The `.`-joined
+  string form does not move: it is mdnsd's format.
+- Pairing-state changes call `on_pairing_changed` instead of touching mDNS.
+- `add_accessory`, `get_bridged_accessories` pass-throughs for the host and the
+  device loader.
+
+### 4.3 Create OpenHAP::Server, delete OpenHAP::HAP
+
+The host takes the other half:
+
+- The listening socket, `accept`, per-connection reads and writes, and the
+  fileno-to-session map, on `FuguLib::EventLoop`. The host closes a connection
+  when `receive` returns undef and calls `session_close`.
+- The MQTT tick and reconnect timers, and accessory resubscription.
+- The mDNS handle: publish at startup, and on `on_pairing_changed` re-advertise
+  with `FuguLib::MDNS::format_txt` over the engine's records.
+- `control_status` and `control_devices`, composing engine introspection with
+  host state (uptime, MQTT, mDNS, connection count).
+- `run`, `stop`, `shutdown`, and the `listen` bootstrap.
+
+### 4.4 FuguLib::MDNS::format_txt
+
+- Add `format_txt(%records)`: sorted keys, `key=value`, joined with `.`
+  [MDNS-Control §5]. Move the join out of the engine.
+- Extend `t/fugulib/mdns.t` and `man/fugulib/MDNS.3p`.
+
+### 4.5 Rewire the entry points
+
+- `bin/openhapd` builds `OpenHAP::Server`, which builds the engine with
+  `OpenHAP::Storage`, `FuguLib::Log->default`, and the loop's timer hooks. The
+  pledge and unveil sequence, and the preload call, do not change.
+- `bin/hapctl` is untouched: it speaks to the control socket.
+- Check `man/openhap/openhapd.8` and the `openhapd`/`hapctl` skills for
+  module-name references; update what names `OpenHAP::HAP`.
+
+### 4.6 Tests
+
+- Split `t/openhap/hap.t`: engine behavior becomes `t/protocol/server.t`, driven
+  sans-IO over `Store::Memory` with captured `output`; host wiring becomes
+  `t/openhap/server.t`.
+- Retarget `t/conformance/hap-http.t`, `hap-mdns.t`, and the two exchange tests.
+  Socket-based exchange flows keep working through `OpenHAP::Test::Controller`
+  until phase 5.
+- `t/openhap/integration/` names the daemon, not the modules; verify, and update
+  only if a test names `OpenHAP::HAP`.
+
+## Deliverables
+
+- `lib/Protocol/HAP/Server.pm` and `HTTP.pm` with `.pod` sidecars.
+- `lib/OpenHAP/Server.pm` with a `.pod` sidecar; `lib/OpenHAP/HAP.pm` and its
+  pod deleted.
+- `t/protocol/server.t`, `t/protocol/http.t`, `t/openhap/server.t`.
+- Updated `bin/openhapd`, `FuguLib::MDNS`, `Makefile`, man pages, web body.
+
+## Acceptance criteria
+
+- `make check` passes; `make spec-coverage` reports no stale citations.
+- `grep -r 'OpenHAP::HAP\b\|FuguLib::HTTP' lib bin t` finds nothing.
+- `t/protocol/server.t` runs the full pair-setup, pair-verify, and encrypted
+  request flow without one socket.
+- `t/protocol/boundary.t` passes with the engine in place.
+- `make integration` passes in the VM before the phase merges: the daemon
+  pledges, publishes, pairs, and serves as before.

--- a/plans/007-protocol-hap/plan-4.md
+++ b/plans/007-protocol-hap/plan-4.md
@@ -34,7 +34,9 @@ The engine takes the protocol half of `OpenHAP::HAP`:
   and returns 1, or undef on a fatal condition.
 - Endpoints: `/pair-setup`, `/pair-verify`, `/identify`, `/pairings` (add,
   remove, list), `/accessories`, `/characteristics` GET and PUT, `/prepare`. The
-  handlers move as they are; only logging and storage calls change spelling.
+  handlers move with their behavior intact; the logging, storage, and JSON calls
+  change spelling. `JSON::XS` becomes core `JSON::PP` here — the boundary test
+  forbids `JSON::XS` under `lib/Protocol/`.
 - Events: the subscription registry, coalescing through `after`/`cancel`,
   `queue_event`, `flush_events`, and `send_event` over `output`.
 - Identity and discovery: `is_paired`, `get_config_number`,
@@ -78,9 +80,11 @@ The host takes the other half:
 - Split `t/openhap/hap.t`: engine behavior becomes `t/protocol/server.t`, driven
   sans-IO over `Store::Memory` with captured `output`; host wiring becomes
   `t/openhap/server.t`.
-- Retarget `t/conformance/hap-http.t`, `hap-mdns.t`, and the two exchange tests.
-  Socket-based exchange flows keep working through `OpenHAP::Test::Controller`
-  until phase 5.
+- Rework the transport of `t/conformance/hap-http.t`, `hap-mdns.t`, and the two
+  exchange tests. They drive the private `$hap->_dispatch` in-process today, and
+  this phase deletes it. The replacement is the public engine API:
+  `session_open`, `receive`, and captured `output`. The assertions and their
+  citations stay as they are.
 - `t/openhap/integration/` names the daemon, not the modules; verify, and update
   only if a test names `OpenHAP::HAP`.
 

--- a/plans/007-protocol-hap/plan-5.md
+++ b/plans/007-protocol-hap/plan-5.md
@@ -1,0 +1,70 @@
+# Phase 5 — Controller and the documentation pass
+
+This phase completes the library with the controller side, retargets the
+conformance suite to it, and finishes the documentation. After it, `OpenHAP`
+contains only product code.
+
+## Tasks
+
+### 5.1 Merge the SRP controller role
+
+- Move the client-side computation from `OpenHAP::Test::Controller::SRP` into
+  `Protocol::HAP::SRP`, next to the accessory role. One module holds both sides
+  of the exchange; the conformance vectors exercise them against each other.
+- Delete `OpenHAP::Test::Controller::SRP`.
+
+### 5.2 Create Protocol::HAP::Controller
+
+- Move `OpenHAP::Test::Controller` to `Protocol::HAP::Controller`: pair-setup,
+  pair-verify, session encryption, and plain and encrypted requests.
+- The controller is the documented sans-IO exception: a blocking convenience
+  client that owns its TCP socket. Embedders with an event loop use the codec
+  modules directly.
+- Add the `logger` argument like every other class; delete any `FuguLib::Log`
+  use.
+- Write the `.pod` sidecar, including one complete pair-and-read example — the
+  shortest path for a new implementer to a working controller.
+- Delete `OpenHAP::Test::Controller`.
+
+### 5.3 Retarget the tests
+
+- Move `t/openhap/test-controller.t` to `t/protocol/controller.t`.
+- Update the conformance suite to `Protocol::HAP::Controller`:
+  `hap-pairing-exchange.t`, `hap-encryption-exchange.t`, and any other file that
+  imports the test controller.
+- Where an exchange test can run sans-IO — controller codec against engine
+  `output` capture — prefer that form; keep one socket-based flow to cover the
+  blocking client itself.
+
+### 5.4 Documentation pass
+
+- Root `CLAUDE.md`: the namespace list gains `Protocol::` with a one-line
+  concern statement; the Layout and Commands sections reflect `t/protocol/` and
+  the final `lib/OpenHAP/` contents; the commit-scope list gains `protocol`.
+- `README.md`: a short section states that the HAP protocol lives in
+  `Protocol::HAP`, is host-neutral, and awaits a CPAN release; it points to
+  `Protocol/HAP.pod`. No restatement of the pod.
+- `t/CLAUDE.md`: the tier table row for `t/protocol/` gets its final wording;
+  the shared-mock note keeps pointing at `t/lib/`.
+- `TODO.md`: confirm the "Protocol::HAP CPAN release" section lists PAUSE
+  registration of `Protocol-HAP`, `$VERSION` policy, distribution tooling, and
+  the `spec/` redistribution-license review as release preconditions.
+- Verify `web/` renders the new pods; adjust `t/web/site.t` expectations.
+
+## Deliverables
+
+- `lib/Protocol/HAP/Controller.pm` and its `.pod`; the SRP controller role in
+  `Protocol::HAP::SRP`.
+- `lib/OpenHAP/Test/Controller.pm` and `Controller/SRP.pm` deleted with their
+  pods.
+- Retargeted conformance suite; `t/protocol/controller.t`.
+- Final `CLAUDE.md`, `README.md`, `t/CLAUDE.md`, `TODO.md`, and web updates.
+
+## Acceptance criteria
+
+- `make check` passes; `make spec-coverage` reports no stale citations.
+- `grep -r 'OpenHAP::Test::Controller' lib bin t` finds nothing.
+- `lib/OpenHAP/` contains exactly: `Server`, `Storage`, `DeviceLoader`,
+  `Tasmota/*`, `Test/Integration` — the product, nothing generic.
+- The controller pod example runs as written against a local `openhapd`.
+- `make integration` passes in the VM.

--- a/plans/007-protocol-hap/plan-5.md
+++ b/plans/007-protocol-hap/plan-5.md
@@ -33,7 +33,8 @@ contains only product code.
   `hap-pairing-exchange.t`, `hap-encryption-exchange.t`, and any other file that
   imports the test controller.
 - Where an exchange test can run sans-IO — controller codec against engine
-  `output` capture — prefer that form; keep one socket-based flow to cover the
+  `output` capture — prefer that form. No socket-based conformance flow exists
+  today; add exactly one, against a listening `OpenHAP::Server`, to cover the
   blocking client itself.
 
 ### 5.4 Documentation pass


### PR DESCRIPTION
Plan 007 extracts the generic HAP protocol into `Protocol::HAP`, a
self-contained, sans-IO Perl library. The goal is a design that other
implementations can build on, with a CPAN release as later work.

- The design defines the target namespace, five injected host contracts
  (logger, store, output, timers, pairing-change callback), and the
  connection contract of the sans-IO engine.
- Five phase plans cover the extraction: foundation codecs, the data
  model, pairing and sessions, the wire engine, and the controller.
- OpenHAP keeps only product code and becomes the reference host.
  `FuguLib::Crypto` shrinks to `FuguLib::Random`. The change is a clean
  break: no shims and no compatibility layers.

The documents passed the cold sub-agent review that `CLAUDE.md`
requires: six reviewers on separate angles, findings kept only when two
independent verifiers confirmed them. All three confirmed findings are
fixed, plus four side findings verified directly against the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016c8CRr7TH5GmXHb1wexw7i

---
_Generated by [Claude Code](https://claude.ai/code/session_016c8CRr7TH5GmXHb1wexw7i)_