### PR TITLE
docs(plans): add plan 008 for the CPAN namespace realignment

### DIFF
--- a/plans/008-cpan-namespaces/design.md
+++ b/plans/008-cpan-namespaces/design.md
@@ -12,11 +12,10 @@ the same empty work as `API` or `Interface`. `OpenHAP` and `FuguVM` are
 applications, and PAUSE puts applications under `App::`.
 
 Some module names describe a mechanism instead of a feature. `FuguVM::Expect`
-names a CPAN dependency, not the OpenBSD installer that it drives. `FuguVM::VM`
-repeats its parent. `OpenHAP::Server` collides with `Protocol::HAP::Server`.
-`OpenHAP::Storage`, `Protocol::HAP::Store`, and `FuguLib::Store` use three words
-for one idea. `FuguLib::Util` hides three unrelated functions behind a general
-noun.
+names a CPAN dependency. `FuguVM::VM` repeats its parent. `OpenHAP::Server`
+collides with `Protocol::HAP::Server`. `OpenHAP::Storage`,
+`Protocol::HAP::Store`, and `FuguLib::Store` use three words for one idea.
+`FuguLib::Util` hides three unrelated functions behind a general noun.
 
 `FuguLib::Imsg` mixes two jobs. It encodes and decodes the imsg(3) frame, and it
 also owns a socket. The codec is reusable; the socket is not.
@@ -30,37 +29,56 @@ The project has no users. A clean break is possible.
 
 1. The repository holds five namespaces: `App::OpenHAP`, `App::FuguVM`, `Fugu`,
    `Protocol::HAP`, and `Protocol::Imsg`.
-2. The repository claims exactly one top-level name, `Fugu`. It is a nexus of 20
-   modules and a fanciful name, so the guidance permits it. `App::` and
-   `Protocol::` are shared namespaces that the project joins.
-3. Every module name says what the module does. No name repeats its parent, no
-   name describes a dependency, and no two modules in the tree share a leaf name
-   for different jobs.
+2. The repository claims exactly one top-level name, `Fugu`. It is a nexus of 21
+   modules, so the guidance permits it. `App::` and `Protocol::` are shared
+   namespaces that the project joins.
+3. No module name repeats its parent, and no module name describes a dependency
+   instead of a feature.
 4. `Protocol::Imsg` is a sans-IO codec. `Fugu::Imsg` owns the socket and uses
    the codec.
-5. Behavior does not change. The wire formats, the configuration grammar, the
-   file paths, the command-line interfaces, and the manual content stay as they
-   are.
+5. Behavior does not change, with one exception: `hapctl` prints a device class,
+   so its output and its manual change with the package names.
 
 The products keep their names. The daemon is still OpenHAP, the command is still
-`openhapd`, and the VM utility is still FuguVM. Only Perl package names, the
-files that hold them, and the manual page names change. The one exception is
-FuguLib: the collection itself is now called Fugu, so prose that names the
-collection changes with the packages.
+`openhapd`, and the VM utility is still FuguVM. The one exception is FuguLib:
+the collection itself is now called Fugu, so prose that names the collection
+changes with the packages.
 
 ## Non-goals
 
 - No CPAN release. No `$VERSION`, no `Makefile.PL`, no distribution main
   modules, and no `no_index` metadata. `TODO.md` records that work.
 - No move of `Fugu::MQTT`, `Fugu::MDNS`, `Fugu::SSH`, or `Fugu::Proxy` into
-  `Net::` or `HTTP::`. Each needs its own study of the existing module in that
-  namespace. `TODO.md` records the question.
-- No rename of `Protocol::HAP::PIN` to `SetupCode`. The specification says
-  "setup code", but the module name is understood, the pod already gives the
-  specification word, and the rename would churn the conformance suite for no
-  gain.
+  `Net::` or `HTTP::`. `TODO.md` records the question. `Fugu::MDNS` needs a
+  second question first: it publishes through `mdnsd(8)`, so the name promises a
+  protocol implementation that the module does not hold.
+- No rename of `Protocol::HAP::PIN` to `SetupCode`. The pod already gives the
+  specification word, and the rename would churn the conformance suite.
 - No new features and no API changes, except the two that a rename forces: the
   split of `FuguLib::Util` and the split of `FuguLib::Imsg`.
+
+## Accepted trade-offs
+
+Three choices in this design have a real argument against them. Take them
+knowingly.
+
+1. **`App::` holds no command implementations.** `bin/openhapd` and `bin/hapctl`
+   hold the command logic, so `App::OpenHAP::` holds libraries only. The
+   counter-precedent is `Mail::SpamAssassin`: an OS-packaged daemon that keeps
+   its modules in a domain namespace. Accept `App::` because both products are
+   applications first, and a domain namespace would be a second top-level claim.
+2. **imsg is not an interoperable wire protocol.** The header is native-endian
+   and never crosses a host, while `Protocol::` on CPAN holds interoperable
+   protocols. `OpenBSD::` is the honest alternative and it is unusable: OpenBSD
+   base perl owns that namespace with `OpenBSD::Pledge`, `OpenBSD::Unveil`, and
+   the `pkg_add` tree. `Protocol::Imsg` states the limit in its first paragraph.
+3. **`Store` still names three things**: a JSON state file (`Fugu::Store`), a
+   persistence contract (`Protocol::HAP::Store`), and an implementation of that
+   contract (`App::OpenHAP::Store::File`). The last cannot move into
+   `Protocol::HAP::Store::File`, because it uses `Fugu::File` and the layering
+   rules forbid that direction. Goal 3 does not claim unique leaf names:
+   `Proxy`, `Config`, and `CLI` also repeat, each as a subclass of the `Fugu::`
+   module with the same leaf name.
 
 ## The clean-break rule
 
@@ -71,12 +89,17 @@ This effort is evergreen. An old name and its replacement never exist together.
   module. No `use lib` trick, and no dual name in `bin/`.
 - No deprecation period and no warning. A phase deletes the old name in the same
   commit that adds the new one.
-- No upgrade path ships. The project has no users. The repository carries no
-  code and no documentation for a machine with an older install.
+- No upgrade path ships. The repository carries no code and no documentation for
+  a machine with an older install.
 - The old names survive in exactly one place: `plans/001` to `plans/007`. Those
   files record what was true when they were written. Do not rewrite them.
-- The acceptance greps in each phase define completeness. A phase is done when
-  its grep finds nothing outside `plans/`.
+
+The rule needs a gate, because nothing in `make check` detects a shim today. A
+new `t/scripts/namespaces.t` reads the tracked files with `git ls-files`, skips
+`plans/`, and fails on any retired name. Phase 1 creates it; every later phase
+appends its retired names. It replaces the hand-run greps, which fail two ways:
+`grep -v 'App::OpenHAP::'` drops a whole line, so a stale name hides behind a
+live one, and `grep -r` reads the generated pages in `build/` and `web/build/`.
 
 ## Target names
 
@@ -92,33 +115,41 @@ This effort is evergreen. An old name and its replacement never exist together.
 
 ### Modules that change name
 
-| Now                          | Target                           | Reason                                                                                      |
-| ---------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------- |
-| `OpenHAP::Server`            | `App::OpenHAP::Host`             | It hosts the engine. Two modules must not both be `Server`.                                 |
-| `OpenHAP::Storage`           | `App::OpenHAP::Store::File`      | It implements the `Protocol::HAP::Store` contract in a file. It pairs with `Store::Memory`. |
-| `OpenHAP::DeviceLoader`      | `App::OpenHAP::Devices`          | It holds the devices. `Loader` names the mechanism.                                         |
-| `FuguVM::VM`                 | `App::FuguVM::Guest`             | The name must not repeat the parent.                                                        |
-| `FuguVM::Expect`             | `App::FuguVM::Installer`         | It drives the OpenBSD installer. `Expect` is the dependency.                                |
-| `FuguLib::Util`              | `Fugu::Timeout`                  | `bounded` and `wait_until` are one idea.                                                    |
-| `FuguLib::Util::format_size` | `App::FuguVM::CLI::_format_size` | The command-line interface is its only caller.                                              |
-| `FuguLib::Imsg`              | `Fugu::Imsg` + `Protocol::Imsg`  | The codec and the socket separate.                                                          |
+| Now                          | Target                           | Reason                                                      |
+| ---------------------------- | -------------------------------- | ----------------------------------------------------------- |
+| `OpenHAP::Server`            | `App::OpenHAP::Host`             | It hosts the engine. Two modules must not both be `Server`. |
+| `OpenHAP::Storage`           | `App::OpenHAP::Store::File`      | It implements `Protocol::HAP::Store` in a file.             |
+| `OpenHAP::DeviceLoader`      | `App::OpenHAP::Devices`          | It holds the devices. `Loader` names the mechanism.         |
+| `FuguVM::VM`                 | `App::FuguVM::Guest`             | The name must not repeat the parent.                        |
+| `FuguVM::Expect`             | `App::FuguVM::Console`           | It drives the serial console. `Expect` is the dependency.   |
+| `FuguLib::Util`              | `Fugu::Timeout`                  | `bounded` and `wait_until` are one idea.                    |
+| `FuguLib::Util::format_size` | `App::FuguVM::CLI::_format_size` | The command-line interface is its only caller.              |
+| `FuguLib::Imsg`              | `Fugu::Imsg` + `Protocol::Imsg`  | The codec and the socket separate.                          |
 
-Every other module keeps its leaf name: `Tasmota::*`, `Test::Integration`,
-`Disk`, `Image`, `ImageCache`, `QMP`, `QGA`, `State`, `Config`, `Proxy`, `CLI`,
-and the 19 other `Fugu::` modules.
+`Console`, not `Installer`: the module has two public verbs, `run_install` and
+`run_script`, and `fuguvm expect <script>` is a documented subcommand that calls
+the second one. `Installer` would name half the module.
+
+Every other module keeps its leaf name.
 
 ## Layering
 
 The split of `Imsg` gives `Fugu::` a reason to use `Protocol::`. Three rules
-keep the direction clear. `t/protocol/boundary.t` enforces all three.
+keep the direction clear.
 
 1. `Protocol::*` uses core Perl and the declared CPAN modules only. It never
    uses `Fugu::` or `App::`.
 2. `Fugu::*` uses core Perl, its optional CPAN libraries, and the `Protocol::`
    codecs on an allowlist. The allowlist holds `Protocol::Imsg` today. `Fugu::`
-   never uses `App::`, and never uses `Protocol::HAP`: a generic daemon toolkit
-   has no business in HomeKit.
+   never uses `App::`, and never uses `Protocol::HAP`.
 3. `App::*` uses both.
+
+`t/protocol/boundary.t` enforces all three, but not as it stands. Direction two
+matches `^(?:Protocol::HAP|OpenHAP)\b` at line 104. After the rename that
+pattern matches nothing, so the rule stops being enforced without one test
+failing. Phase 2 must widen it to `^App\b`, and phase 4 must add the
+`Protocol::` allowlist. The plans call this out because the acceptance greps
+cannot see it: the literal text is `OpenHAP)`, with no trailing colons.
 
 ## The Imsg contract
 
@@ -128,19 +159,26 @@ keep the direction clear. `t/protocol/boundary.t` enforces all three.
   and `FD_MARK`, as in `spec/MDNS-Imsg.md`.
 - `Protocol::Imsg->new` makes a decode buffer.
 - `encode(type =>, data =>, peerid =>, pid =>)` returns the framed bytes. It
-  returns undef with `$!` set to `EMSGSIZE` for an oversized payload. `pid`
-  defaults to `$$`, the one environment value that the codec reads.
+  returns undef with `$!` set to `EMSGSIZE` for an oversized payload. `pid` uses
+  `$args{pid} || $$`, because imsg substitutes the sender's pid when the caller
+  passes 0 [MDNS-Imsg §3]. That is the one environment value the codec reads.
 - `append($bytes)` adds received bytes to the buffer.
 - `next_message` pops one whole message and returns a hashref with `type`,
   `peerid`, `pid`, and `data`. It returns undef when more bytes are necessary.
   An invalid length sets `$!` to `EBADMSG` and makes the failure permanent.
 - `is_failed` reports that permanent framing failure.
+- `reset` empties the buffer and clears the failure. `Fugu::Imsg::close` needs
+  it: it empties the buffer today, so a closed connection can never hand out a
+  frame that arrived before the close.
 
-`Fugu::Imsg` keeps its current public API: `new(fh =>)`, `send`, `recv`,
-`close`, and `is_dead`. It holds a `Protocol::Imsg` object, does the write loop,
-the `SIGPIPE` guard, the `IO::Select` poll, and the read loop. The callers —
-`Fugu::Control`, `Fugu::MDNS`, and the tests — change the module name and
-nothing else.
+`Fugu::Imsg` keeps `new(fh =>)`, `send`, `recv`, `close`, and `is_dead`, with
+the same return values and the same `$!` values. It holds one `Protocol::Imsg`
+object and does the write loop, the `SIGPIPE` guard, the `IO::Select` poll, and
+the read loop.
+
+The transport must also re-export `MAX_PAYLOAD`. `Fugu::Control` chunks its
+replies with `FuguLib::Imsg::MAX_PAYLOAD` as a bareword, so the constant leaving
+the module is a compile-time abort, not a runtime error.
 
 ## Wiring after the change
 
@@ -149,54 +187,56 @@ graph TD
     openhapd[bin/openhapd] --> H[App::OpenHAP::Host]
     hapctl[bin/hapctl] --> D[App::OpenHAP::Devices]
     fuguvm[bin/fuguvm] --> VC[App::FuguVM::CLI] --> G[App::FuguVM::Guest]
-    G --> I[App::FuguVM::Installer]
+    G --> I[App::FuguVM::Console]
     H --> PS[Protocol::HAP::Server]
     H --> SF[App::OpenHAP::Store::File] -. store contract .-> PS
     H --> FH[Fugu: EventLoop Log MQTT MDNS Timeout]
     D --> TAS[App::OpenHAP::Tasmota::*]
     FM[Fugu::MDNS] --> FI[Fugu::Imsg] --> PI[Protocol::Imsg]
     FC[Fugu::Control] --> FI
+    FC --> PI
 ```
 
-## Testing
+## Testing and the build
 
-- `t/fugulib/` becomes `t/fugu/`. A tier is named after its product, and only
-  this product name changes. `t/openhap/` and `t/fuguvm/` keep their names.
-- `t/lib/FuguLib/TestLog.pm` becomes `t/lib/Fugu/TestLog.pm`.
-  `t/lib/OpenHAP/TestMock/MQTT.pm` becomes `t/lib/App/OpenHAP/TestMock/MQTT.pm`.
-- `t/protocol/imsg.t` covers the codec. `t/fugu/imsg.t` covers the transport
-  over a socketpair. `t/conformance/mdns-imsg.t` keeps its name and its
-  citations, and drives `Protocol::Imsg` for the framing rules.
-- `t/fugu/coreperl.t` must still pass. `Fugu::Imsg` requires `Protocol::Imsg`,
-  which is under `lib/` and uses core Perl only.
-- `t/web/site.t` holds the directory name `fugulib` and a
-  `^(?:OpenHAP|FuguVM|Protocol)::` match. Both change.
-- Each phase ends with `make check` green and `make spec-coverage` clean.
+`t/fugulib/` becomes `t/fugu/`. A tier is named after its product, and only this
+product name changes. The rename also reaches 29 test files in the other tiers,
+3 of which run only under `make integration`.
 
-## Build, install, and CI
+Six mechanisms fail quietly under a rename, and no acceptance grep can see any
+of them: the `skip_all` guards in `t/fugulib/coreperl.t` and `t/fuguvm/vm.t`,
+the path-prefix groups in `web/mkindex.sh`, the `TESTS` variable in
+`scripts/integration`, the stale guest install that `scripts/vm-provision`
+leaves in `@INC`, the `find … -exec perl -cw {} \;` in `check.yml` that always
+exits 0, and the `-d "$script_lib/OpenHAP"` unveil probe in `bin/openhapd`. Each
+phase names the ones it touches.
 
-- The `Makefile` names every namespace directory in `install`, `uninstall`, and
-  `package`. All three change. `App::FuguVM` does not join them: FuguVM is a
-  development tool and is not installed.
-- The `install-man` and `web` targets rename each 3p page to `FuguLib::<stem>`.
-  The prefix becomes `Fugu::`. `MAN3P` and the `.Xr` cross-references follow.
-- `scripts/integration` carries `t/fugulib/sandbox.t` and `lib/OpenHAP/Test/`
-  into the guest, and copies the second to `site_perl/OpenHAP/`. All three paths
-  change.
-- The path filters in `.github/workflows/integration.yml` name `lib/FuguLib/`,
-  `lib/OpenHAP/`, `lib/FuguVM/`, and `t/fugulib/sandbox.t`, in the push list and
-  the pull-request list. `check.yml` matches `lib/**.pm` and needs no change.
+`make check` is `lint test tidy`. It does not run `prettier`, `mandoc -Tlint`,
+`install`, or `package`, and `lint` and `tidy` read `lib bin scripts` only.
+`t/web/site.t` skips without `lowdown` and `mandoc`, which are `develop`
+dependencies. Each phase therefore names the extra commands it must run, and
+ends with one `make install DESTDIR=` into an empty directory.
+
+The `Makefile` names every namespace directory in `install`, `uninstall`, and
+`package`, and renames each 3p page to `FuguLib::<stem>` in two loops.
+`App::FuguVM` joins none of them: FuguVM is a development tool and is not
+installed. `uninstall` must never remove a shared parent. It does
+`rm -rf $(LIBDIR)/Protocol` today, which deletes every other `Protocol::`
+distribution on the machine, and `App/` would be worse.
 
 ## Phases
 
-1. `FuguLib::` becomes `Fugu::`. Names only, no behavior change.
+1. `FuguLib::` becomes `Fugu::`. Names only, plus the two gates that later
+   phases depend on: `t/scripts/namespaces.t` and the CI compile step.
 2. `OpenHAP::` becomes `App::OpenHAP::`, with `Host`, `Store::File`, and
    `Devices`.
-3. `FuguVM::` becomes `App::FuguVM::`, with `Guest` and `Installer`.
+3. `FuguVM::` becomes `App::FuguVM::`, with `Guest` and `Console`.
 4. `Protocol::Imsg` splits out of `Fugu::Imsg`.
 5. `Fugu::Util` splits into `Fugu::Timeout`; the documentation and website pass;
    `TODO.md` records the release work.
 
-The order follows the dependency direction, from the base to the products. Each
+The order follows the dependency direction, from the base to the products. Phase
+3 depends on phase 2, because both edit the same regex in `t/web/site.t` and in
+`t/protocol/boundary.t`, and the phase-2 state must keep `FuguVM` in both. Each
 phase lands whole: the modules, their callers, their tests, their manuals, and
 the build rules change together.

--- a/plans/008-cpan-namespaces/design.md
+++ b/plans/008-cpan-namespaces/design.md
@@ -1,0 +1,202 @@
+# CPAN namespace realignment — Design
+
+## Problem
+
+The repository claims three top-level namespaces: `OpenHAP`, `FuguLib`, and
+`FuguVM`. The PAUSE guidance on module naming permits a top-level name only for
+a nexus of modules, or for a fanciful name that names an application. Three
+claims for one project fail that test. Two other faults come with them.
+
+`Lib` carries no information. Every Perl module is a library, so the word does
+the same empty work as `API` or `Interface`. `OpenHAP` and `FuguVM` are
+applications, and PAUSE puts applications under `App::`.
+
+Some module names describe a mechanism instead of a feature. `FuguVM::Expect`
+names a CPAN dependency, not the OpenBSD installer that it drives. `FuguVM::VM`
+repeats its parent. `OpenHAP::Server` collides with `Protocol::HAP::Server`.
+`OpenHAP::Storage`, `Protocol::HAP::Store`, and `FuguLib::Store` use three words
+for one idea. `FuguLib::Util` hides three unrelated functions behind a general
+noun.
+
+`FuguLib::Imsg` mixes two jobs. It encodes and decodes the imsg(3) frame, and it
+also owns a socket. The codec is reusable; the socket is not.
+
+`Protocol::HAP` is the one namespace that already follows the guidance. It is
+the model for this effort.
+
+The project has no users. A clean break is possible.
+
+## Goals
+
+1. The repository holds five namespaces: `App::OpenHAP`, `App::FuguVM`, `Fugu`,
+   `Protocol::HAP`, and `Protocol::Imsg`.
+2. The repository claims exactly one top-level name, `Fugu`. It is a nexus of 20
+   modules and a fanciful name, so the guidance permits it. `App::` and
+   `Protocol::` are shared namespaces that the project joins.
+3. Every module name says what the module does. No name repeats its parent, no
+   name describes a dependency, and no two modules in the tree share a leaf name
+   for different jobs.
+4. `Protocol::Imsg` is a sans-IO codec. `Fugu::Imsg` owns the socket and uses
+   the codec.
+5. Behavior does not change. The wire formats, the configuration grammar, the
+   file paths, the command-line interfaces, and the manual content stay as they
+   are.
+
+The products keep their names. The daemon is still OpenHAP, the command is still
+`openhapd`, and the VM utility is still FuguVM. Only Perl package names, the
+files that hold them, and the manual page names change. The one exception is
+FuguLib: the collection itself is now called Fugu, so prose that names the
+collection changes with the packages.
+
+## Non-goals
+
+- No CPAN release. No `$VERSION`, no `Makefile.PL`, no distribution main
+  modules, and no `no_index` metadata. `TODO.md` records that work.
+- No move of `Fugu::MQTT`, `Fugu::MDNS`, `Fugu::SSH`, or `Fugu::Proxy` into
+  `Net::` or `HTTP::`. Each needs its own study of the existing module in that
+  namespace. `TODO.md` records the question.
+- No rename of `Protocol::HAP::PIN` to `SetupCode`. The specification says
+  "setup code", but the module name is understood, the pod already gives the
+  specification word, and the rename would churn the conformance suite for no
+  gain.
+- No new features and no API changes, except the two that a rename forces: the
+  split of `FuguLib::Util` and the split of `FuguLib::Imsg`.
+
+## The clean-break rule
+
+This effort is evergreen. An old name and its replacement never exist together.
+
+- Each rename is a `git mv` plus a rewrite. No file stays behind.
+- No aliases. No `our @ISA` bridges to an old package. No empty compatibility
+  module. No `use lib` trick, and no dual name in `bin/`.
+- No deprecation period and no warning. A phase deletes the old name in the same
+  commit that adds the new one.
+- No upgrade path ships. The project has no users. The repository carries no
+  code and no documentation for a machine with an older install.
+- The old names survive in exactly one place: `plans/001` to `plans/007`. Those
+  files record what was true when they were written. Do not rewrite them.
+- The acceptance greps in each phase define completeness. A phase is done when
+  its grep finds nothing outside `plans/`.
+
+## Target names
+
+### Namespaces
+
+| Now               | Target           | Reason                                |
+| ----------------- | ---------------- | ------------------------------------- |
+| `OpenHAP::`       | `App::OpenHAP::` | An application belongs under `App::`. |
+| `FuguVM::`        | `App::FuguVM::`  | An application belongs under `App::`. |
+| `FuguLib::`       | `Fugu::`         | `Lib` says nothing. One nexus stays.  |
+| `Protocol::HAP::` | unchanged        | It already follows the guidance.      |
+| —                 | `Protocol::Imsg` | A new sans-IO codec.                  |
+
+### Modules that change name
+
+| Now                          | Target                           | Reason                                                                                      |
+| ---------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------- |
+| `OpenHAP::Server`            | `App::OpenHAP::Host`             | It hosts the engine. Two modules must not both be `Server`.                                 |
+| `OpenHAP::Storage`           | `App::OpenHAP::Store::File`      | It implements the `Protocol::HAP::Store` contract in a file. It pairs with `Store::Memory`. |
+| `OpenHAP::DeviceLoader`      | `App::OpenHAP::Devices`          | It holds the devices. `Loader` names the mechanism.                                         |
+| `FuguVM::VM`                 | `App::FuguVM::Guest`             | The name must not repeat the parent.                                                        |
+| `FuguVM::Expect`             | `App::FuguVM::Installer`         | It drives the OpenBSD installer. `Expect` is the dependency.                                |
+| `FuguLib::Util`              | `Fugu::Timeout`                  | `bounded` and `wait_until` are one idea.                                                    |
+| `FuguLib::Util::format_size` | `App::FuguVM::CLI::_format_size` | The command-line interface is its only caller.                                              |
+| `FuguLib::Imsg`              | `Fugu::Imsg` + `Protocol::Imsg`  | The codec and the socket separate.                                                          |
+
+Every other module keeps its leaf name: `Tasmota::*`, `Test::Integration`,
+`Disk`, `Image`, `ImageCache`, `QMP`, `QGA`, `State`, `Config`, `Proxy`, `CLI`,
+and the 19 other `Fugu::` modules.
+
+## Layering
+
+The split of `Imsg` gives `Fugu::` a reason to use `Protocol::`. Three rules
+keep the direction clear. `t/protocol/boundary.t` enforces all three.
+
+1. `Protocol::*` uses core Perl and the declared CPAN modules only. It never
+   uses `Fugu::` or `App::`.
+2. `Fugu::*` uses core Perl, its optional CPAN libraries, and the `Protocol::`
+   codecs on an allowlist. The allowlist holds `Protocol::Imsg` today. `Fugu::`
+   never uses `App::`, and never uses `Protocol::HAP`: a generic daemon toolkit
+   has no business in HomeKit.
+3. `App::*` uses both.
+
+## The Imsg contract
+
+`Protocol::Imsg` is pure. It takes bytes and returns bytes.
+
+- Constants: `HEADER_SIZE`, `HEADER_TEMPLATE`, `MAX_IMSGSIZE`, `MAX_PAYLOAD`,
+  and `FD_MARK`, as in `spec/MDNS-Imsg.md`.
+- `Protocol::Imsg->new` makes a decode buffer.
+- `encode(type =>, data =>, peerid =>, pid =>)` returns the framed bytes. It
+  returns undef with `$!` set to `EMSGSIZE` for an oversized payload. `pid`
+  defaults to `$$`, the one environment value that the codec reads.
+- `append($bytes)` adds received bytes to the buffer.
+- `next_message` pops one whole message and returns a hashref with `type`,
+  `peerid`, `pid`, and `data`. It returns undef when more bytes are necessary.
+  An invalid length sets `$!` to `EBADMSG` and makes the failure permanent.
+- `is_failed` reports that permanent framing failure.
+
+`Fugu::Imsg` keeps its current public API: `new(fh =>)`, `send`, `recv`,
+`close`, and `is_dead`. It holds a `Protocol::Imsg` object, does the write loop,
+the `SIGPIPE` guard, the `IO::Select` poll, and the read loop. The callers —
+`Fugu::Control`, `Fugu::MDNS`, and the tests — change the module name and
+nothing else.
+
+## Wiring after the change
+
+```mermaid
+graph TD
+    openhapd[bin/openhapd] --> H[App::OpenHAP::Host]
+    hapctl[bin/hapctl] --> D[App::OpenHAP::Devices]
+    fuguvm[bin/fuguvm] --> VC[App::FuguVM::CLI] --> G[App::FuguVM::Guest]
+    G --> I[App::FuguVM::Installer]
+    H --> PS[Protocol::HAP::Server]
+    H --> SF[App::OpenHAP::Store::File] -. store contract .-> PS
+    H --> FH[Fugu: EventLoop Log MQTT MDNS Timeout]
+    D --> TAS[App::OpenHAP::Tasmota::*]
+    FM[Fugu::MDNS] --> FI[Fugu::Imsg] --> PI[Protocol::Imsg]
+    FC[Fugu::Control] --> FI
+```
+
+## Testing
+
+- `t/fugulib/` becomes `t/fugu/`. A tier is named after its product, and only
+  this product name changes. `t/openhap/` and `t/fuguvm/` keep their names.
+- `t/lib/FuguLib/TestLog.pm` becomes `t/lib/Fugu/TestLog.pm`.
+  `t/lib/OpenHAP/TestMock/MQTT.pm` becomes `t/lib/App/OpenHAP/TestMock/MQTT.pm`.
+- `t/protocol/imsg.t` covers the codec. `t/fugu/imsg.t` covers the transport
+  over a socketpair. `t/conformance/mdns-imsg.t` keeps its name and its
+  citations, and drives `Protocol::Imsg` for the framing rules.
+- `t/fugu/coreperl.t` must still pass. `Fugu::Imsg` requires `Protocol::Imsg`,
+  which is under `lib/` and uses core Perl only.
+- `t/web/site.t` holds the directory name `fugulib` and a
+  `^(?:OpenHAP|FuguVM|Protocol)::` match. Both change.
+- Each phase ends with `make check` green and `make spec-coverage` clean.
+
+## Build, install, and CI
+
+- The `Makefile` names every namespace directory in `install`, `uninstall`, and
+  `package`. All three change. `App::FuguVM` does not join them: FuguVM is a
+  development tool and is not installed.
+- The `install-man` and `web` targets rename each 3p page to `FuguLib::<stem>`.
+  The prefix becomes `Fugu::`. `MAN3P` and the `.Xr` cross-references follow.
+- `scripts/integration` carries `t/fugulib/sandbox.t` and `lib/OpenHAP/Test/`
+  into the guest, and copies the second to `site_perl/OpenHAP/`. All three paths
+  change.
+- The path filters in `.github/workflows/integration.yml` name `lib/FuguLib/`,
+  `lib/OpenHAP/`, `lib/FuguVM/`, and `t/fugulib/sandbox.t`, in the push list and
+  the pull-request list. `check.yml` matches `lib/**.pm` and needs no change.
+
+## Phases
+
+1. `FuguLib::` becomes `Fugu::`. Names only, no behavior change.
+2. `OpenHAP::` becomes `App::OpenHAP::`, with `Host`, `Store::File`, and
+   `Devices`.
+3. `FuguVM::` becomes `App::FuguVM::`, with `Guest` and `Installer`.
+4. `Protocol::Imsg` splits out of `Fugu::Imsg`.
+5. `Fugu::Util` splits into `Fugu::Timeout`; the documentation and website pass;
+   `TODO.md` records the release work.
+
+The order follows the dependency direction, from the base to the products. Each
+phase lands whole: the modules, their callers, their tests, their manuals, and
+the build rules change together.

--- a/plans/008-cpan-namespaces/design.md
+++ b/plans/008-cpan-namespaces/design.md
@@ -11,11 +11,15 @@ claims for one project fail that test. Two other faults come with them.
 the same empty work as `API` or `Interface`. `OpenHAP` and `FuguVM` are
 applications, and PAUSE puts applications under `App::`.
 
-Some module names describe a mechanism instead of a feature. `FuguVM::Expect`
-names a CPAN dependency. `FuguVM::VM` repeats its parent. `OpenHAP::Server`
-collides with `Protocol::HAP::Server`. `OpenHAP::Storage`,
-`Protocol::HAP::Store`, and `FuguLib::Store` use three words for one idea.
-`FuguLib::Util` hides three unrelated functions behind a general noun.
+Nine module names are wrong in four ways. Some name a mechanism instead of a
+feature: `FuguVM::Expect` names a CPAN dependency, `OpenHAP::DeviceLoader` and
+`OpenHAP::Tasmota::Base` name a role in the code. Some claim more than they
+hold: `FuguLib::MDNS` implements no mDNS, and only controls `mdnsd(8)`. Some
+collide or mislead: `FuguVM::VM` repeats its parent, `OpenHAP::Server` collides
+with `Protocol::HAP::Server`, and `FuguVM::Image` and `FuguVM::ImageCache` are
+two caches of two different artefacts. Some are simply stale or empty:
+`Protocol::HAP::PIN` uses a word the specification replaced with "setup code",
+and `FuguLib::Util` hides three unrelated functions behind a general noun.
 
 `FuguLib::Imsg` mixes two jobs. It encodes and decodes the imsg(3) frame, and it
 also owns a socket. The codec is reusable; the socket is not.
@@ -32,8 +36,9 @@ The project has no users. A clean break is possible.
 2. The repository claims exactly one top-level name, `Fugu`. It is a nexus of 21
    modules, so the guidance permits it. `App::` and `Protocol::` are shared
    namespaces that the project joins.
-3. No module name repeats its parent, and no module name describes a dependency
-   instead of a feature.
+3. No module name repeats its parent, describes a dependency instead of a
+   feature, claims a capability the module does not hold, or uses a word the
+   specification has replaced.
 4. `Protocol::Imsg` is a sans-IO codec. `Fugu::Imsg` owns the socket and uses
    the codec.
 5. Behavior does not change, with one exception: `hapctl` prints a device class,
@@ -48,14 +53,11 @@ changes with the packages.
 
 - No CPAN release. No `$VERSION`, no `Makefile.PL`, no distribution main
   modules, and no `no_index` metadata. `TODO.md` records that work.
-- No move of `Fugu::MQTT`, `Fugu::MDNS`, `Fugu::SSH`, or `Fugu::Proxy` into
-  `Net::` or `HTTP::`. `TODO.md` records the question. `Fugu::MDNS` needs a
-  second question first: it publishes through `mdnsd(8)`, so the name promises a
-  protocol implementation that the module does not hold.
-- No rename of `Protocol::HAP::PIN` to `SetupCode`. The pod already gives the
-  specification word, and the rename would churn the conformance suite.
 - No new features and no API changes, except the two that a rename forces: the
   split of `FuguLib::Util` and the split of `FuguLib::Imsg`.
+
+No naming question is out of scope. This is the naming effort, so every name in
+the tree is decided here, and none is recorded for later.
 
 ## Accepted trade-offs
 
@@ -72,13 +74,12 @@ knowingly.
    protocols. `OpenBSD::` is the honest alternative and it is unusable: OpenBSD
    base perl owns that namespace with `OpenBSD::Pledge`, `OpenBSD::Unveil`, and
    the `pkg_add` tree. `Protocol::Imsg` states the limit in its first paragraph.
-3. **`Store` still names three things**: a JSON state file (`Fugu::Store`), a
-   persistence contract (`Protocol::HAP::Store`), and an implementation of that
-   contract (`App::OpenHAP::Store::File`). The last cannot move into
-   `Protocol::HAP::Store::File`, because it uses `Fugu::File` and the layering
-   rules forbid that direction. Goal 3 does not claim unique leaf names:
-   `Proxy`, `Config`, and `CLI` also repeat, each as a subclass of the `Fugu::`
-   module with the same leaf name.
+3. **`App::OpenHAP::Store::File` sits far from the contract it implements.**
+   Someone who takes `Protocol::HAP` to CPAN and wants file persistence will
+   look for `Protocol::HAP::Store::File`. It cannot live there: it uses
+   `Fugu::File`, and the layering rules forbid that direction. Goal 3 does not
+   claim unique leaf names either. `Proxy`, `Config`, and `CLI` each repeat,
+   every time as a subclass of the `Fugu::` module with the same leaf name.
 
 ## The clean-break rule
 
@@ -122,15 +123,42 @@ live one, and `grep -r` reads the generated pages in `build/` and `web/build/`.
 | `OpenHAP::DeviceLoader`      | `App::OpenHAP::Devices`          | It holds the devices. `Loader` names the mechanism.         |
 | `FuguVM::VM`                 | `App::FuguVM::Guest`             | The name must not repeat the parent.                        |
 | `FuguVM::Expect`             | `App::FuguVM::Console`           | It drives the serial console. `Expect` is the dependency.   |
+| `OpenHAP::Tasmota::Base`     | `App::OpenHAP::Tasmota::Device`  | `Base` names a mechanism, as `Loader` did.                  |
+| `FuguVM::Image`              | `App::FuguVM::Miniroot`          | It downloads and caches the install media.                  |
+| `FuguVM::ImageCache`         | `App::FuguVM::DiskCache`         | It caches installed qcow2 disks, not the media above.       |
 | `FuguLib::Util`              | `Fugu::Timeout`                  | `bounded` and `wait_until` are one idea.                    |
 | `FuguLib::Util::format_size` | `App::FuguVM::CLI::_format_size` | The command-line interface is its only caller.              |
+| `FuguLib::Store`             | `Fugu::StateFile`                | Its own abstract calls it a JSON state file.                |
+| `FuguLib::MDNS`              | `Fugu::Mdnsd`                    | It controls `mdnsd(8)`. It does not implement mDNS.         |
 | `FuguLib::Imsg`              | `Fugu::Imsg` + `Protocol::Imsg`  | The codec and the socket separate.                          |
+| `Protocol::HAP::PIN`         | `Protocol::HAP::SetupCode`       | The specification says "setup code" [HAP-Pairing §2].       |
 
-`Console`, not `Installer`: the module has two public verbs, `run_install` and
-`run_script`, and `fuguvm expect <script>` is a documented subcommand that calls
-the second one. `Installer` would name half the module.
+Three of these need a word. `Console`, not `Installer`, because the module has
+two public verbs and `fuguvm expect <script>` is a documented subcommand that
+calls `run_script`. `Miniroot` and `DiskCache`, because both modules cache and
+neither name says what: one fetches the install media, the other keeps the disk
+the installer produced, and `ImageCache` loads `Image`, so the pair reads as a
+cache of the thing above it. `Mdnsd`, because the module sends `IMSG_CTL_*` over
+the control socket and no mDNS packet ever leaves it — the same fault as
+`Expect`, and a worse one, because `Expect` named a dependency while `MDNS`
+claims a capability.
 
-Every other module keeps its leaf name.
+### Names that stay, and why
+
+These were open questions. They are decided.
+
+- `Fugu::MQTT` and `Fugu::SSH` stay out of `Net::`. Neither implements a
+  protocol. The first adapts `Net::MQTT::Simple` to a `select` loop and owns the
+  reconnect policy; the second drives `ssh(1)`. Host policy belongs in the host
+  nexus, and the `Net::` rule governs a top-level claim, which this is not.
+- `Fugu::Proxy` stays. It is a caching HTTP proxy, so the name is honest.
+- `Fugu::File` stays. Eleven functions is a lot, but they are one domain: files
+  and paths. That is what separates it from `Util`.
+- `Fugu::Config`, `Fugu::CLI`, `Fugu::Control`, `Fugu::JSONSocket`, and
+  `Fugu::EventLoop` stay. Each is accurate inside the nexus.
+- Every other `Protocol::HAP::` name stays. `TLV`, `SRP`, `Pairing`, `Session`,
+  `Accessory`, `Service`, `Characteristic`, and `Bridge` are the specification's
+  own words, and it calls `Server` the accessory server.
 
 ## Layering
 
@@ -192,7 +220,7 @@ graph TD
     H --> SF[App::OpenHAP::Store::File] -. store contract .-> PS
     H --> FH[Fugu: EventLoop Log MQTT MDNS Timeout]
     D --> TAS[App::OpenHAP::Tasmota::*]
-    FM[Fugu::MDNS] --> FI[Fugu::Imsg] --> PI[Protocol::Imsg]
+    FM[Fugu::Mdnsd] --> FI[Fugu::Imsg] --> PI[Protocol::Imsg]
     FC[Fugu::Control] --> FI
     FC --> PI
 ```
@@ -228,12 +256,14 @@ distribution on the machine, and `App/` would be worse.
 
 1. `FuguLib::` becomes `Fugu::`. Names only, plus the two gates that later
    phases depend on: `t/scripts/namespaces.t` and the CI compile step.
-2. `OpenHAP::` becomes `App::OpenHAP::`, with `Host`, `Store::File`, and
-   `Devices`.
-3. `FuguVM::` becomes `App::FuguVM::`, with `Guest` and `Console`.
+2. `OpenHAP::` becomes `App::OpenHAP::`, with `Host`, `Store::File`, `Devices`,
+   and `Tasmota::Device`.
+3. `FuguVM::` becomes `App::FuguVM::`, with `Guest`, `Console`, `Miniroot`, and
+   `DiskCache`.
 4. `Protocol::Imsg` splits out of `Fugu::Imsg`.
-5. `Fugu::Util` splits into `Fugu::Timeout`; the documentation and website pass;
-   `TODO.md` records the release work.
+5. The leaf renames that no namespace move forces: `Fugu::Timeout`,
+   `Fugu::StateFile`, `Fugu::Mdnsd`, and `Protocol::HAP::SetupCode`. Then the
+   documentation and website pass.
 
 The order follows the dependency direction, from the base to the products. Phase
 3 depends on phase 2, because both edit the same regex in `t/web/site.t` and in

--- a/plans/008-cpan-namespaces/plan-1.md
+++ b/plans/008-cpan-namespaces/plan-1.md
@@ -1,13 +1,11 @@
 # Phase 1 — FuguLib becomes Fugu
 
-This phase renames one namespace and nothing else. It touches more files than
-the other four phases together, so it stays mechanical on purpose: no module
-splits, no API changes, and no moved functions. A reviewer must be able to check
-it with a grep.
+This phase renames one namespace, and builds the two gates that every later
+phase depends on. The rename itself stays mechanical: no module splits, no API
+changes, and no moved functions.
 
-The product keeps its name in prose only where the prose means the collection of
-daemon utilities. That collection is now called Fugu, so the website body, the
-manual titles, and the `CLAUDE.md` text change with the packages.
+The collection is now called Fugu, so the website body, the manual titles, and
+the `CLAUDE.md` text change with the packages.
 
 ## Tasks
 
@@ -23,84 +21,142 @@ manual titles, and the `CLAUDE.md` text change with the packages.
 ### 1.2 Retarget the callers
 
 - `bin/openhapd` and `bin/hapctl`: nine and five import lines.
-- `lib/OpenHAP/`: `Server.pm`, `Storage.pm`, `DeviceLoader.pm`, `Tasmota/*.pm`,
-  `Test/Integration.pm`, and the `.pod` sidecars.
-- `lib/FuguVM/`: every module and every `.pod` sidecar.
+- `lib/OpenHAP/` and `lib/FuguVM/`: every module and every `.pod` sidecar.
 - `lib/Protocol/` must not match. If it does, `t/protocol/boundary.t` is broken,
   not the code.
+- 29 test files outside `t/fugulib/` also name a `FuguLib::` module: 15 under
+  `t/conformance/`, 7 under `t/openhap/` (including
+  `t/openhap/integration/control.t` and `sandbox.t`), and 7 under `t/fuguvm/`.
+  `make check` never runs the integration files, so a miss there surfaces only
+  in `make integration`.
 
 ### 1.3 Move the manuals
 
 - `git mv man/fugulib man/fugu`. Rewrite the `.Nm` name, the `.Xr`
   cross-references, and the body text of all 21 pages.
 - `Makefile`: the `MAN3P` list, the comment above it, the `install-man` rename
-  loop, the `uninstall` rename loop, and the `web` staging loop all use the
-  literal `FuguLib::`. Each becomes `Fugu::`.
-- The `package` target makes and fills `build/$(PACKAGE)/man/fugulib/`. That
-  staging directory becomes `man/fugu/`.
+  loop, the `uninstall` rename loop, the `web` staging loop, and the
+  `build/$(PACKAGE)/man/fugulib/` staging directory in `package`.
 - A page installs as `Fugu::Daemon.3p`, so `man Fugu::Daemon` finds it.
+- Run `mandoc -Tlint -W warning` over the moved pages. `make check` does not.
 
 ### 1.4 Move the tests
 
 - `git mv t/fugulib t/fugu`. Retarget the imports in all 22 files.
 - `git mv t/lib/FuguLib t/lib/Fugu`, and rename the `FuguLib::TestLog` package.
-  Retarget every test that loads it.
-- `t/fugu/coreperl.t` scans `lib/FuguLib` and builds `require FuguLib::$module`
-  strings. Both change.
-- `t/protocol/boundary.t`: direction two scans `$ROOT/lib/FuguLib` and matches
-  `^(?:FuguLib|FuguVM|OpenHAP)\b`. Change the path, the pattern, and the subtest
-  names.
+- `t/fugu/coreperl.t:20` opens `$lib/FuguLib` and calls `skip_all` when the
+  directory is absent, and line 64 builds `require FuguLib::$module`. Change the
+  path and the string, and make the missing directory a hard failure. A skip
+  would hide the whole core-Perl guarantee.
+- `t/protocol/boundary.t` holds two different subtests, and the plan for each
+  differs:
+  - Direction one, at line 64, scans `lib/Protocol` and matches
+    `^(?:FuguLib|FuguVM|OpenHAP)\b` at line 73. Change the pattern only.
+  - Direction two, at line 94, scans `lib/FuguLib` and matches
+    `^(?:Protocol::HAP|OpenHAP)\b` at line 104. Change the path only. Phase 2
+    changes that pattern.
+  - The file header at lines 3 to 8 and both subtest names name FuguLib.
 - `Makefile`: the `test` target names `t/fugulib`.
 - `t/CLAUDE.md`: the tier table row and the sandbox paragraph.
 
-### 1.5 Build, install, and CI
+### 1.5 Add the clean-break gate
+
+- Write `t/scripts/namespaces.t`. It lists the retired names, reads the tracked
+  files with `git ls-files`, skips `plans/`, and fails on any hit. Seed the list
+  with `FuguLib`.
+- Reading tracked files only keeps `build/`, `web/build/`, and `.fuguvm/` out of
+  the result. Those directories hold generated pages under the old names until
+  `make clean`, and they make a plain `grep -r` useless as a gate.
+- Match the retired name where no live name precedes it, so that a line holding
+  both an old and a new name still fails. A line filter such as
+  `grep -v 'App::OpenHAP::'` cannot do that.
+- Every later phase appends its retired names to the list. This test replaces
+  the hand-run greps.
+
+### 1.6 Fix the CI compile gate
+
+- `.github/workflows/check.yml:89-90` runs
+  `find lib -name "*.pm" -exec perl -I lib -cw {} \;`. `find -exec … \;` does
+  not propagate the exit status, so a module that fails to compile prints an
+  error and the step passes.
+- Replace both lines with a form that fails, such as
+  `find lib -name '*.pm' -print0 | xargs -0 -n1 perl -I lib -cw`.
+- Without this, no gate in the project compiles the renamed tree end to end.
+
+### 1.7 Build, install, and CI
 
 - `Makefile`: `install` makes `$(LIBDIR)/FuguLib` and copies `lib/FuguLib/*.pm`
   into it. `package` makes and fills the same directory. `uninstall` removes it.
   All three change to `Fugu`.
-- `scripts/integration`: the tarball carries `t/fugulib/sandbox.t`, and the
-  comment above it names the path. Both change.
+- `scripts/integration` names the path four times: the comment at line 22, the
+  `tar czf` at line 27, the comment at line 67, and the `TESTS` variable at
+  line 69. Miss line 69 and the OpenBSD-only pledge and unveil subtests stop
+  running, because the no-`prove` fallback at line 75 skips a missing file
+  without a word.
+- `scripts/vm-provision` runs `make uninstall` from the new checkout, which no
+  longer names `$(LIBDIR)/FuguLib`. Add a purge of the retired path to the
+  provisioning step, before `make install`. Without it, a warm guest disk keeps
+  the old modules in `@INC`, and a missed rename still resolves there, so
+  `make integration` passes against a shim that the environment supplies.
 - `.github/workflows/integration.yml`: `lib/FuguLib/*.pm` and
   `t/fugulib/sandbox.t` appear in the push list and in the pull-request list.
   Change all four lines.
-- `check.yml` matches `lib/**.pm` and `t/**`, so it needs no change. Confirm
-  this rather than assume it.
+- `check.yml` matches `lib/**.pm` and `t/**`, so its filters need no change.
 
-### 1.6 Move the website page
+### 1.8 Move the website page
 
 - `git mv web/fugulib.body.html web/fugu.body.html`. Rewrite the heading, the 21
   `<dt>` module names, the body text, and the `manuals.html#fugulib` anchor.
+- `web/mkindex.sh:148` is
+  `emit_group 'FuguLib' fugulib man/fugulib/ 'FuguLib::' "$@"`. It is the only
+  source of both the 3p entries and the `id="fugulib"` anchor, and `emit_group`
+  emits nothing when its path prefix matches nothing. Miss this line and all 21
+  index entries and the anchor disappear. Line 91 names the page format in a
+  comment.
+- `web/head.html:16` links `fugulib.html` in the navigation that `mkpage.sh`
+  stamps on every page.
 - `Makefile`: the `web` target builds `$(WEBOUT)/fugulib.html` with the title
-  `FuguLib`. Both change.
+  `FuguLib`.
 - `web/index.body.html`: the link text and the target file name.
-- `t/web/site.t`: the `$dir eq 'fugulib'` test, the `"FuguLib::$stem"` name, the
-  `FuguLib::Daemon.3p.html` and `FuguLib::Pidfile.3p.html` assertions, and the
-  comments that explain them.
+- `web/CLAUDE.md:60-64`: four mentions that explain the staging rename.
+- `t/web/site.t`: `@SITE` at line 44, `@NAV` at line 56, the `$dir eq 'fugulib'`
+  test at line 68, the `"FuguLib::$stem"` name at line 71, and the
+  `FuguLib::Daemon` and `FuguLib::Pidfile` assertions at lines 223 to 225.
+- `t/web/site.t` skips without `lowdown` and `mandoc`, which `make deps-test`
+  does not install. Run `make deps-develop` and `make web` in this phase, and
+  confirm the suite runs rather than skips.
 
-### 1.7 Update the project documentation
+### 1.9 Update the project documentation
 
 - Root `CLAUDE.md`: the namespace list in the introduction, the `lib/FuguLib/`
   and `man/fugulib/` rows in Layout, and row 2 of the documentation table.
-- `README.md`, `INSTALL.md`, and `TODO.md`: every mention.
+- `TODO.md`: every mention, in both the `FuguLib::` and the `lib/FuguLib/`
+  forms.
+- `README.md` and `INSTALL.md` hold no occurrence of `FuguLib`. Confirm that,
+  and change nothing.
 - Do not touch `plans/001` to `plans/007`.
 
 ## Deliverables
 
 - `lib/Fugu/` with 21 modules, `man/fugu/` with 21 3p pages, `t/fugu/` with 22
   test files, and `t/lib/Fugu/TestLog.pm`.
-- `web/fugu.body.html`, and an updated `web/index.body.html`.
-- Updated `Makefile`, `scripts/integration`,
-  `.github/workflows/integration.yml`, root `CLAUDE.md`, `t/CLAUDE.md`,
-  `README.md`, `INSTALL.md`, `TODO.md`, `t/web/site.t`, `t/protocol/boundary.t`.
+- `t/scripts/namespaces.t`, the new clean-break gate.
+- `web/fugu.body.html`, and updated `web/head.html`, `web/mkindex.sh`,
+  `web/index.body.html`, and `web/CLAUDE.md`.
+- Updated `Makefile`, `scripts/integration`, `scripts/vm-provision`,
+  `.github/workflows/check.yml`, `.github/workflows/integration.yml`, root
+  `CLAUDE.md`, `t/CLAUDE.md`, `TODO.md`, `t/web/site.t`,
+  `t/protocol/boundary.t`.
 
 ## Acceptance criteria
 
-- `make check` passes.
-- `grep -rn 'FuguLib\|fugulib' --exclude-dir=.git --exclude-dir=plans .` finds
-  nothing.
+- `make check` passes, and so do `make prettier`, `make web`, and
+  `mandoc -Tlint -W warning` over `man/fugu/`.
+- `t/scripts/namespaces.t` passes, and fails correctly on a planted
+  `use FuguLib::Log;` and on a planted `lib/FuguLib/Log.pm` that carries
+  `our @ISA = ('Fugu::Log');`. Prove both failure modes once by hand.
+- `t/web/site.t` runs rather than skips, and passes.
 - `make install DESTDIR=...` into an empty directory installs
   `$(LIBDIR)/Fugu/*.pm` and `man3p/Fugu::Daemon.3p`, and no `FuguLib` path.
-- `make web` builds `fugu.html`, and `t/web/site.t` passes.
 - `make spec-coverage` reports no stale citations.
-- No file in `lib/`, `bin/`, `t/`, or `man/` defines or names a `FuguLib`
-  package. This phase adds no alias and no compatibility module.
+- `make integration` passes on a guest that was purged of the old install.

--- a/plans/008-cpan-namespaces/plan-1.md
+++ b/plans/008-cpan-namespaces/plan-1.md
@@ -1,0 +1,106 @@
+# Phase 1 — FuguLib becomes Fugu
+
+This phase renames one namespace and nothing else. It touches more files than
+the other four phases together, so it stays mechanical on purpose: no module
+splits, no API changes, and no moved functions. A reviewer must be able to check
+it with a grep.
+
+The product keeps its name in prose only where the prose means the collection of
+daemon utilities. That collection is now called Fugu, so the website body, the
+manual titles, and the `CLAUDE.md` text change with the packages.
+
+## Tasks
+
+### 1.1 Move the modules
+
+- `git mv lib/FuguLib lib/Fugu`. Rename the package statement in each of the 21
+  modules.
+- Rename the three nested packages: `FuguLib::Control::Client`,
+  `FuguLib::Proxy::Cache`, and `FuguLib::Proxy::Meta`.
+- Rewrite every `use` and `require` line, every fully qualified call such as
+  `FuguLib::Util::bounded`, and every mention in a code comment.
+
+### 1.2 Retarget the callers
+
+- `bin/openhapd` and `bin/hapctl`: nine and five import lines.
+- `lib/OpenHAP/`: `Server.pm`, `Storage.pm`, `DeviceLoader.pm`, `Tasmota/*.pm`,
+  `Test/Integration.pm`, and the `.pod` sidecars.
+- `lib/FuguVM/`: every module and every `.pod` sidecar.
+- `lib/Protocol/` must not match. If it does, `t/protocol/boundary.t` is broken,
+  not the code.
+
+### 1.3 Move the manuals
+
+- `git mv man/fugulib man/fugu`. Rewrite the `.Nm` name, the `.Xr`
+  cross-references, and the body text of all 21 pages.
+- `Makefile`: the `MAN3P` list, the comment above it, the `install-man` rename
+  loop, the `uninstall` rename loop, and the `web` staging loop all use the
+  literal `FuguLib::`. Each becomes `Fugu::`.
+- The `package` target makes and fills `build/$(PACKAGE)/man/fugulib/`. That
+  staging directory becomes `man/fugu/`.
+- A page installs as `Fugu::Daemon.3p`, so `man Fugu::Daemon` finds it.
+
+### 1.4 Move the tests
+
+- `git mv t/fugulib t/fugu`. Retarget the imports in all 22 files.
+- `git mv t/lib/FuguLib t/lib/Fugu`, and rename the `FuguLib::TestLog` package.
+  Retarget every test that loads it.
+- `t/fugu/coreperl.t` scans `lib/FuguLib` and builds `require FuguLib::$module`
+  strings. Both change.
+- `t/protocol/boundary.t`: direction two scans `$ROOT/lib/FuguLib` and matches
+  `^(?:FuguLib|FuguVM|OpenHAP)\b`. Change the path, the pattern, and the subtest
+  names.
+- `Makefile`: the `test` target names `t/fugulib`.
+- `t/CLAUDE.md`: the tier table row and the sandbox paragraph.
+
+### 1.5 Build, install, and CI
+
+- `Makefile`: `install` makes `$(LIBDIR)/FuguLib` and copies `lib/FuguLib/*.pm`
+  into it. `package` makes and fills the same directory. `uninstall` removes it.
+  All three change to `Fugu`.
+- `scripts/integration`: the tarball carries `t/fugulib/sandbox.t`, and the
+  comment above it names the path. Both change.
+- `.github/workflows/integration.yml`: `lib/FuguLib/*.pm` and
+  `t/fugulib/sandbox.t` appear in the push list and in the pull-request list.
+  Change all four lines.
+- `check.yml` matches `lib/**.pm` and `t/**`, so it needs no change. Confirm
+  this rather than assume it.
+
+### 1.6 Move the website page
+
+- `git mv web/fugulib.body.html web/fugu.body.html`. Rewrite the heading, the 21
+  `<dt>` module names, the body text, and the `manuals.html#fugulib` anchor.
+- `Makefile`: the `web` target builds `$(WEBOUT)/fugulib.html` with the title
+  `FuguLib`. Both change.
+- `web/index.body.html`: the link text and the target file name.
+- `t/web/site.t`: the `$dir eq 'fugulib'` test, the `"FuguLib::$stem"` name, the
+  `FuguLib::Daemon.3p.html` and `FuguLib::Pidfile.3p.html` assertions, and the
+  comments that explain them.
+
+### 1.7 Update the project documentation
+
+- Root `CLAUDE.md`: the namespace list in the introduction, the `lib/FuguLib/`
+  and `man/fugulib/` rows in Layout, and row 2 of the documentation table.
+- `README.md`, `INSTALL.md`, and `TODO.md`: every mention.
+- Do not touch `plans/001` to `plans/007`.
+
+## Deliverables
+
+- `lib/Fugu/` with 21 modules, `man/fugu/` with 21 3p pages, `t/fugu/` with 22
+  test files, and `t/lib/Fugu/TestLog.pm`.
+- `web/fugu.body.html`, and an updated `web/index.body.html`.
+- Updated `Makefile`, `scripts/integration`,
+  `.github/workflows/integration.yml`, root `CLAUDE.md`, `t/CLAUDE.md`,
+  `README.md`, `INSTALL.md`, `TODO.md`, `t/web/site.t`, `t/protocol/boundary.t`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `grep -rn 'FuguLib\|fugulib' --exclude-dir=.git --exclude-dir=plans .` finds
+  nothing.
+- `make install DESTDIR=...` into an empty directory installs
+  `$(LIBDIR)/Fugu/*.pm` and `man3p/Fugu::Daemon.3p`, and no `FuguLib` path.
+- `make web` builds `fugu.html`, and `t/web/site.t` passes.
+- `make spec-coverage` reports no stale citations.
+- No file in `lib/`, `bin/`, `t/`, or `man/` defines or names a `FuguLib`
+  package. This phase adds no alias and no compatibility module.

--- a/plans/008-cpan-namespaces/plan-2.md
+++ b/plans/008-cpan-namespaces/plan-2.md
@@ -1,0 +1,127 @@
+# Phase 2 — OpenHAP becomes App::OpenHAP
+
+This phase moves the daemon into `App::`, and gives three modules a name that
+says what they do. The product is still called OpenHAP, and the daemon is still
+`openhapd`. Prose that names the product does not change. Package names, file
+paths, and test names do.
+
+The phase depends on phase 1: the modules import `Fugu::` names.
+
+## Tasks
+
+### 2.1 Move the namespace
+
+- `mkdir lib/App`, then `git mv lib/OpenHAP lib/App/OpenHAP`. Rename the package
+  statement in each module, and in each `.pod` sidecar `=head1 NAME` line.
+- Rewrite every `use`, `require`, and fully qualified call.
+- `App::OpenHAP::Tasmota::*` and `App::OpenHAP::Test::Integration` keep their
+  leaf names.
+
+### 2.2 OpenHAP::Server becomes App::OpenHAP::Host
+
+- `git mv lib/App/OpenHAP/Server.pm lib/App/OpenHAP/Host.pm`, and the `.pod`
+  with it.
+- The name states the job: the module hosts `Protocol::HAP::Server`. Two modules
+  in one tree must not both be `Server`.
+- Rewrite the sidecar abstract:
+  `App::OpenHAP::Host - the host of the Protocol::HAP engine`.
+- Users: `bin/openhapd`, `t/openhap/server.t`, and the comments in
+  `t/protocol/server.t`.
+
+### 2.3 OpenHAP::Storage becomes App::OpenHAP::Store::File
+
+- `mkdir lib/App/OpenHAP/Store`, then `git mv` the module and its sidecar into
+  it as `File.pm` and `File.pod`.
+- The name states the contract and the medium. The module implements
+  `Protocol::HAP::Store` in a file, and it pairs with
+  `Protocol::HAP::Store::Memory`.
+- The twelve contract methods do not change. This is a rename, not a rewrite.
+- Users: `bin/openhapd` and `t/openhap/storage.t`.
+
+### 2.4 OpenHAP::DeviceLoader becomes App::OpenHAP::Devices
+
+- `git mv` the module and its sidecar. `Loader` names a mechanism; the module
+  holds the configured devices.
+- Users: `bin/openhapd`, `bin/hapctl`, and `t/openhap/device-loading.t`.
+
+### 2.5 Write the two missing sidecars
+
+- `lib/App/OpenHAP/Tasmota/Base.pod` and `Lightbulb.pod` do not exist. The
+  documentation rule in the root `CLAUDE.md` requires a sidecar for every module
+  outside `lib/Fugu/`.
+- `Base.pod` documents the constructor arguments, the MQTT topic contract, and
+  the methods that a subclass overrides. `Lightbulb.pod` documents the
+  capability flags and the brightness and color characteristics.
+- This phase already rewrites the header of both files, so the cost is the
+  documentation alone.
+
+### 2.6 Retarget the callers
+
+- `bin/openhapd`: `use OpenHAP::DeviceLoader` and `use OpenHAP::Server` become
+  `App::OpenHAP::Devices` and `App::OpenHAP::Host`. The `Storage` constructor
+  call becomes `App::OpenHAP::Store::File`.
+- `bin/hapctl`: one import line.
+
+### 2.7 Move and retarget the tests
+
+- `git mv t/openhap/server.t t/openhap/host.t` and
+  `git mv t/openhap/storage.t t/openhap/store-file.t`. The tier directory keeps
+  its name: it is named after the product, not the namespace.
+- `t/openhap/device-loading.t` and `t/openhap/tasmota.t` keep their names.
+- `mkdir -p t/lib/App`, then `git mv t/lib/OpenHAP t/lib/App/OpenHAP`, and
+  rename the `OpenHAP::TestMock::MQTT` package. Retarget the four
+  `t/conformance/mqtt-*.t` files that load it.
+- Retarget the six `t/conformance/hap-*.t` files and the 17 files under
+  `t/openhap/integration/` that name an `OpenHAP::` module.
+- `t/protocol/boundary.t` matches `^(?:Fugu|FuguVM|OpenHAP)\b` after phase 1.
+  The pattern becomes `^(?:Fugu|FuguVM|App)\b`. `FuguVM` needs its own
+  alternative until phase 3, because `^Fugu\b` does not match `FuguVM`.
+- `t/CLAUDE.md`: the `OpenHAP::TestMock::MQTT` example in the conformance
+  section.
+
+### 2.8 Build, install, and CI
+
+- `Makefile`: `install`, `package`, and `uninstall` name `$(LIBDIR)/OpenHAP`,
+  `/OpenHAP/Tasmota`, and `/OpenHAP/Test`. Each gains the `App/` level, and
+  `install -d $(DESTDIR)$(LIBDIR)/App` comes first. The `Store/` subdirectory
+  needs the same treatment as `Protocol/HAP/Store/`: a directory rule and a copy
+  rule.
+- `scripts/integration`: the tarball carries `lib/OpenHAP/Test/`, and the guest
+  copy targets `site_perl/OpenHAP/`. Both become the `App/OpenHAP` path, and the
+  copy needs `mkdir -p` for the new parent.
+- `.github/workflows/integration.yml`: `lib/OpenHAP/**.pm` becomes
+  `lib/App/OpenHAP/**.pm`, in the push list and the pull-request list.
+
+### 2.9 Update the documentation
+
+- Root `CLAUDE.md`: the namespace list, the `lib/OpenHAP/` row in Layout, and
+  the module names in it.
+- `t/web/site.t`: the `^(?:OpenHAP|FuguVM|Protocol)::` match that finds module
+  manual pages. `App::OpenHAP::Host.3p.html` must match after this phase.
+- `README.md`, `INSTALL.md`, `TODO.md`, `web/index.body.html`, and
+  `t/openhap/integration/CLAUDE.md`: every mention of an `OpenHAP::` module.
+  Mentions of the product OpenHAP stay as they are.
+
+## Deliverables
+
+- `lib/App/OpenHAP/` with `Host.pm`, `Devices.pm`, `Store/File.pm`,
+  `Tasmota/*.pm`, and `Test/Integration.pm`, each with a `.pod` sidecar.
+- `t/openhap/host.t`, `t/openhap/store-file.t`, and
+  `t/lib/App/OpenHAP/TestMock/MQTT.pm`.
+- Updated `Makefile`, `scripts/integration`,
+  `.github/workflows/integration.yml`, `bin/openhapd`, `bin/hapctl`,
+  `t/protocol/boundary.t`, `t/web/site.t`, and the documentation files.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `grep -rn 'OpenHAP::' --exclude-dir=.git --exclude-dir=plans . | grep -v 'App::OpenHAP::'`
+  finds nothing.
+- `grep -rn 'OpenHAP::Server\|OpenHAP::Storage\|OpenHAP::DeviceLoader' --exclude-dir=.git --exclude-dir=plans .`
+  finds nothing.
+- `make install DESTDIR=...` into an empty directory installs
+  `$(LIBDIR)/App/OpenHAP/Store/File.pm`, and no `$(LIBDIR)/OpenHAP` path.
+- Every `.pm` under `lib/App/OpenHAP/` has a `.pod` beside it.
+- `make integration` passes, or its failure is unrelated to this phase and is
+  recorded.
+- No alias, no `@ISA` bridge, and no compatibility module carries an old name.

--- a/plans/008-cpan-namespaces/plan-2.md
+++ b/plans/008-cpan-namespaces/plan-2.md
@@ -1,6 +1,6 @@
 # Phase 2 — OpenHAP becomes App::OpenHAP
 
-This phase moves the daemon into `App::`, and gives three modules a name that
+This phase moves the daemon into `App::`, and gives four modules a name that
 says what they do. The product is still called OpenHAP, and the daemon is still
 `openhapd`.
 
@@ -13,8 +13,8 @@ The phase depends on phase 1. Phase 3 depends on this one.
 - `mkdir lib/App`, then `git mv lib/OpenHAP lib/App/OpenHAP`. Rename the package
   statement in each module, and the `=head1 NAME` line of each `.pod` sidecar.
 - Rewrite every `use`, `require`, and fully qualified call.
-- `App::OpenHAP::Tasmota::*` and `App::OpenHAP::Test::Integration` keep their
-  leaf names.
+- `App::OpenHAP::Test::Integration` and the four device classes keep their leaf
+  names. `Tasmota::Base` does not: task 2.5 renames it.
 
 ### 2.2 OpenHAP::Server becomes App::OpenHAP::Host
 
@@ -44,18 +44,27 @@ The phase depends on phase 1. Phase 3 depends on this one.
   holds the configured devices.
 - Users: `bin/openhapd`, `bin/hapctl`, and `t/openhap/device-loading.t`.
 
-### 2.5 Write the two missing sidecars
+### 2.5 OpenHAP::Tasmota::Base becomes App::OpenHAP::Tasmota::Device
 
-- `lib/App/OpenHAP/Tasmota/Base.pod` and `Lightbulb.pod` do not exist. The
+- `git mv lib/App/OpenHAP/Tasmota/Base.pm lib/App/OpenHAP/Tasmota/Device.pm`.
+- `Base` names a role in the code, as `Loader` did. The class is a Tasmota
+  device that is also a `Protocol::HAP::Accessory`: it owns the MQTT
+  subscription, the availability state, and the power helpers.
+- Users: the four device classes that inherit from it, `App::OpenHAP::Devices`,
+  and `t/openhap/tasmota.t`.
+
+### 2.6 Write the two missing sidecars
+
+- `Tasmota/Device.pod` and `Tasmota/Lightbulb.pod` do not exist. The
   documentation rule in the root `CLAUDE.md` requires a sidecar for every module
   outside `lib/Fugu/`.
-- `Base.pod` documents the constructor arguments, the MQTT topic contract, and
+- `Device.pod` documents the constructor arguments, the MQTT topic contract, and
   the methods that a subclass overrides. `Lightbulb.pod` documents the
   capability flags and the brightness and color characteristics.
 - The two new sidecars change the sidecar count that `t/web/site.t` asserts at
-  line 206. Task 2.9 handles the regex on the other side of that assertion.
+  line 206. Task 2.10 handles the regex on the other side of that assertion.
 
-### 2.6 Retarget the callers
+### 2.7 Retarget the callers
 
 - `bin/openhapd`: the `use OpenHAP::DeviceLoader` and `use OpenHAP::Server`
   lines, and the `Storage` constructor call.
@@ -69,7 +78,7 @@ The phase depends on phase 1. Phase 3 depends on this one.
   sandbox. Change the probe to `"$script_lib/App/OpenHAP"`.
 - `bin/hapctl`: one import line.
 
-### 2.7 Move and retarget the tests
+### 2.8 Move and retarget the tests
 
 - `git mv t/openhap/server.t t/openhap/host.t` and
   `git mv t/openhap/storage.t t/openhap/store-file.t`. The tier directory keeps
@@ -89,11 +98,11 @@ The phase depends on phase 1. Phase 3 depends on this one.
     enforced, and no acceptance grep can see it: the literal text is `OpenHAP)`,
     with no trailing colons.
 - Add the retired names to `t/scripts/namespaces.t`: `OpenHAP::`,
-  `OpenHAP::Server`, `OpenHAP::Storage`, `OpenHAP::DeviceLoader`, and the path
-  form `lib/OpenHAP/`.
+  `OpenHAP::Server`, `OpenHAP::Storage`, `OpenHAP::DeviceLoader`,
+  `OpenHAP::Tasmota::Base`, and the path form `lib/OpenHAP/`.
 - `t/CLAUDE.md`: the `OpenHAP::TestMock::MQTT` example.
 
-### 2.8 Build, install, and CI
+### 2.9 Build, install, and CI
 
 - `Makefile`: `install`, `package`, and `uninstall` name `$(LIBDIR)/OpenHAP`,
   `/OpenHAP/Tasmota`, and `/OpenHAP/Test`. Each gains the `App/` level, and
@@ -113,7 +122,7 @@ The phase depends on phase 1. Phase 3 depends on this one.
 - `.github/workflows/integration.yml`: `lib/OpenHAP/**.pm` becomes
   `lib/App/OpenHAP/**.pm`, in the push list and the pull-request list.
 
-### 2.9 Update the website and the manuals
+### 2.10 Update the website and the manuals
 
 - `web/mkindex.sh:149` is
   `emit_group 'OpenHAP modules' modules lib/OpenHAP/ '' "$@"`. The prefix stops
@@ -131,7 +140,7 @@ The phase depends on phase 1. Phase 3 depends on this one.
   `Devices` sets that field to the package name, so the daemon's output changes
   with the rename. Update the manual.
 
-### 2.10 Update the project documentation
+### 2.11 Update the project documentation
 
 - Root `CLAUDE.md`: the namespace list, and the `lib/OpenHAP/` row in Layout.
 - `TODO.md` holds 18 references in the path form `lib/OpenHAP/...`. A grep for
@@ -141,7 +150,8 @@ The phase depends on phase 1. Phase 3 depends on this one.
 ## Deliverables
 
 - `lib/App/OpenHAP/` with `Host.pm`, `Devices.pm`, `Store/File.pm`,
-  `Tasmota/*.pm`, and `Test/Integration.pm`, each with a `.pod` sidecar.
+  `Tasmota/Device.pm`, the four device classes, and `Test/Integration.pm`, each
+  with a `.pod` sidecar.
 - `t/openhap/host.t`, `t/openhap/store-file.t`, and
   `t/lib/App/OpenHAP/TestMock/MQTT.pm`.
 - Updated `Makefile`, `scripts/integration`, `scripts/vm-provision`,

--- a/plans/008-cpan-namespaces/plan-2.md
+++ b/plans/008-cpan-namespaces/plan-2.md
@@ -2,17 +2,16 @@
 
 This phase moves the daemon into `App::`, and gives three modules a name that
 says what they do. The product is still called OpenHAP, and the daemon is still
-`openhapd`. Prose that names the product does not change. Package names, file
-paths, and test names do.
+`openhapd`.
 
-The phase depends on phase 1: the modules import `Fugu::` names.
+The phase depends on phase 1. Phase 3 depends on this one.
 
 ## Tasks
 
 ### 2.1 Move the namespace
 
 - `mkdir lib/App`, then `git mv lib/OpenHAP lib/App/OpenHAP`. Rename the package
-  statement in each module, and in each `.pod` sidecar `=head1 NAME` line.
+  statement in each module, and the `=head1 NAME` line of each `.pod` sidecar.
 - Rewrite every `use`, `require`, and fully qualified call.
 - `App::OpenHAP::Tasmota::*` and `App::OpenHAP::Test::Integration` keep their
   leaf names.
@@ -23,8 +22,6 @@ The phase depends on phase 1: the modules import `Fugu::` names.
   with it.
 - The name states the job: the module hosts `Protocol::HAP::Server`. Two modules
   in one tree must not both be `Server`.
-- Rewrite the sidecar abstract:
-  `App::OpenHAP::Host - the host of the Protocol::HAP engine`.
 - Users: `bin/openhapd`, `t/openhap/server.t`, and the comments in
   `t/protocol/server.t`.
 
@@ -32,11 +29,14 @@ The phase depends on phase 1: the modules import `Fugu::` names.
 
 - `mkdir lib/App/OpenHAP/Store`, then `git mv` the module and its sidecar into
   it as `File.pm` and `File.pod`.
-- The name states the contract and the medium. The module implements
-  `Protocol::HAP::Store` in a file, and it pairs with
-  `Protocol::HAP::Store::Memory`.
+- The name states the contract and the medium. The module cannot live in
+  `Protocol::HAP::Store::File`, because it uses `Fugu::File` and the layering
+  rules forbid that direction. Say so in the sidecar.
 - The twelve contract methods do not change. This is a rename, not a rewrite.
 - Users: `bin/openhapd` and `t/openhap/storage.t`.
+- `lib/Protocol/HAP/Store.pod:11` names `OpenHAP::Storage` in prose. It is a
+  shipped `.pod` that `make web` publishes, and `t/protocol/boundary.t` reads
+  `.pm` files only, so nothing else catches it.
 
 ### 2.4 OpenHAP::DeviceLoader becomes App::OpenHAP::Devices
 
@@ -52,14 +52,21 @@ The phase depends on phase 1: the modules import `Fugu::` names.
 - `Base.pod` documents the constructor arguments, the MQTT topic contract, and
   the methods that a subclass overrides. `Lightbulb.pod` documents the
   capability flags and the brightness and color characteristics.
-- This phase already rewrites the header of both files, so the cost is the
-  documentation alone.
+- The two new sidecars change the sidecar count that `t/web/site.t` asserts at
+  line 206. Task 2.9 handles the regex on the other side of that assertion.
 
 ### 2.6 Retarget the callers
 
-- `bin/openhapd`: `use OpenHAP::DeviceLoader` and `use OpenHAP::Server` become
-  `App::OpenHAP::Devices` and `App::OpenHAP::Host`. The `Storage` constructor
-  call becomes `App::OpenHAP::Store::File`.
+- `bin/openhapd`: the `use OpenHAP::DeviceLoader` and `use OpenHAP::Server`
+  lines, and the `Storage` constructor call.
+- `bin/openhapd:380` is
+  `push @perl_dirs, $script_lib if -d "$script_lib/OpenHAP";`. This is a
+  filesystem probe on a directory name, not a package name, so no grep for
+  `OpenHAP::` finds it. After the move the test is false forever, the checkout's
+  `lib/` never joins the unveil list, and a daemon started from a checkout loses
+  read access to its own modules under pledge. The lazy
+  `require Net::MQTT::Simple` on the MQTT reconnect path then dies inside the
+  sandbox. Change the probe to `"$script_lib/App/OpenHAP"`.
 - `bin/hapctl`: one import line.
 
 ### 2.7 Move and retarget the tests
@@ -67,40 +74,69 @@ The phase depends on phase 1: the modules import `Fugu::` names.
 - `git mv t/openhap/server.t t/openhap/host.t` and
   `git mv t/openhap/storage.t t/openhap/store-file.t`. The tier directory keeps
   its name: it is named after the product, not the namespace.
-- `t/openhap/device-loading.t` and `t/openhap/tasmota.t` keep their names.
 - `mkdir -p t/lib/App`, then `git mv t/lib/OpenHAP t/lib/App/OpenHAP`, and
   rename the `OpenHAP::TestMock::MQTT` package. Retarget the four
   `t/conformance/mqtt-*.t` files that load it.
 - Retarget the six `t/conformance/hap-*.t` files and the 17 files under
   `t/openhap/integration/` that name an `OpenHAP::` module.
-- `t/protocol/boundary.t` matches `^(?:Fugu|FuguVM|OpenHAP)\b` after phase 1.
-  The pattern becomes `^(?:Fugu|FuguVM|App)\b`. `FuguVM` needs its own
-  alternative until phase 3, because `^Fugu\b` does not match `FuguVM`.
-- `t/CLAUDE.md`: the `OpenHAP::TestMock::MQTT` example in the conformance
-  section.
+- `t/protocol/boundary.t` needs both patterns changed in this phase:
+  - Direction one, line 73, is `^(?:Fugu|FuguVM|OpenHAP)\b` after phase 1. It
+    becomes `^(?:Fugu|FuguVM|App)\b`. `FuguVM` needs its own alternative until
+    phase 3, because `^Fugu\b` does not match `FuguVM`.
+  - Direction two, line 104, is `^(?:Protocol::HAP|OpenHAP)\b`. It becomes
+    `^(?:Protocol::HAP|App)\b`, and the subtest name at line 93 follows. Without
+    this the design's rule that `Fugu::` never uses `App::` stops being
+    enforced, and no acceptance grep can see it: the literal text is `OpenHAP)`,
+    with no trailing colons.
+- Add the retired names to `t/scripts/namespaces.t`: `OpenHAP::`,
+  `OpenHAP::Server`, `OpenHAP::Storage`, `OpenHAP::DeviceLoader`, and the path
+  form `lib/OpenHAP/`.
+- `t/CLAUDE.md`: the `OpenHAP::TestMock::MQTT` example.
 
 ### 2.8 Build, install, and CI
 
 - `Makefile`: `install`, `package`, and `uninstall` name `$(LIBDIR)/OpenHAP`,
   `/OpenHAP/Tasmota`, and `/OpenHAP/Test`. Each gains the `App/` level, and
   `install -d $(DESTDIR)$(LIBDIR)/App` comes first. The `Store/` subdirectory
-  needs the same treatment as `Protocol/HAP/Store/`: a directory rule and a copy
-  rule.
+  needs a directory rule and a copy rule.
+- `uninstall` must not do `rm -rf $(DESTDIR)$(LIBDIR)/App`. `App/` is a shared
+  parent that holds other distributions, such as `App::cpanminus`. Remove
+  `App/OpenHAP` and then `rmdir` the parent, which fails harmlessly when the
+  parent is not empty. Fix the same fault on the line above it:
+  `rm -rf $(LIBDIR)/Protocol` deletes every other `Protocol::` distribution on
+  the machine today.
 - `scripts/integration`: the tarball carries `lib/OpenHAP/Test/`, and the guest
   copy targets `site_perl/OpenHAP/`. Both become the `App/OpenHAP` path, and the
   copy needs `mkdir -p` for the new parent.
+- `scripts/vm-provision`: purge `site_perl/OpenHAP` on the guest before
+  `make install`, for the reason phase 1 gives.
 - `.github/workflows/integration.yml`: `lib/OpenHAP/**.pm` becomes
   `lib/App/OpenHAP/**.pm`, in the push list and the pull-request list.
 
-### 2.9 Update the documentation
+### 2.9 Update the website and the manuals
 
-- Root `CLAUDE.md`: the namespace list, the `lib/OpenHAP/` row in Layout, and
-  the module names in it.
-- `t/web/site.t`: the `^(?:OpenHAP|FuguVM|Protocol)::` match that finds module
-  manual pages. `App::OpenHAP::Host.3p.html` must match after this phase.
-- `README.md`, `INSTALL.md`, `TODO.md`, `web/index.body.html`, and
-  `t/openhap/integration/CLAUDE.md`: every mention of an `OpenHAP::` module.
-  Mentions of the product OpenHAP stay as they are.
+- `web/mkindex.sh:149` is
+  `emit_group 'OpenHAP modules' modules lib/OpenHAP/ '' "$@"`. The prefix stops
+  matching, and `emit_group` emits nothing when nothing matches, so the whole
+  group and its `id="modules"` anchor vanish from `manuals.html`.
+  `web/index.body.html` links `manuals.html#modules`, and `t/web/site.t`
+  requires that anchor to resolve. Line 60 names the path in a comment.
+- `t/web/site.t:203` matches `^(?:OpenHAP|FuguVM|Protocol)::` and asserts one
+  page per sidecar at line 206. This phase sets it to
+  `^(?:App|FuguVM|Protocol)::`. `FuguVM` must stay until phase 3, because 11
+  FuguVM sidecars are still in the tree. Line 97 also names `lib/OpenHAP` in an
+  assertion description.
+- `man/openhap/hapctl.8:170` prints `Class: OpenHAP::Tasmota::Thermostat` in a
+  sample session. `bin/hapctl:182` prints `$device->{class}` verbatim, and
+  `Devices` sets that field to the package name, so the daemon's output changes
+  with the rename. Update the manual.
+
+### 2.10 Update the project documentation
+
+- Root `CLAUDE.md`: the namespace list, and the `lib/OpenHAP/` row in Layout.
+- `TODO.md` holds 18 references in the path form `lib/OpenHAP/...`. A grep for
+  `OpenHAP::` does not match them.
+- `t/openhap/integration/CLAUDE.md`: the module names in the rules.
 
 ## Deliverables
 
@@ -108,20 +144,25 @@ The phase depends on phase 1: the modules import `Fugu::` names.
   `Tasmota/*.pm`, and `Test/Integration.pm`, each with a `.pod` sidecar.
 - `t/openhap/host.t`, `t/openhap/store-file.t`, and
   `t/lib/App/OpenHAP/TestMock/MQTT.pm`.
-- Updated `Makefile`, `scripts/integration`,
+- Updated `Makefile`, `scripts/integration`, `scripts/vm-provision`,
   `.github/workflows/integration.yml`, `bin/openhapd`, `bin/hapctl`,
-  `t/protocol/boundary.t`, `t/web/site.t`, and the documentation files.
+  `t/protocol/boundary.t`, `t/scripts/namespaces.t`, `t/web/site.t`,
+  `web/mkindex.sh`, `man/openhap/hapctl.8`, `lib/Protocol/HAP/Store.pod`, and
+  the documentation files.
 
 ## Acceptance criteria
 
-- `make check` passes.
-- `grep -rn 'OpenHAP::' --exclude-dir=.git --exclude-dir=plans . | grep -v 'App::OpenHAP::'`
-  finds nothing.
-- `grep -rn 'OpenHAP::Server\|OpenHAP::Storage\|OpenHAP::DeviceLoader' --exclude-dir=.git --exclude-dir=plans .`
-  finds nothing.
+- `make check` passes, and so do `make prettier` and `make web`.
+- `t/scripts/namespaces.t` passes with the new retired names, and fails
+  correctly on a planted `OpenHAP::Server` in a `.pod` line that also names a
+  live module.
+- `t/protocol/boundary.t` fails correctly on a planted `use App::OpenHAP::Host;`
+  inside `lib/Fugu/`. Prove it once by hand.
 - `make install DESTDIR=...` into an empty directory installs
   `$(LIBDIR)/App/OpenHAP/Store/File.pm`, and no `$(LIBDIR)/OpenHAP` path.
+- `make uninstall DESTDIR=...` against a directory that also holds
+  `$(LIBDIR)/App/Other.pm` and `$(LIBDIR)/Protocol/Other.pm` leaves both files
+  in place.
 - Every `.pm` under `lib/App/OpenHAP/` has a `.pod` beside it.
-- `make integration` passes, or its failure is unrelated to this phase and is
-  recorded.
-- No alias, no `@ISA` bridge, and no compatibility module carries an old name.
+- `make integration` passes on a guest that was purged of the old install, and
+  the unveil path list in `bin/openhapd` covers the checkout `lib/`.

--- a/plans/008-cpan-namespaces/plan-3.md
+++ b/plans/008-cpan-namespaces/plan-3.md
@@ -3,10 +3,11 @@
 This phase moves the VM utility into `App::`, and renames the two modules that
 name a mechanism instead of a feature. The command is still `fuguvm`, the
 configuration file is still `.fuguvmrc`, and the data files stay under
-`share/fuguvm/`. Only Perl package names and file paths change.
+`share/fuguvm/`.
 
-The phase depends on phase 1. It does not depend on phase 2, and the two can
-land in either order.
+The phase depends on phase 2. Both phases edit the same regex in
+`t/web/site.t:203` and in `t/protocol/boundary.t:73`, and the phase-2 state must
+keep the `FuguVM` alternative in each. Phase 3 removes it.
 
 ## Tasks
 
@@ -17,38 +18,52 @@ land in either order.
   `=head1 NAME` line of each `.pod` sidecar.
 - Rewrite every `use`, `require`, and fully qualified call.
 - `bin/fuguvm` loads one module. Change that line.
+- `lib/FuguVM/Image.pm:73` explains that the file "is two directories below the
+  project root". After the move it is three. The code is safe, because
+  `share_path` derives the root from `Fugu::File`'s own `__FILE__`, but the
+  comment is wrong.
 
 ### 3.2 FuguVM::VM becomes App::FuguVM::Guest
 
 - `git mv lib/App/FuguVM/VM.pm lib/App/FuguVM/Guest.pm`, and the `.pod` with it.
 - `FuguVM::VM` repeats its parent. The module is the lifecycle of one OpenBSD
-  guest, and `Guest` says that.
+  guest.
 - The private methods keep their names. `_bounded` becomes a call into
   `Fugu::Timeout` in phase 5, not here.
 - Users: `App::FuguVM::CLI`, `t/fuguvm/vm.t`, and the `.pod` sidecars that
   cross-reference it.
 
-### 3.3 FuguVM::Expect becomes App::FuguVM::Installer
+### 3.3 FuguVM::Expect becomes App::FuguVM::Console
 
-- `git mv lib/App/FuguVM/Expect.pm lib/App/FuguVM/Installer.pm`, and the `.pod`
+- `git mv lib/App/FuguVM/Expect.pm lib/App/FuguVM/Console.pm`, and the `.pod`
   with it.
-- `Expect` names the CPAN dependency. The module drives the OpenBSD installer
-  over the serial console, and that is the feature.
+- `Expect` names the CPAN dependency. `Console` names the feature: the module
+  drives the guest's serial console.
+- `Console`, not `Installer`. The module has two public verbs, `run_install` and
+  `run_script`, and `fuguvm expect <script>` is a documented subcommand
+  (`lib/FuguVM/CLI.pm:102`, `man/fuguvm/fuguvm.1:185`) that calls the second
+  one. `Installer` would name half the module.
 - `SCRIPT_DIR` stays `share/fuguvm/expect`. That directory holds expect(1)
-  scripts, so the path is still correct, and the data files do not move.
+  scripts, so the path is still correct, and the data files do not move. The
+  `expect` subcommand keeps its name for the same reason.
 - Rewrite the sidecar abstract:
-  `App::FuguVM::Installer - drive the OpenBSD installer over the serial console`.
+  `App::FuguVM::Console - drive the serial console of a guest`.
 
 ### 3.4 Move and retarget the tests
 
 - `git mv t/fuguvm/vm.t t/fuguvm/guest.t`. The tier directory keeps its name: it
   is named after the product, and the product is still FuguVM.
+- `t/fuguvm/vm.t:15` is
+  `eval { require FuguVM::VM; 1 } or plan skip_all => ...`. A stale guard turns
+  this rename into a skipped file, not a failing one. Make the load a hard
+  failure, or retarget the guard and confirm the file still runs.
 - Retarget the imports in the other nine files under `t/fuguvm/`.
-- `t/protocol/boundary.t` matches `^(?:Fugu|FuguVM|App)\b` after phase 2. Drop
-  the `FuguVM` alternative, because `App` now covers it.
-- `t/scripts/conventions.t` compiles every script under `scripts/`. Confirm that
-  it still passes: nothing under `scripts/` loads a `FuguVM::` module today, and
-  nothing may start to.
+- `t/protocol/boundary.t:73` is `^(?:Fugu|FuguVM|App)\b` after phase 2. Drop the
+  `FuguVM` alternative, because `App` now covers it.
+- Add the retired names to `t/scripts/namespaces.t`: `FuguVM::`, `FuguVM::VM`,
+  `FuguVM::Expect`, and the path form `lib/FuguVM/`.
+- `t/scripts/conventions.t` compiles every script under `scripts/`. Nothing
+  there loads a `FuguVM::` module today. Confirm that rather than assume it.
 
 ### 3.5 Build and CI
 
@@ -60,12 +75,16 @@ land in either order.
 - `scripts/vm-provision` and `scripts/vm-up` name the command `fuguvm` and the
   `.fuguvmrc` file, not a module. Confirm this rather than assume it.
 
-### 3.6 Update the documentation
+### 3.6 Update the website and the documentation
 
+- `web/mkindex.sh:151` is
+  `emit_group 'FuguVM modules' vm-modules lib/FuguVM/ '' "$@"`. The prefix stops
+  matching, and the group emits nothing when nothing matches, so the whole
+  section and its `id="vm-modules"` anchor vanish from `manuals.html`.
+- `t/web/site.t:203` is `^(?:App|FuguVM|Protocol)::` after phase 2. Drop the
+  `FuguVM` alternative here, and confirm the one-page-per-sidecar assertion at
+  line 206 still balances.
 - Root `CLAUDE.md`: the namespace list, and the `lib/FuguVM/` row in Layout.
-- `t/web/site.t`: after phase 2 the module-manual match is
-  `^(?:App|Protocol)::`, and it already covers `App::FuguVM::Guest`. Confirm the
-  page names that the test expects.
 - `web/fuguvm.body.html` and `.claude/skills/fuguvm/SKILL.md` name the product
   and the command, not the modules. They stay as they are, unless a grep finds a
   module name in them.
@@ -74,21 +93,20 @@ land in either order.
 
 ## Deliverables
 
-- `lib/App/FuguVM/` with 11 modules, including `Guest.pm` and `Installer.pm`,
-  each with a `.pod` sidecar.
+- `lib/App/FuguVM/` with 11 modules, including `Guest.pm` and `Console.pm`, each
+  with a `.pod` sidecar.
 - `t/fuguvm/guest.t`, and nine retargeted test files.
-- Updated `bin/fuguvm`, `Makefile` comments where they name the namespace,
-  `.github/workflows/integration.yml`, `t/protocol/boundary.t`, and root
-  `CLAUDE.md`.
+- Updated `bin/fuguvm`, `web/mkindex.sh`, `t/web/site.t`,
+  `t/protocol/boundary.t`, `t/scripts/namespaces.t`,
+  `.github/workflows/integration.yml`, and root `CLAUDE.md`.
 
 ## Acceptance criteria
 
-- `make check` passes.
-- `grep -rn 'FuguVM::' --exclude-dir=.git --exclude-dir=plans . | grep -v 'App::FuguVM::'`
-  finds nothing.
-- `grep -rn 'FuguVM::VM\|FuguVM::Expect' --exclude-dir=.git --exclude-dir=plans .`
-  finds nothing.
+- `make check` passes, and so do `make prettier` and `make web`.
+- `t/scripts/namespaces.t` passes with the new retired names.
+- `t/fuguvm/guest.t` runs rather than skips. Confirm the planned test count
+  against the count before the rename.
 - `make package` does not ship `lib/App/FuguVM/`.
+- `manuals.html` holds the `vm-modules` group with all 11 entries.
 - `bin/fuguvm status` runs from a clean checkout, or fails only for a reason
   that a missing VM explains.
-- No alias, no `@ISA` bridge, and no compatibility module carries an old name.

--- a/plans/008-cpan-namespaces/plan-3.md
+++ b/plans/008-cpan-namespaces/plan-3.md
@@ -1,0 +1,94 @@
+# Phase 3 — FuguVM becomes App::FuguVM
+
+This phase moves the VM utility into `App::`, and renames the two modules that
+name a mechanism instead of a feature. The command is still `fuguvm`, the
+configuration file is still `.fuguvmrc`, and the data files stay under
+`share/fuguvm/`. Only Perl package names and file paths change.
+
+The phase depends on phase 1. It does not depend on phase 2, and the two can
+land in either order.
+
+## Tasks
+
+### 3.1 Move the namespace
+
+- `git mv lib/FuguVM lib/App/FuguVM`. Rename the package statement in each of
+  the 11 modules, the nested `FuguVM::Proxy::Cache` package, and the
+  `=head1 NAME` line of each `.pod` sidecar.
+- Rewrite every `use`, `require`, and fully qualified call.
+- `bin/fuguvm` loads one module. Change that line.
+
+### 3.2 FuguVM::VM becomes App::FuguVM::Guest
+
+- `git mv lib/App/FuguVM/VM.pm lib/App/FuguVM/Guest.pm`, and the `.pod` with it.
+- `FuguVM::VM` repeats its parent. The module is the lifecycle of one OpenBSD
+  guest, and `Guest` says that.
+- The private methods keep their names. `_bounded` becomes a call into
+  `Fugu::Timeout` in phase 5, not here.
+- Users: `App::FuguVM::CLI`, `t/fuguvm/vm.t`, and the `.pod` sidecars that
+  cross-reference it.
+
+### 3.3 FuguVM::Expect becomes App::FuguVM::Installer
+
+- `git mv lib/App/FuguVM/Expect.pm lib/App/FuguVM/Installer.pm`, and the `.pod`
+  with it.
+- `Expect` names the CPAN dependency. The module drives the OpenBSD installer
+  over the serial console, and that is the feature.
+- `SCRIPT_DIR` stays `share/fuguvm/expect`. That directory holds expect(1)
+  scripts, so the path is still correct, and the data files do not move.
+- Rewrite the sidecar abstract:
+  `App::FuguVM::Installer - drive the OpenBSD installer over the serial console`.
+
+### 3.4 Move and retarget the tests
+
+- `git mv t/fuguvm/vm.t t/fuguvm/guest.t`. The tier directory keeps its name: it
+  is named after the product, and the product is still FuguVM.
+- Retarget the imports in the other nine files under `t/fuguvm/`.
+- `t/protocol/boundary.t` matches `^(?:Fugu|FuguVM|App)\b` after phase 2. Drop
+  the `FuguVM` alternative, because `App` now covers it.
+- `t/scripts/conventions.t` compiles every script under `scripts/`. Confirm that
+  it still passes: nothing under `scripts/` loads a `FuguVM::` module today, and
+  nothing may start to.
+
+### 3.5 Build and CI
+
+- `Makefile`: FuguVM is a development tool. The `install` and `package` targets
+  do not name `lib/FuguVM/` or `bin/fuguvm`, and they must not gain them. Only
+  the `test` target names `t/fuguvm/`, and that path does not change.
+- `.github/workflows/integration.yml`: `lib/FuguVM/**.pm` becomes
+  `lib/App/FuguVM/**.pm`, in the push list and the pull-request list.
+- `scripts/vm-provision` and `scripts/vm-up` name the command `fuguvm` and the
+  `.fuguvmrc` file, not a module. Confirm this rather than assume it.
+
+### 3.6 Update the documentation
+
+- Root `CLAUDE.md`: the namespace list, and the `lib/FuguVM/` row in Layout.
+- `t/web/site.t`: after phase 2 the module-manual match is
+  `^(?:App|Protocol)::`, and it already covers `App::FuguVM::Guest`. Confirm the
+  page names that the test expects.
+- `web/fuguvm.body.html` and `.claude/skills/fuguvm/SKILL.md` name the product
+  and the command, not the modules. They stay as they are, unless a grep finds a
+  module name in them.
+- `man/fuguvm/fuguvm.1` documents the command. Change it only where it names a
+  module.
+
+## Deliverables
+
+- `lib/App/FuguVM/` with 11 modules, including `Guest.pm` and `Installer.pm`,
+  each with a `.pod` sidecar.
+- `t/fuguvm/guest.t`, and nine retargeted test files.
+- Updated `bin/fuguvm`, `Makefile` comments where they name the namespace,
+  `.github/workflows/integration.yml`, `t/protocol/boundary.t`, and root
+  `CLAUDE.md`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `grep -rn 'FuguVM::' --exclude-dir=.git --exclude-dir=plans . | grep -v 'App::FuguVM::'`
+  finds nothing.
+- `grep -rn 'FuguVM::VM\|FuguVM::Expect' --exclude-dir=.git --exclude-dir=plans .`
+  finds nothing.
+- `make package` does not ship `lib/App/FuguVM/`.
+- `bin/fuguvm status` runs from a clean checkout, or fails only for a reason
+  that a missing VM explains.
+- No alias, no `@ISA` bridge, and no compatibility module carries an old name.

--- a/plans/008-cpan-namespaces/plan-3.md
+++ b/plans/008-cpan-namespaces/plan-3.md
@@ -1,9 +1,8 @@
 # Phase 3 — FuguVM becomes App::FuguVM
 
-This phase moves the VM utility into `App::`, and renames the two modules that
-name a mechanism instead of a feature. The command is still `fuguvm`, the
-configuration file is still `.fuguvmrc`, and the data files stay under
-`share/fuguvm/`.
+This phase moves the VM utility into `App::`, and renames the four modules whose
+names mislead. The command is still `fuguvm`, the configuration file is still
+`.fuguvmrc`, and the data files stay under `share/fuguvm/`.
 
 The phase depends on phase 2. Both phases edit the same regex in
 `t/web/site.t:203` and in `t/protocol/boundary.t:73`, and the phase-2 state must
@@ -49,7 +48,23 @@ keep the `FuguVM` alternative in each. Phase 3 removes it.
 - Rewrite the sidecar abstract:
   `App::FuguVM::Console - drive the serial console of a guest`.
 
-### 3.4 Move and retarget the tests
+### 3.4 FuguVM::Image and ImageCache become Miniroot and DiskCache
+
+- `git mv lib/App/FuguVM/Image.pm lib/App/FuguVM/Miniroot.pm` and
+  `git mv lib/App/FuguVM/ImageCache.pm lib/App/FuguVM/DiskCache.pm`, each with
+  its `.pod`.
+- Both modules cache, and neither name says what. `Image` downloads the OpenBSD
+  miniroot install media and stores it in the proxy cache. `ImageCache` keeps
+  the compacted qcow2 disk that the installer produced. `ImageCache` even loads
+  `Image`, so the pair reads as a cache of the module above it. It is not.
+- The constants stay: `BASE_NAME`, `META_NAME`, and `INSTALLED_DIR` name files
+  on disk, not modules.
+- Users: `App::FuguVM::CLI` for both, and `DiskCache` for `Miniroot` and
+  `Console`.
+- `git mv t/fuguvm/image.t t/fuguvm/miniroot.t` and
+  `git mv t/fuguvm/imagecache.t t/fuguvm/diskcache.t`.
+
+### 3.5 Move and retarget the tests
 
 - `git mv t/fuguvm/vm.t t/fuguvm/guest.t`. The tier directory keeps its name: it
   is named after the product, and the product is still FuguVM.
@@ -57,15 +72,16 @@ keep the `FuguVM` alternative in each. Phase 3 removes it.
   `eval { require FuguVM::VM; 1 } or plan skip_all => ...`. A stale guard turns
   this rename into a skipped file, not a failing one. Make the load a hard
   failure, or retarget the guard and confirm the file still runs.
-- Retarget the imports in the other nine files under `t/fuguvm/`.
+- Retarget the imports in the other seven files under `t/fuguvm/`.
 - `t/protocol/boundary.t:73` is `^(?:Fugu|FuguVM|App)\b` after phase 2. Drop the
   `FuguVM` alternative, because `App` now covers it.
 - Add the retired names to `t/scripts/namespaces.t`: `FuguVM::`, `FuguVM::VM`,
-  `FuguVM::Expect`, and the path form `lib/FuguVM/`.
+  `FuguVM::Expect`, `FuguVM::Image`, `FuguVM::ImageCache`, and the path form
+  `lib/FuguVM/`.
 - `t/scripts/conventions.t` compiles every script under `scripts/`. Nothing
   there loads a `FuguVM::` module today. Confirm that rather than assume it.
 
-### 3.5 Build and CI
+### 3.6 Build and CI
 
 - `Makefile`: FuguVM is a development tool. The `install` and `package` targets
   do not name `lib/FuguVM/` or `bin/fuguvm`, and they must not gain them. Only
@@ -75,7 +91,7 @@ keep the `FuguVM` alternative in each. Phase 3 removes it.
 - `scripts/vm-provision` and `scripts/vm-up` name the command `fuguvm` and the
   `.fuguvmrc` file, not a module. Confirm this rather than assume it.
 
-### 3.6 Update the website and the documentation
+### 3.7 Update the website and the documentation
 
 - `web/mkindex.sh:151` is
   `emit_group 'FuguVM modules' vm-modules lib/FuguVM/ '' "$@"`. The prefix stops
@@ -93,9 +109,10 @@ keep the `FuguVM` alternative in each. Phase 3 removes it.
 
 ## Deliverables
 
-- `lib/App/FuguVM/` with 11 modules, including `Guest.pm` and `Console.pm`, each
-  with a `.pod` sidecar.
-- `t/fuguvm/guest.t`, and nine retargeted test files.
+- `lib/App/FuguVM/` with 11 modules, including `Guest.pm`, `Console.pm`,
+  `Miniroot.pm`, and `DiskCache.pm`, each with a `.pod` sidecar.
+- `t/fuguvm/guest.t`, `t/fuguvm/miniroot.t`, `t/fuguvm/diskcache.t`, and seven
+  retargeted test files.
 - Updated `bin/fuguvm`, `web/mkindex.sh`, `t/web/site.t`,
   `t/protocol/boundary.t`, `t/scripts/namespaces.t`,
   `.github/workflows/integration.yml`, and root `CLAUDE.md`.

--- a/plans/008-cpan-namespaces/plan-4.md
+++ b/plans/008-cpan-namespaces/plan-4.md
@@ -1,0 +1,120 @@
+# Phase 4 — Protocol::Imsg splits out of Fugu::Imsg
+
+`Fugu::Imsg` does two jobs. It frames and unframes imsg(3) messages, and it owns
+a socket. The framing is a wire format that any program can reuse. The socket is
+host policy. This phase separates them, and puts the codec in the namespace that
+CPAN uses for sans-IO protocol codecs.
+
+The phase depends on phase 1. The public API of the transport does not change,
+so its callers change nothing.
+
+## Tasks
+
+### 4.1 Create Protocol::Imsg
+
+- New `lib/Protocol/Imsg.pm`. It holds the constants, the header pack and
+  unpack, and the message extraction. It performs no system call, and it opens
+  no file.
+- Move these from `Fugu::Imsg`: `HEADER_SIZE`, `HEADER_TEMPLATE`,
+  `MAX_IMSGSIZE`, `MAX_PAYLOAD`, `FD_MARK`, `_encode_header`, `_decode_header`,
+  and `_extract_message`. The spec citations move with the code.
+- The public API is `new`, `encode`, `append`, `next_message`, and `is_failed`,
+  as the design defines them. `_encode_header` and `_decode_header` stay
+  private: the tests reach them through `encode` and `next_message`.
+- `encode` returns undef with `$!` set to `EMSGSIZE` for an oversized payload.
+  `next_message` returns undef with `$!` set to `EBADMSG` for an invalid length,
+  and `is_failed` then reports 1 forever.
+- `pid` defaults to `$$`. Document it as the one environment value that the
+  codec reads.
+- Write `lib/Protocol/Imsg.pod`. State in the first paragraph that the module
+  implements the framing subset without descriptor passing: `FD_MARK` is masked
+  off, never set. A reader must not expect `SCM_RIGHTS`.
+
+### 4.2 Rewrite Fugu::Imsg as the transport
+
+- `Fugu::Imsg` keeps `new(fh =>)`, `send`, `recv`, `close`, and `is_dead`. The
+  behavior, the return values, and the `$!` values do not change.
+- It holds one `Protocol::Imsg` object. `send` calls `encode`, then does the
+  write loop and the `SIGPIPE` guard. `recv` calls `next_message`, then polls
+  with `IO::Select` and reads with `sysread`, and feeds `append`.
+- A framing failure in the codec marks the transport dead, as it does today.
+- The read buffer lives in the codec. The transport keeps only the handle and
+  the dead flag.
+
+### 4.3 Update the manuals
+
+- Rewrite `man/fugu/Imsg.3p` for the smaller module. The framing rules move to
+  the pod; the page documents the socket, the timeout behavior, and the errors.
+- Do not add an `.Xr` link to the codec. A sidecar `.pod` is not a 3p page, so
+  `.Xr` would point at a page that does not exist. Name `Protocol::Imsg` in the
+  SEE ALSO text, and point at `spec/MDNS-Imsg.md`.
+- The documentation table in the root `CLAUDE.md` sends `Fugu::` modules to 3p
+  pages and every other module to a sidecar. This split follows that rule, and
+  no module gets both.
+
+### 4.4 Split the tests
+
+- New `t/protocol/imsg.t`. Move the byte-level subtests from `t/fugu/imsg.t`:
+  the header encoding, the length bounds, the oversized payload, the invalid
+  length, and the partial-message extraction. They drive `encode`, `append`, and
+  `next_message` on plain strings, with no socketpair.
+- `t/fugu/imsg.t` keeps the transport subtests: the socketpair round trip, the
+  short read across calls, the timeout of 0, the clean EOF, and the dead
+  connection.
+- `t/conformance/mdns-imsg.t` keeps its file name and its citations. It loads
+  `Protocol::Imsg` for the framing rules in sections 1 to 4. Section 5, on
+  descriptor passing, states what the codec does not implement.
+- `t/conformance/mdns-control.t`, `t/fugu/control.t`, `t/fugu/mdns.t`, and
+  `t/openhap/integration/control.t` use the transport. They change nothing.
+
+### 4.5 Extend the boundary test
+
+- `t/protocol/boundary.t` gains direction three: `Fugu::` may use a `Protocol::`
+  module on an allowlist, and that allowlist holds `Protocol::Imsg` only. Any
+  other `Protocol::` import under `lib/Fugu/` fails the test, and
+  `Protocol::HAP` fails it by name.
+- Direction one already scans all of `lib/Protocol/`, so it covers the new
+  module without a change.
+- Prove the new failure mode once by hand before commit: plant a
+  `use Protocol::HAP;` in a `Fugu::` module and watch the test fail.
+
+### 4.6 Confirm the build
+
+- `Makefile`: `install` and `package` copy `lib/Protocol/*.pm` and
+  `lib/Protocol/*.pod` with a glob, so `Protocol/Imsg.pm` and `Imsg.pod` ship
+  without a change. Confirm this with an install into an empty directory.
+- `t/fugu/coreperl.t` loads each `Fugu::` module with the core paths plus
+  `lib/`. `Fugu::Imsg` now requires `Protocol::Imsg`, which is under `lib/` and
+  uses core Perl only, so the test still passes. Run it and confirm.
+- `t/web/site.t`: the page expectations gain the `Protocol::Imsg` sidecar.
+
+### 4.7 Update the documentation
+
+- Root `CLAUDE.md`: the `lib/Protocol/` row in Layout describes the
+  `Protocol::HAP` library. It now holds two libraries. State that `Protocol::`
+  is the sans-IO tier, and that `Protocol::Imsg` is the imsg(3) codec.
+- `t/CLAUDE.md`: the `t/protocol/` tier row says "the Protocol::HAP library".
+- `TODO.md`: record that a `Protocol-Imsg` distribution would need descriptor
+  passing, or an explicit statement of the subset, before a release.
+
+## Deliverables
+
+- `lib/Protocol/Imsg.pm` and `lib/Protocol/Imsg.pod`.
+- A smaller `lib/Fugu/Imsg.pm` and a rewritten `man/fugu/Imsg.3p`.
+- `t/protocol/imsg.t`, a smaller `t/fugu/imsg.t`, a retargeted
+  `t/conformance/mdns-imsg.t`, and an extended `t/protocol/boundary.t`.
+- Updated root `CLAUDE.md`, `t/CLAUDE.md`, `TODO.md`, and `t/web/site.t`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `grep -rn 'syswrite\|sysread\|IO::Select\|CORE::close' lib/Protocol/Imsg.pm`
+  finds nothing.
+- `t/protocol/boundary.t` passes, and fails correctly on a planted
+  `use Protocol::HAP;` inside `lib/Fugu/`.
+- `make spec-coverage` reports no stale citations, and `spec/MDNS-Imsg.md` keeps
+  full section coverage.
+- `make integration` passes: the control socket and the mdnsd client both use
+  the rewritten transport.
+- The transport API is unchanged. No caller outside `lib/Fugu/Imsg.pm` and its
+  tests changes in this phase.

--- a/plans/008-cpan-namespaces/plan-4.md
+++ b/plans/008-cpan-namespaces/plan-4.md
@@ -1,12 +1,10 @@
 # Phase 4 — Protocol::Imsg splits out of Fugu::Imsg
 
 `Fugu::Imsg` does two jobs. It frames and unframes imsg(3) messages, and it owns
-a socket. The framing is a wire format that any program can reuse. The socket is
-host policy. This phase separates them, and puts the codec in the namespace that
-CPAN uses for sans-IO protocol codecs.
+a socket. The framing is a wire format that another program can reuse. The
+socket is host policy. This phase separates them.
 
-The phase depends on phase 1. The public API of the transport does not change,
-so its callers change nothing.
+The phase depends on phase 1 only.
 
 ## Tasks
 
@@ -18,65 +16,98 @@ so its callers change nothing.
 - Move these from `Fugu::Imsg`: `HEADER_SIZE`, `HEADER_TEMPLATE`,
   `MAX_IMSGSIZE`, `MAX_PAYLOAD`, `FD_MARK`, `_encode_header`, `_decode_header`,
   and `_extract_message`. The spec citations move with the code.
-- The public API is `new`, `encode`, `append`, `next_message`, and `is_failed`,
-  as the design defines them. `_encode_header` and `_decode_header` stay
-  private: the tests reach them through `encode` and `next_message`.
-- `encode` returns undef with `$!` set to `EMSGSIZE` for an oversized payload.
-  `next_message` returns undef with `$!` set to `EBADMSG` for an invalid length,
-  and `is_failed` then reports 1 forever.
-- `pid` defaults to `$$`. Document it as the one environment value that the
-  codec reads.
-- Write `lib/Protocol/Imsg.pod`. State in the first paragraph that the module
-  implements the framing subset without descriptor passing: `FD_MARK` is masked
-  off, never set. A reader must not expect `SCM_RIGHTS`.
+- The public API is `new`, `encode`, `append`, `next_message`, `is_failed`, and
+  `reset`, as the design defines them.
+- `encode` uses `$args{pid} || $$`, not `//`. imsg substitutes the sender's pid
+  when the caller passes 0 [MDNS-Imsg §3], so a `//` default would emit a wire
+  value that native imsg never produces.
+- `reset` empties the buffer and clears the failure flag. `Fugu::Imsg::close`
+  needs it.
+- Write `lib/Protocol/Imsg.pod`. The first paragraph states three limits: the
+  header is native-endian and the format never crosses a host; the module frames
+  without descriptor passing, because `FD_MARK` is masked off and never set; and
+  `encode` reads `$$` per call, while native imsg seeds the pid once per buffer,
+  so a forked child diverges.
 
 ### 4.2 Rewrite Fugu::Imsg as the transport
 
-- `Fugu::Imsg` keeps `new(fh =>)`, `send`, `recv`, `close`, and `is_dead`. The
-  behavior, the return values, and the `$!` values do not change.
-- It holds one `Protocol::Imsg` object. `send` calls `encode`, then does the
-  write loop and the `SIGPIPE` guard. `recv` calls `next_message`, then polls
-  with `IO::Select` and reads with `sysread`, and feeds `append`.
-- A framing failure in the codec marks the transport dead, as it does today.
-- The read buffer lives in the codec. The transport keeps only the handle and
-  the dead flag.
+- `Fugu::Imsg` keeps `new(fh =>)`, `send`, `recv`, `close`, and `is_dead`, with
+  the same return values and the same `$!` values.
+- It holds one `Protocol::Imsg` object. `send` checks the dead flag and sets
+  `EPIPE` **first**, then calls `encode`, then does the write loop and the
+  `SIGPIPE` guard. The order matters: today a dead connection reports `EPIPE`
+  even for an oversized payload, and `Fugu::Control::Client::request` prints
+  that `$!` to the operator. Reversed, "the daemon closed the connection"
+  becomes "Message too long".
+- `recv` calls `next_message`, then polls with `IO::Select`, reads with
+  `sysread`, and feeds `append`. A framing failure marks the transport dead.
+- `close` calls `reset` on the codec. Without it a closed connection can still
+  hand out a frame that arrived before the close, because `recv` extracts before
+  it checks the dead flag.
+- Re-export the constant:
+  `use constant MAX_PAYLOAD => Protocol::Imsg::MAX_PAYLOAD;`.
+  `lib/Fugu/Control.pm:307` reads `FuguLib::Imsg::MAX_PAYLOAD` as a bareword, so
+  the constant leaving this module is a compile-time abort, not a runtime error.
+  `t/fugu/control.t:145` calls it as a function.
+- Keep the `{fh}` hash key. `Fugu::Control` and the tests reach into it.
 
 ### 4.3 Update the manuals
 
 - Rewrite `man/fugu/Imsg.3p` for the smaller module. The framing rules move to
   the pod; the page documents the socket, the timeout behavior, and the errors.
+  It keeps `MAX_PAYLOAD`, which the module still exports.
 - Do not add an `.Xr` link to the codec. A sidecar `.pod` is not a 3p page, so
   `.Xr` would point at a page that does not exist. Name `Protocol::Imsg` in the
   SEE ALSO text, and point at `spec/MDNS-Imsg.md`.
-- The documentation table in the root `CLAUDE.md` sends `Fugu::` modules to 3p
-  pages and every other module to a sidecar. This split follows that rule, and
-  no module gets both.
+- `web/mkindex.sh:150` groups `lib/Protocol/` under the heading "Protocol::HAP
+  modules". That heading is now wrong. Rename it, or split the group.
 
 ### 4.4 Split the tests
 
-- New `t/protocol/imsg.t`. Move the byte-level subtests from `t/fugu/imsg.t`:
-  the header encoding, the length bounds, the oversized payload, the invalid
-  length, and the partial-message extraction. They drive `encode`, `append`, and
-  `next_message` on plain strings, with no socketpair.
-- `t/fugu/imsg.t` keeps the transport subtests: the socketpair round trip, the
-  short read across calls, the timeout of 0, the clean EOF, and the dead
-  connection.
-- `t/conformance/mdns-imsg.t` keeps its file name and its citations. It loads
-  `Protocol::Imsg` for the framing rules in sections 1 to 4. Section 5, on
-  descriptor passing, states what the codec does not implement.
+`t/fugu/imsg.t` holds ten subtests. Each one has a destination, and three of
+them split rather than move.
+
+| Subtest                                     | Destination                                                                  |
+| ------------------------------------------- | ---------------------------------------------------------------------------- |
+| round-trip over a socketpair                | transport                                                                    |
+| oversized payload is refused, not truncated | both: the bound to the codec, the 16368-byte round trip to the transport     |
+| truncated header then EOF returns undef     | transport                                                                    |
+| two messages in one read                    | codec, and keep a transport case                                             |
+| write after peer close returns undef        | transport; it proves the `SIGPIPE` guard                                     |
+| recv timeout returns undef without data     | transport; this is the positive-timeout deadline path                        |
+| a zero timeout takes what arrived           | transport                                                                    |
+| invalid length poisons the connection       | both: the `EBADMSG` to the codec, the `is_dead` propagation to the transport |
+| the header carries peerid and pid           | codec                                                                        |
+| close ends the connection for both sides    | transport                                                                    |
+
+- The propagation case is the only new seam this phase creates, so it must have
+  a transport test: inject an invalid `len` over a socketpair, assert `is_dead`,
+  and assert that a second `recv` returns without blocking. Without it, an
+  implementation that forgets `$self->{dead} = 1` passes the suite, and
+  `Fugu::Control` spins on a readable but unusable socket forever.
+- The zero-timeout subtest builds its split message with `_encode_header`. It
+  becomes `Protocol::Imsg->new->encode(...)`, so `t/fugu/imsg.t` gains a codec
+  dependency. Name that in the file header.
+- `t/conformance/mdns-imsg.t` keeps its file name and its citations. Sections 1
+  and 2 and the two accumulation cases of section 4 drive the codec. Two cases
+  cannot: `[MDNS-Imsg §2] invalid len drops the connection` and
+  `[MDNS-Imsg §4] EOF mid-message is an error` are transport predicates, because
+  a codec with `append` and `next_message` has no concept of EOF. They keep
+  their socketpair against `Fugu::Imsg`.
 - `t/conformance/mdns-control.t`, `t/fugu/control.t`, `t/fugu/mdns.t`, and
-  `t/openhap/integration/control.t` use the transport. They change nothing.
+  `t/openhap/integration/control.t` use the transport. Only the `MAX_PAYLOAD`
+  call site in `t/fugu/control.t` changes.
 
 ### 4.5 Extend the boundary test
 
-- `t/protocol/boundary.t` gains direction three: `Fugu::` may use a `Protocol::`
-  module on an allowlist, and that allowlist holds `Protocol::Imsg` only. Any
-  other `Protocol::` import under `lib/Fugu/` fails the test, and
-  `Protocol::HAP` fails it by name.
+- `t/protocol/boundary.t` direction two matches `^(?:Protocol::HAP|App)\b` after
+  phase 2. Widen it to reject any `^Protocol\b` import that is not on an
+  allowlist, and seed the allowlist with `Protocol::Imsg`.
 - Direction one already scans all of `lib/Protocol/`, so it covers the new
   module without a change.
-- Prove the new failure mode once by hand before commit: plant a
-  `use Protocol::HAP;` in a `Fugu::` module and watch the test fail.
+- Prove the new rule with a planted `use Protocol::Something;` in a `Fugu::`
+  module, and confirm that `use Protocol::Imsg;` passes. A planted
+  `use Protocol::HAP;` proves nothing: direction two already rejects it.
 
 ### 4.6 Confirm the build
 
@@ -92,29 +123,36 @@ so its callers change nothing.
 
 - Root `CLAUDE.md`: the `lib/Protocol/` row in Layout describes the
   `Protocol::HAP` library. It now holds two libraries. State that `Protocol::`
-  is the sans-IO tier, and that `Protocol::Imsg` is the imsg(3) codec.
+  is the sans-IO tier.
 - `t/CLAUDE.md`: the `t/protocol/` tier row says "the Protocol::HAP library".
-- `TODO.md`: record that a `Protocol-Imsg` distribution would need descriptor
-  passing, or an explicit statement of the subset, before a release.
+- `TODO.md`: record that a `Protocol-Imsg` distribution needs descriptor passing
+  or an explicit statement of the subset, and that the native-endian header
+  makes the name a compromise.
 
 ## Deliverables
 
 - `lib/Protocol/Imsg.pm` and `lib/Protocol/Imsg.pod`.
 - A smaller `lib/Fugu/Imsg.pm` and a rewritten `man/fugu/Imsg.3p`.
 - `t/protocol/imsg.t`, a smaller `t/fugu/imsg.t`, a retargeted
-  `t/conformance/mdns-imsg.t`, and an extended `t/protocol/boundary.t`.
-- Updated root `CLAUDE.md`, `t/CLAUDE.md`, `TODO.md`, and `t/web/site.t`.
+  `t/conformance/mdns-imsg.t`, and a widened `t/protocol/boundary.t`.
+- Updated `web/mkindex.sh`, root `CLAUDE.md`, `t/CLAUDE.md`, `TODO.md`, and
+  `t/web/site.t`.
 
 ## Acceptance criteria
 
-- `make check` passes.
-- `grep -rn 'syswrite\|sysread\|IO::Select\|CORE::close' lib/Protocol/Imsg.pm`
+- `make check` passes, and so do `make prettier` and `make web`.
+- `grep -n 'syswrite\|sysread\|IO::Select\|CORE::close' lib/Protocol/Imsg.pm`
   finds nothing.
-- `t/protocol/boundary.t` passes, and fails correctly on a planted
-  `use Protocol::HAP;` inside `lib/Fugu/`.
-- `make spec-coverage` reports no stale citations, and `spec/MDNS-Imsg.md` keeps
-  full section coverage.
+- The subtest count of `t/protocol/imsg.t` plus `t/fugu/imsg.t` is at least the
+  ten that `t/fugu/imsg.t` holds today, and the table in task 4.4 accounts for
+  each one.
+- `t/protocol/boundary.t` fails on a planted `use Protocol::Something;` inside
+  `lib/Fugu/`, and passes with `use Protocol::Imsg;`.
+- `make spec-coverage` reports no stale citations, and `spec/MDNS-Imsg.md` stays
+  at 4 of 5 sections. Section 5 is uncovered today, and it stays uncovered: a
+  subtest that only states what the codec omits asserts nothing, and
+  `t/CLAUDE.md` forbids a citation for a section that a test merely mentions.
 - `make integration` passes: the control socket and the mdnsd client both use
   the rewritten transport.
-- The transport API is unchanged. No caller outside `lib/Fugu/Imsg.pm` and its
-  tests changes in this phase.
+- No caller outside `lib/Fugu/Imsg.pm`, `t/fugu/imsg.t`, `t/fugu/control.t`, and
+  `t/conformance/mdns-imsg.t` changes in this phase.

--- a/plans/008-cpan-namespaces/plan-5.md
+++ b/plans/008-cpan-namespaces/plan-5.md
@@ -1,0 +1,108 @@
+# Phase 5 — Fugu::Timeout, and the documentation pass
+
+This phase removes the last general noun from the tree, and finishes the
+documentation. After it, every module name in the repository says what the
+module does, and no document names a namespace that no longer exists.
+
+The phase depends on phases 1 to 3. It does not depend on phase 4.
+
+## Tasks
+
+### 5.1 Fugu::Util becomes Fugu::Timeout
+
+- `Fugu::Util` holds three functions that share no idea: `bounded`,
+  `wait_until`, and `format_size`. The name hides that.
+- `git mv lib/Fugu/Util.pm lib/Fugu/Timeout.pm`. The module keeps `bounded` and
+  `wait_until`, which are one idea: run something under a time limit.
+- Users of the two: `Fugu::SSH`, `Fugu::MQTT`, `Fugu::Proxy`,
+  `App::FuguVM::Guest`, and `App::FuguVM::QGA`.
+- `git mv man/fugu/Util.3p man/fugu/Timeout.3p`, and rewrite it for the two
+  functions. Update `MAN3P` in the `Makefile` and every `.Xr` that names the
+  page.
+- `git mv t/fugu/util.t t/fugu/timeout.t`.
+
+### 5.2 format_size moves to its only caller
+
+- `App::FuguVM::CLI` calls `format_size` six times. Nothing else calls it.
+- Move the function into `App::FuguVM::CLI` as the private `_format_size`.
+  Delete it from the module, from the manual page, and from the export list.
+- Move its subtests from `t/fugu/util.t` into `t/fuguvm/cli.t`. Keep the same
+  cases: the byte, kilobyte, megabyte, and gigabyte boundaries, and the
+  undefined argument.
+
+### 5.3 Rewrite the website text
+
+- `web/fugu.body.html`: replace the `Fugu::Util` entry with `Fugu::Timeout`, and
+  correct its description. Add the `Fugu::Imsg` entry for the smaller module if
+  phase 4 has landed.
+- `web/index.body.html`: confirm that the namespace names and the links match
+  the tree.
+- `t/web/site.t`: confirm the page list, the module-manual match, and the `.Xr`
+  assertions after all five phases.
+
+### 5.4 Finish the project documentation
+
+- Root `CLAUDE.md`: the introduction now names `App::OpenHAP`, `App::FuguVM`,
+  `Fugu`, `Protocol::HAP`, and `Protocol::Imsg`. Rewrite the four-namespace
+  paragraph, the Layout list, and row 2 of the documentation table.
+- `README.md` and `INSTALL.md`: every module name.
+- `t/CLAUDE.md`: the tier table and the mock example.
+- `t/openhap/integration/CLAUDE.md`: the module names in the rules.
+- Leave `plans/001` to `plans/007` as they are. They record what was true when
+  they were written.
+
+### 5.5 Record the release work in TODO.md
+
+Replace the `Protocol::HAP CPAN release` section with one section for the whole
+tree. It lists what a release of any distribution here still needs:
+
+- A distribution main module for `App-OpenHAP` and for `App-FuguVM`. PAUSE
+  grants indexing permission on that module first, and neither exists today.
+- A `$VERSION` policy. No module in the repository carries one, and PAUSE does
+  not index a module without a version.
+- `no_index` metadata for the packages that live inside another file:
+  `Protocol::HAP::Log::Null`, `Protocol::HAP::SRP::Client`,
+  `Fugu::Control::Client`, `Fugu::Proxy::Cache`, `Fugu::Proxy::Meta`, and
+  `App::FuguVM::Proxy::Cache`.
+- Distribution tooling: `Makefile.PL` or `Build.PL`, `MANIFEST`, and
+  distribution tests.
+- The redistribution-license review of `spec/`.
+- The open naming question: `Fugu::MQTT`, `Fugu::MDNS`, `Fugu::SSH`, and
+  `Fugu::Proxy` may belong under `Net::` or `HTTP::`. Each needs a study of the
+  existing module in that namespace before it moves.
+- The descriptor-passing subset of `Protocol::Imsg`, from phase 4.
+
+### 5.6 Sweep the tree
+
+Run the greps from every phase one more time, from the repository root, with
+`plans/` excluded. Each must find nothing:
+
+```sh
+grep -rn 'FuguLib\|fugulib' --exclude-dir=.git --exclude-dir=plans .
+grep -rn 'OpenHAP::' --exclude-dir=.git --exclude-dir=plans . | grep -v 'App::'
+grep -rn 'FuguVM::' --exclude-dir=.git --exclude-dir=plans . | grep -v 'App::'
+grep -rn 'Fugu::Util\|FuguVM::VM\|FuguVM::Expect' --exclude-dir=.git \
+    --exclude-dir=plans .
+```
+
+## Deliverables
+
+- `lib/Fugu/Timeout.pm`, `man/fugu/Timeout.3p`, and `t/fugu/timeout.t`.
+- `App::FuguVM::CLI` with the private `_format_size`, and the moved subtests in
+  `t/fuguvm/cli.t`.
+- Updated `web/fugu.body.html`, `web/index.body.html`, root `CLAUDE.md`,
+  `t/CLAUDE.md`, `t/openhap/integration/CLAUDE.md`, `README.md`, `INSTALL.md`,
+  and `TODO.md`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- The four greps in task 5.6 find nothing.
+- `grep -rn 'format_size' lib/Fugu man/fugu` finds nothing.
+- `make web` builds, and `t/web/site.t` passes with the final page list.
+- `make install DESTDIR=...` into an empty directory produces only `App/`,
+  `Fugu/`, and `Protocol/` under `$(LIBDIR)`, and only `Fugu::*.3p` under
+  `man3p/`.
+- `make integration` passes.
+- The repository contains no alias, no `@ISA` bridge, no compatibility module,
+  and no migration note for an older install.

--- a/plans/008-cpan-namespaces/plan-5.md
+++ b/plans/008-cpan-namespaces/plan-5.md
@@ -1,7 +1,7 @@
-# Phase 5 — Fugu::Timeout, and the documentation pass
+# Phase 5 — The leaf renames, and the documentation pass
 
-This phase removes the last general noun from the tree, and finishes the
-documentation. After it, every module name in the repository says what the
+This phase renames the four modules that no namespace move touches, and finishes
+the documentation. After it, every module name in the repository says what the
 module does, and no document names a namespace that no longer exists.
 
 The phase depends on phases 1 to 3. It does not depend on phase 4.
@@ -20,9 +20,57 @@ The phase depends on phases 1 to 3. It does not depend on phase 4.
   functions. Update `MAN3P` in the `Makefile` and every `.Xr` that names the
   page.
 - `git mv t/fugu/util.t t/fugu/timeout.t`.
-- Add `Fugu::Util` to the retired list in `t/scripts/namespaces.t`.
+- Add `Fugu::Util` to the retired list in `t/scripts/namespaces.t`. Tasks 5.2 to
+  5.4 add `Fugu::Store`, `Fugu::MDNS`, `Protocol::HAP::PIN`, and
+  `normalize_pin`.
 
-### 5.2 format_size moves to its only caller
+### 5.2 Fugu::Store becomes Fugu::StateFile
+
+- `git mv lib/Fugu/Store.pm lib/Fugu/StateFile.pm`, and
+  `git mv man/fugu/Store.3p man/fugu/StateFile.3p`. Update `MAN3P` and every
+  `.Xr` that names the page.
+- The module is a small JSON state file with `load`, `save`, `get`, `set`,
+  `increment`, and `delete`. Its own abstract says so.
+- The rename also ends the three-`Store` problem. After it, `Store` in this tree
+  means the `Protocol::HAP` persistence contract and its two implementations,
+  and nothing else.
+- Users: `Fugu::Proxy`, `App::OpenHAP::Store::File`, `App::FuguVM::State` and
+  its `.pod`, `t/fugu/proxy.t`, and `t/fuguvm/proxy.t`.
+- `git mv t/fugu/store.t t/fugu/statefile.t`.
+
+### 5.3 Fugu::MDNS becomes Fugu::Mdnsd
+
+- `git mv lib/Fugu/MDNS.pm lib/Fugu/Mdnsd.pm`, and
+  `git mv man/fugu/MDNS.3p man/fugu/Mdnsd.3p`.
+- The module implements no mDNS. It opens the `mdnsd(8)` control socket and
+  sends `IMSG_CTL_*` messages over `Fugu::Imsg`. `connect`, `publish`,
+  `publish_service`, `update_txt`, and `withdraw` are all control operations.
+  The name claims a capability the module does not hold.
+- `format_txt` stays, and its comment keeps the point that the join is mdnsd's
+  format, not HAP's.
+- The spec files keep their names. `spec/MDNS-Control.md` and
+  `spec/MDNS-Imsg.md` document the protocol of mdnsd, not this module, and
+  `make spec-coverage` maps `t/conformance/mdns-control.t` to the first by stem.
+- Users: `bin/openhapd`, `App::OpenHAP::Host`, `t/fugu/mdns.t`,
+  `t/conformance/mdns-control.t`, and the integration tests.
+- `git mv t/fugu/mdns.t t/fugu/mdnsd.t`. Do not rename the conformance file: it
+  is named after the spec stem, and `t/CLAUDE.md` requires that.
+
+### 5.4 Protocol::HAP::PIN becomes Protocol::HAP::SetupCode
+
+- `git mv lib/Protocol/HAP/PIN.pm lib/Protocol/HAP/SetupCode.pm`, and the `.pod`
+  with it.
+- `spec/HAP-Pairing.md` §2 says "8-digit setup code". `PIN` is the word the
+  specification replaced.
+- Rename the exported `normalize_pin` to `normalize_setup_code`, and any `*_pin`
+  name inside the module with it. A module named for the specification that
+  exports the superseded word is half a rename.
+- Users: `bin/openhapd`, `Protocol::HAP::SRP`, `Protocol::HAP::Pairing`,
+  `Protocol::HAP::Server`, and the umbrella `lib/Protocol/HAP.pod`.
+- `git mv t/protocol/pin.t t/protocol/setupcode.t`. The conformance files keep
+  their names and their citations: the spec sections do not move.
+
+### 5.5 format_size moves to its only caller
 
 - `App::FuguVM::CLI` calls `format_size` six times. Nothing else calls it.
 - Move the function into `App::FuguVM::CLI` as the private `_format_size`.
@@ -30,10 +78,12 @@ The phase depends on phases 1 to 3. It does not depend on phase 4.
 - Move its subtests from `t/fugu/util.t` into `t/fuguvm/cli.t`, with the same
   cases.
 
-### 5.3 Rewrite the website text
+### 5.6 Rewrite the website text
 
-- `web/fugu.body.html`: replace the `Fugu::Util` entry with `Fugu::Timeout`, and
-  correct its description. Correct the `Fugu::Imsg` entry if phase 4 has landed.
+- `web/fugu.body.html`: replace the `Fugu::Util`, `Fugu::Store`, and
+  `Fugu::MDNS` entries with `Fugu::Timeout`, `Fugu::StateFile`, and
+  `Fugu::Mdnsd`, and correct each description. Correct the `Fugu::Imsg` entry if
+  phase 4 has landed.
 - `web/index.body.html`: confirm that the namespace names and the links match
   the tree.
 - `t/web/site.t`: confirm the page list, the module-manual match, and the `.Xr`
@@ -41,7 +91,7 @@ The phase depends on phases 1 to 3. It does not depend on phase 4.
 - `web/mkindex.sh`: confirm that every `emit_group` prefix matches a directory
   that exists, and that `manuals.html` holds all five groups with their entries.
 
-### 5.4 Finish the project documentation
+### 5.7 Finish the project documentation
 
 - Root `CLAUDE.md`: the introduction now names `App::OpenHAP`, `App::FuguVM`,
   `Fugu`, `Protocol::HAP`, and `Protocol::Imsg`. Rewrite the four-namespace
@@ -52,7 +102,7 @@ The phase depends on phases 1 to 3. It does not depend on phase 4.
   change nothing.
 - Leave `plans/001` to `plans/007` as they are.
 
-### 5.5 Record the release work in TODO.md
+### 5.8 Record the release work in TODO.md
 
 Replace the `Protocol::HAP CPAN release` section with one section for the whole
 tree. It lists what a release of any distribution here still needs:
@@ -74,13 +124,13 @@ tree. It lists what a release of any distribution here still needs:
 - Distribution tooling: `Makefile.PL` or `Build.PL`, `MANIFEST`, and
   distribution tests.
 - The redistribution-license review of `spec/`.
-- The open naming questions: `Fugu::MQTT`, `Fugu::SSH`, and `Fugu::Proxy` may
-  belong under `Net::` or `HTTP::`. `Fugu::MDNS` needs a different question
-  first, because it does not implement mDNS: it is a control client for
-  `mdnsd(8)`, so the name promises more than the module holds.
 - The descriptor-passing subset of `Protocol::Imsg`, from phase 4.
 
-### 5.6 Close the sweep
+No naming question belongs in this list. Plan 008 decides every name in the
+tree, including the ones it decides to keep. The design records those with their
+reasons.
+
+### 5.9 Close the sweep
 
 - `t/scripts/namespaces.t` now holds every retired name from phases 1 to 5.
   Confirm the list against the design's rename table, and confirm the test reads
@@ -94,7 +144,10 @@ tree. It lists what a release of any distribution here still needs:
 
 ## Deliverables
 
-- `lib/Fugu/Timeout.pm`, `man/fugu/Timeout.3p`, and `t/fugu/timeout.t`.
+- `lib/Fugu/Timeout.pm`, `lib/Fugu/StateFile.pm`, `lib/Fugu/Mdnsd.pm`, and
+  `lib/Protocol/HAP/SetupCode.pm`, each with its 3p page or `.pod` sidecar.
+- `t/fugu/timeout.t`, `t/fugu/statefile.t`, `t/fugu/mdnsd.t`, and
+  `t/protocol/setupcode.t`.
 - `App::FuguVM::CLI` with the private `_format_size`, and the moved subtests in
   `t/fuguvm/cli.t`.
 - A complete `t/scripts/namespaces.t` retired list.
@@ -107,7 +160,10 @@ tree. It lists what a release of any distribution here still needs:
   `mandoc -Tlint -W warning` over every manual page.
 - `t/scripts/namespaces.t` passes on a clean tree and on a built tree, and fails
   on each of the four planted shims.
-- `grep -n 'format_size' lib/Fugu/Timeout.pm man/fugu/Timeout.3p` finds nothing.
+- `grep -n 'format_size' lib/Fugu/Timeout.pm man/fugu/Timeout.3p` finds nothing,
+  and `grep -rn 'normalize_pin' lib bin t` finds nothing.
+- `make spec-coverage` still maps every `spec/MDNS-*.md` and `spec/HAP-*.md`
+  file to its conformance test.
 - `make install DESTDIR=...` into an empty directory produces only `App/`,
   `Fugu/`, and `Protocol/` under `$(LIBDIR)`, and only `Fugu::*.3p` under
   `man3p/`.

--- a/plans/008-cpan-namespaces/plan-5.md
+++ b/plans/008-cpan-namespaces/plan-5.md
@@ -20,46 +20,53 @@ The phase depends on phases 1 to 3. It does not depend on phase 4.
   functions. Update `MAN3P` in the `Makefile` and every `.Xr` that names the
   page.
 - `git mv t/fugu/util.t t/fugu/timeout.t`.
+- Add `Fugu::Util` to the retired list in `t/scripts/namespaces.t`.
 
 ### 5.2 format_size moves to its only caller
 
 - `App::FuguVM::CLI` calls `format_size` six times. Nothing else calls it.
 - Move the function into `App::FuguVM::CLI` as the private `_format_size`.
   Delete it from the module, from the manual page, and from the export list.
-- Move its subtests from `t/fugu/util.t` into `t/fuguvm/cli.t`. Keep the same
-  cases: the byte, kilobyte, megabyte, and gigabyte boundaries, and the
-  undefined argument.
+- Move its subtests from `t/fugu/util.t` into `t/fuguvm/cli.t`, with the same
+  cases.
 
 ### 5.3 Rewrite the website text
 
 - `web/fugu.body.html`: replace the `Fugu::Util` entry with `Fugu::Timeout`, and
-  correct its description. Add the `Fugu::Imsg` entry for the smaller module if
-  phase 4 has landed.
+  correct its description. Correct the `Fugu::Imsg` entry if phase 4 has landed.
 - `web/index.body.html`: confirm that the namespace names and the links match
   the tree.
 - `t/web/site.t`: confirm the page list, the module-manual match, and the `.Xr`
-  assertions after all five phases.
+  assertions after every landed phase.
+- `web/mkindex.sh`: confirm that every `emit_group` prefix matches a directory
+  that exists, and that `manuals.html` holds all five groups with their entries.
 
 ### 5.4 Finish the project documentation
 
 - Root `CLAUDE.md`: the introduction now names `App::OpenHAP`, `App::FuguVM`,
   `Fugu`, `Protocol::HAP`, and `Protocol::Imsg`. Rewrite the four-namespace
   paragraph, the Layout list, and row 2 of the documentation table.
-- `README.md` and `INSTALL.md`: every module name.
 - `t/CLAUDE.md`: the tier table and the mock example.
 - `t/openhap/integration/CLAUDE.md`: the module names in the rules.
-- Leave `plans/001` to `plans/007` as they are. They record what was true when
-  they were written.
+- `README.md` and `INSTALL.md` name no module that moves. Confirm that, and
+  change nothing.
+- Leave `plans/001` to `plans/007` as they are.
 
 ### 5.5 Record the release work in TODO.md
 
 Replace the `Protocol::HAP CPAN release` section with one section for the whole
 tree. It lists what a release of any distribution here still needs:
 
-- A distribution main module for `App-OpenHAP` and for `App-FuguVM`. PAUSE
-  grants indexing permission on that module first, and neither exists today.
-- A `$VERSION` policy. No module in the repository carries one, and PAUSE does
-  not index a module without a version.
+- **A `Fugu` distribution would ship with no documentation.** MetaCPAN renders
+  POD, not mdoc, and no `lib/Fugu/` module holds POD: the API documentation is
+  in `man/fugu/*.3p`, which `Makefile` installs and the distribution would not
+  carry. This is the largest obstacle to releasing the namespace that the whole
+  effort exists to justify. Either the release ships generated POD, or the
+  documentation rule changes for `Fugu::`.
+- A distribution main module for `App-OpenHAP`, `App-FuguVM`, and `Fugu`. PAUSE
+  grants indexing permission on that module first, and none exists.
+- A `$VERSION` policy. No module carries one, and PAUSE does not index a module
+  without a version.
 - `no_index` metadata for the packages that live inside another file:
   `Protocol::HAP::Log::Null`, `Protocol::HAP::SRP::Client`,
   `Fugu::Control::Client`, `Fugu::Proxy::Cache`, `Fugu::Proxy::Meta`, and
@@ -67,42 +74,44 @@ tree. It lists what a release of any distribution here still needs:
 - Distribution tooling: `Makefile.PL` or `Build.PL`, `MANIFEST`, and
   distribution tests.
 - The redistribution-license review of `spec/`.
-- The open naming question: `Fugu::MQTT`, `Fugu::MDNS`, `Fugu::SSH`, and
-  `Fugu::Proxy` may belong under `Net::` or `HTTP::`. Each needs a study of the
-  existing module in that namespace before it moves.
+- The open naming questions: `Fugu::MQTT`, `Fugu::SSH`, and `Fugu::Proxy` may
+  belong under `Net::` or `HTTP::`. `Fugu::MDNS` needs a different question
+  first, because it does not implement mDNS: it is a control client for
+  `mdnsd(8)`, so the name promises more than the module holds.
 - The descriptor-passing subset of `Protocol::Imsg`, from phase 4.
 
-### 5.6 Sweep the tree
+### 5.6 Close the sweep
 
-Run the greps from every phase one more time, from the repository root, with
-`plans/` excluded. Each must find nothing:
-
-```sh
-grep -rn 'FuguLib\|fugulib' --exclude-dir=.git --exclude-dir=plans .
-grep -rn 'OpenHAP::' --exclude-dir=.git --exclude-dir=plans . | grep -v 'App::'
-grep -rn 'FuguVM::' --exclude-dir=.git --exclude-dir=plans . | grep -v 'App::'
-grep -rn 'Fugu::Util\|FuguVM::VM\|FuguVM::Expect' --exclude-dir=.git \
-    --exclude-dir=plans .
-```
+- `t/scripts/namespaces.t` now holds every retired name from phases 1 to 5.
+  Confirm the list against the design's rename table, and confirm the test reads
+  tracked files only.
+- Run it against a dirty tree: `make web` and `make package` first, so that
+  `build/` and `web/build/` hold generated pages under the old names. The test
+  must still pass, because generated output is not tracked.
+- Plant one shim of each kind and confirm the test fails: a stale `use`, an
+  `@ISA` bridge in a new file under the old path, a stale name in a `.pod` line
+  that also names a live module, and a stale name in a manual page.
 
 ## Deliverables
 
 - `lib/Fugu/Timeout.pm`, `man/fugu/Timeout.3p`, and `t/fugu/timeout.t`.
 - `App::FuguVM::CLI` with the private `_format_size`, and the moved subtests in
   `t/fuguvm/cli.t`.
+- A complete `t/scripts/namespaces.t` retired list.
 - Updated `web/fugu.body.html`, `web/index.body.html`, root `CLAUDE.md`,
-  `t/CLAUDE.md`, `t/openhap/integration/CLAUDE.md`, `README.md`, `INSTALL.md`,
-  and `TODO.md`.
+  `t/CLAUDE.md`, `t/openhap/integration/CLAUDE.md`, and `TODO.md`.
 
 ## Acceptance criteria
 
-- `make check` passes.
-- The four greps in task 5.6 find nothing.
-- `grep -rn 'format_size' lib/Fugu man/fugu` finds nothing.
-- `make web` builds, and `t/web/site.t` passes with the final page list.
+- `make check` passes, and so do `make prettier`, `make web`, and
+  `mandoc -Tlint -W warning` over every manual page.
+- `t/scripts/namespaces.t` passes on a clean tree and on a built tree, and fails
+  on each of the four planted shims.
+- `grep -n 'format_size' lib/Fugu/Timeout.pm man/fugu/Timeout.3p` finds nothing.
 - `make install DESTDIR=...` into an empty directory produces only `App/`,
   `Fugu/`, and `Protocol/` under `$(LIBDIR)`, and only `Fugu::*.3p` under
   `man3p/`.
-- `make integration` passes.
-- The repository contains no alias, no `@ISA` bridge, no compatibility module,
-  and no migration note for an older install.
+- `make uninstall DESTDIR=...` leaves an unrelated `App::` or `Protocol::`
+  module in place.
+- `make integration` passes on a guest that was purged of every old install
+  path.


### PR DESCRIPTION
Plan 008 aligns every namespace and module name with the PAUSE guidance in
"On The Naming of Modules".

The repository claims three top-level namespaces today. `Lib` says nothing,
`OpenHAP` and `FuguVM` are applications, and nine module names name a
mechanism, claim a capability the module does not hold, or use a word the
specification replaced.

## Target

- `OpenHAP::` becomes `App::OpenHAP::`, and `FuguVM::` becomes `App::FuguVM::`.
- `FuguLib::` becomes `Fugu::`, the one top-level name that stays.
- `Protocol::Imsg` splits out of `FuguLib::Imsg`: the codec is sans-IO, and
  `Fugu::Imsg` keeps the socket.
- Eleven modules get a name that says what they do, among them
  `App::OpenHAP::Host`, `App::FuguVM::Console`, `App::FuguVM::Miniroot`,
  `Fugu::Mdnsd`, `Fugu::StateFile`, and `Protocol::HAP::SetupCode`.

## Five phases

1. `Fugu::`, plus two gates that later phases need.
2. `App::OpenHAP::`.
3. `App::FuguVM::`.
4. `Protocol::Imsg`.
5. The leaf renames and the documentation pass.

## Clean break

The plan is evergreen. No aliases, no `@ISA` bridges, no deprecation period,
and no upgrade path. A new `t/scripts/namespaces.t` gates the rule, because
nothing in `make check` detects a shim today.

## Review

Five cold sub-agents attacked the design and the phases, as the root
`CLAUDE.md` requires. Their confirmed findings are in the second commit: the
rename breaks six mechanisms that no grep can see, `t/protocol/boundary.t`
stops enforcing the layering rule after phase 2, and the `Protocol::Imsg`
split needs a re-exported constant to compile at all.

No naming question is left open. The design records the names that stay,
with their reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CDMjXoUfPe8apj5rKZunw

---
_Generated by [Claude Code](https://claude.ai/code/session_013CDMjXoUfPe8apj5rKZunw)_