### PR TITLE
docs(protocol): resolve trade-off 3 of plan 008

### DIFF
--- a/plans/008-cpan-namespaces/design.md
+++ b/plans/008-cpan-namespaces/design.md
@@ -41,8 +41,12 @@ The project has no users. A clean break is possible.
    specification has replaced.
 4. `Protocol::Imsg` is a sans-IO codec. `Fugu::Imsg` owns the socket and uses
    the codec.
-5. Behavior does not change, with one exception: `hapctl` prints a device class,
-   so its output and its manual change with the package names.
+5. Every implementation of a `Protocol::` contract lives beside the contract.
+   `Protocol::HAP::Store::File` joins `Protocol::HAP::Store::Memory`, and one
+   test proves the contract over both.
+6. Behavior does not change, with two exceptions: `hapctl` prints a device
+   class, so its output and its manual change with the package names, and the
+   file store takes the path of its directory from the caller.
 
 The products keep their names. The daemon is still OpenHAP, the command is still
 `openhapd`, and the VM utility is still FuguVM. The one exception is FuguLib:
@@ -53,15 +57,16 @@ changes with the packages.
 
 - No CPAN release. No `$VERSION`, no `Makefile.PL`, no distribution main
   modules, and no `no_index` metadata. `TODO.md` records that work.
-- No new features and no API changes, except the two that a rename forces: the
-  split of `FuguLib::Util` and the split of `FuguLib::Imsg`.
+- No new features and no API changes, except the three that this effort forces:
+  the split of `FuguLib::Util`, the split of `FuguLib::Imsg`, and the move of
+  the file store into `Protocol::HAP`.
 
 No naming question is out of scope. This is the naming effort, so every name in
 the tree is decided here, and none is recorded for later.
 
 ## Accepted trade-offs
 
-Three choices in this design have a real argument against them. Take them
+Four choices in this design have a real argument against them. Take them
 knowingly.
 
 1. **`App::` holds no command implementations.** `bin/openhapd` and `bin/hapctl`
@@ -74,12 +79,16 @@ knowingly.
    protocols. `OpenBSD::` is the honest alternative and it is unusable: OpenBSD
    base perl owns that namespace with `OpenBSD::Pledge`, `OpenBSD::Unveil`, and
    the `pkg_add` tree. `Protocol::Imsg` states the limit in its first paragraph.
-3. **`App::OpenHAP::Store::File` sits far from the contract it implements.**
-   Someone who takes `Protocol::HAP` to CPAN and wants file persistence will
-   look for `Protocol::HAP::Store::File`. It cannot live there: it uses
-   `Fugu::File`, and the layering rules forbid that direction. Goal 3 does not
-   claim unique leaf names either. `Proxy`, `Config`, and `CLI` each repeat,
-   every time as a subclass of the `Fugu::` module with the same leaf name.
+3. **`Protocol::HAP::Store::File` opens files inside the protocol tier.** The
+   tier holds a sans-IO engine, and a store that writes files is not sans-IO.
+   Accept it, because sans-IO describes `Protocol::HAP::Server`, and the store
+   is the injected seam that keeps the engine pure. `Protocol::HAP::Controller`
+   already opens TCP sockets in this tier, so four files set no new precedent.
+   The alternative puts the only file store of `Protocol::HAP::Store` where no
+   user of the library looks for it.
+4. **Leaf names repeat.** Goal 3 does not claim unique leaf names. `Proxy`,
+   `Config`, and `CLI` each repeat, every time as a subclass of the `Fugu::`
+   module with the same leaf name.
 
 ## The clean-break rule
 
@@ -116,22 +125,22 @@ live one, and `grep -r` reads the generated pages in `build/` and `web/build/`.
 
 ### Modules that change name
 
-| Now                          | Target                           | Reason                                                      |
-| ---------------------------- | -------------------------------- | ----------------------------------------------------------- |
-| `OpenHAP::Server`            | `App::OpenHAP::Host`             | It hosts the engine. Two modules must not both be `Server`. |
-| `OpenHAP::Storage`           | `App::OpenHAP::Store::File`      | It implements `Protocol::HAP::Store` in a file.             |
-| `OpenHAP::DeviceLoader`      | `App::OpenHAP::Devices`          | It holds the devices. `Loader` names the mechanism.         |
-| `FuguVM::VM`                 | `App::FuguVM::Guest`             | The name must not repeat the parent.                        |
-| `FuguVM::Expect`             | `App::FuguVM::Console`           | It drives the serial console. `Expect` is the dependency.   |
-| `OpenHAP::Tasmota::Base`     | `App::OpenHAP::Tasmota::Device`  | `Base` names a mechanism, as `Loader` did.                  |
-| `FuguVM::Image`              | `App::FuguVM::Miniroot`          | It downloads and caches the install media.                  |
-| `FuguVM::ImageCache`         | `App::FuguVM::DiskCache`         | It caches installed qcow2 disks, not the media above.       |
-| `FuguLib::Util`              | `Fugu::Timeout`                  | `bounded` and `wait_until` are one idea.                    |
-| `FuguLib::Util::format_size` | `App::FuguVM::CLI::_format_size` | The command-line interface is its only caller.              |
-| `FuguLib::Store`             | `Fugu::StateFile`                | Its own abstract calls it a JSON state file.                |
-| `FuguLib::MDNS`              | `Fugu::Mdnsd`                    | It controls `mdnsd(8)`. It does not implement mDNS.         |
-| `FuguLib::Imsg`              | `Fugu::Imsg` + `Protocol::Imsg`  | The codec and the socket separate.                          |
-| `Protocol::HAP::PIN`         | `Protocol::HAP::SetupCode`       | The specification says "setup code" [HAP-Pairing §2].       |
+| Now                          | Target                           | Reason                                                       |
+| ---------------------------- | -------------------------------- | ------------------------------------------------------------ |
+| `OpenHAP::Server`            | `App::OpenHAP::Host`             | It hosts the engine. Two modules must not both be `Server`.  |
+| `OpenHAP::Storage`           | `Protocol::HAP::Store::File`     | It implements `Protocol::HAP::Store`, so it joins that tier. |
+| `OpenHAP::DeviceLoader`      | `App::OpenHAP::Devices`          | It holds the devices. `Loader` names the mechanism.          |
+| `FuguVM::VM`                 | `App::FuguVM::Guest`             | The name must not repeat the parent.                         |
+| `FuguVM::Expect`             | `App::FuguVM::Console`           | It drives the serial console. `Expect` is the dependency.    |
+| `OpenHAP::Tasmota::Base`     | `App::OpenHAP::Tasmota::Device`  | `Base` names a mechanism, as `Loader` did.                   |
+| `FuguVM::Image`              | `App::FuguVM::Miniroot`          | It downloads and caches the install media.                   |
+| `FuguVM::ImageCache`         | `App::FuguVM::DiskCache`         | It caches installed qcow2 disks, not the media above.        |
+| `FuguLib::Util`              | `Fugu::Timeout`                  | `bounded` and `wait_until` are one idea.                     |
+| `FuguLib::Util::format_size` | `App::FuguVM::CLI::_format_size` | The command-line interface is its only caller.               |
+| `FuguLib::Store`             | `Fugu::StateFile`                | Its own abstract calls it a JSON state file.                 |
+| `FuguLib::MDNS`              | `Fugu::Mdnsd`                    | It controls `mdnsd(8)`. It does not implement mDNS.          |
+| `FuguLib::Imsg`              | `Fugu::Imsg` + `Protocol::Imsg`  | The codec and the socket separate.                           |
+| `Protocol::HAP::PIN`         | `Protocol::HAP::SetupCode`       | The specification says "setup code" [HAP-Pairing §2].        |
 
 Three of these need a word. `Console`, not `Installer`, because the module has
 two public verbs and `fuguvm expect <script>` is a documented subcommand that
@@ -179,6 +188,35 @@ failing. Phase 2 must widen it to `^App\b`, and phase 4 must add the
 `Protocol::` allowlist. The plans call this out because the acceptance greps
 cannot see it: the literal text is `OpenHAP)`, with no trailing colons.
 
+## The file store
+
+`OpenHAP::Storage` holds nothing that is specific to the host. It keeps the
+twelve contract methods, the key files, the pairings format, and the counters.
+All four are HAP, so the module moves to `Protocol::HAP::Store::File` whole.
+
+Three host dependencies go away. None of them is deep.
+
+- `FuguLib::Log` becomes an injected `logger`, with `Protocol::HAP->null_logger`
+  as the default. Every other class in the tier already takes that argument.
+- `FuguLib::File` gives the store four of its eleven functions: `read`, `write`
+  with a mode, `write_atomic`, and `ensure_dir`. The replacement is about 80
+  lines over `Fcntl` and `File::Path`. `atomic_dir`, `sweep_temp`, `share_path`,
+  `expand_tilde`, and `valid_name` do not follow it.
+- `FuguLib::Store` gives the store a JSON file of counters. The replacement is
+  about 40 lines over `JSON::PP`, and it keeps the atomic write.
+
+`Fcntl`, `File::Path`, and `JSON::PP` are core Perl, so direction one of the
+layering rules already permits all three. The boundary test needs no new entry.
+
+The duplicated logic that matters is the mode at the open. Two copies of that
+rule can drift, and the rule protects the identity of the accessory. Thus one
+test asserts the mode of every file that the store creates. Nothing asserts the
+mode of `accessory_ltsk` or `pairings.db` today, so this is a gain, not a cost.
+
+`db_path` becomes `path`, and it is required. The `/var/db/openhapd` default
+moves to `openhapd`, beside the other path policy. Nothing else about the
+constructor changes, and the layout on disk does not change at all.
+
 ## The Imsg contract
 
 `Protocol::Imsg` is pure. It takes bytes and returns bytes.
@@ -217,7 +255,7 @@ graph TD
     fuguvm[bin/fuguvm] --> VC[App::FuguVM::CLI] --> G[App::FuguVM::Guest]
     G --> I[App::FuguVM::Console]
     H --> PS[Protocol::HAP::Server]
-    H --> SF[App::OpenHAP::Store::File] -. store contract .-> PS
+    H --> SF[Protocol::HAP::Store::File] -. store contract .-> PS
     H --> FH[Fugu: EventLoop Log MQTT MDNS Timeout]
     D --> TAS[App::OpenHAP::Tasmota::*]
     FM[Fugu::Mdnsd] --> FI[Fugu::Imsg] --> PI[Protocol::Imsg]
@@ -256,8 +294,10 @@ distribution on the machine, and `App/` would be worse.
 
 1. `FuguLib::` becomes `Fugu::`. Names only, plus the two gates that later
    phases depend on: `t/scripts/namespaces.t` and the CI compile step.
-2. `OpenHAP::` becomes `App::OpenHAP::`, with `Host`, `Store::File`, `Devices`,
-   and `Tasmota::Device`.
+2. `OpenHAP::` becomes `App::OpenHAP::`, with `Host`, `Devices`, and
+   `Tasmota::Device`. `OpenHAP::Storage` leaves the host for
+   `Protocol::HAP::Store::File`, in a commit of its own: it is the one rewrite
+   in this effort, and a bisect must separate it from the namespace move.
 3. `FuguVM::` becomes `App::FuguVM::`, with `Guest`, `Console`, `Miniroot`, and
    `DiskCache`.
 4. `Protocol::Imsg` splits out of `Fugu::Imsg`.

--- a/plans/008-cpan-namespaces/plan-2.md
+++ b/plans/008-cpan-namespaces/plan-2.md
@@ -25,18 +25,37 @@ The phase depends on phase 1. Phase 3 depends on this one.
 - Users: `bin/openhapd`, `t/openhap/server.t`, and the comments in
   `t/protocol/server.t`.
 
-### 2.3 OpenHAP::Storage becomes App::OpenHAP::Store::File
+### 2.3 OpenHAP::Storage becomes Protocol::HAP::Store::File
 
-- `mkdir lib/App/OpenHAP/Store`, then `git mv` the module and its sidecar into
-  it as `File.pm` and `File.pod`.
-- The name states the contract and the medium. The module cannot live in
-  `Protocol::HAP::Store::File`, because it uses `Fugu::File` and the layering
-  rules forbid that direction. Say so in the sidecar.
-- The twelve contract methods do not change. This is a rename, not a rewrite.
-- Users: `bin/openhapd` and `t/openhap/storage.t`.
-- `lib/Protocol/HAP/Store.pod:11` names `OpenHAP::Storage` in prose. It is a
-  shipped `.pod` that `make web` publishes, and `t/protocol/boundary.t` reads
-  `.pm` files only, so nothing else catches it.
+This task is the one rewrite in the effort. Land it in a commit of its own, so a
+bisect separates it from the namespace move. Task 2.1 must not carry the module
+into `lib/App/OpenHAP/` first: the old name and its replacement never exist
+together, and a move to `App::` would be a name that this task deletes.
+
+- `git mv lib/OpenHAP/Storage.pm lib/Protocol/HAP/Store/File.pm`, and the
+  sidecar with it as `File.pod`. The directory already holds `Memory.pm`.
+- The twelve contract methods keep their behavior, and the layout on disk does
+  not change. Three host dependencies go, as the design describes:
+  - `FuguLib::Log` becomes a `logger` argument, with
+    `Protocol::HAP->null_logger` as the default.
+  - `FuguLib::File` becomes private `_read`, `_write`, `_write_atomic`, and
+    `_ensure_dir` methods over `Fcntl` and `File::Path`. `_write` takes the mode
+    and applies it at the `sysopen`. A `chmod` after the write is a fault, not a
+    style choice.
+  - `FuguLib::Store` becomes a private JSON file over `JSON::PP`. Keep the two
+    guarantees of `Fugu::Store`: `load` tolerates a missing and a corrupt file,
+    and `save` writes through a temporary file and renames over the target.
+- `Fcntl`, `File::Path`, and `JSON::PP` are core Perl, so `%DECLARED` in
+  `t/protocol/boundary.t` needs no new entry. Prove that the test still passes.
+- `db_path` becomes `path`, and `new` dies without it. The `/var/db/openhapd`
+  default moves to `bin/openhapd`, beside the other path policy.
+- Users: `lib/OpenHAP/Server.pm:78`, which becomes
+  `Protocol::HAP::Store::File->new( path => ..., logger => Fugu::Log->default )`.
+- `lib/Protocol/HAP/Store.pod:11` names `OpenHAP::Storage` as a production
+  implementation elsewhere. It now names `Protocol::HAP::Store::File` as the
+  file implementation in this distribution. It is a shipped `.pod` that
+  `make web` publishes, and `t/protocol/boundary.t` reads `.pm` files only, so
+  nothing else catches it.
 
 ### 2.4 OpenHAP::DeviceLoader becomes App::OpenHAP::Devices
 
@@ -67,7 +86,10 @@ The phase depends on phase 1. Phase 3 depends on this one.
 ### 2.7 Retarget the callers
 
 - `bin/openhapd`: the `use OpenHAP::DeviceLoader` and `use OpenHAP::Server`
-  lines, and the `Storage` constructor call.
+  lines. The daemon now owns the `/var/db/openhapd` default, per task 2.3.
+- `bin/openhapd:282` and the pledge comment at `bin/openhapd:296` to `:300` name
+  `Storage` six times. The promises do not change: the same module makes the
+  same calls under a new name. Only the name in the comments changes.
 - `bin/openhapd:380` is
   `push @perl_dirs, $script_lib if -d "$script_lib/OpenHAP";`. This is a
   filesystem probe on a directory name, not a package name, so no grep for
@@ -80,9 +102,20 @@ The phase depends on phase 1. Phase 3 depends on this one.
 
 ### 2.8 Move and retarget the tests
 
-- `git mv t/openhap/server.t t/openhap/host.t` and
-  `git mv t/openhap/storage.t t/openhap/store-file.t`. The tier directory keeps
-  its name: it is named after the product, not the namespace.
+- `git mv t/openhap/server.t t/openhap/host.t`. The tier directory keeps its
+  name: it is named after the product, not the namespace.
+- `git mv t/openhap/storage.t t/protocol/store-file.t`. The test follows its
+  module into the protocol tier. Keep the file-specific assertions here: the
+  layout on disk, the counters that survive a restart, and the mode of every
+  file that the store creates. Nothing asserts the mode of `accessory_ltsk` or
+  `pairings.db` today, and both must be 0600 from their first byte.
+- Add `t/protocol/store.t`: the twelve contract methods of
+  `Protocol/HAP/Store.pod`, driven over `Store::Memory` and `Store::File` from
+  one loop. It replaces the `can` loop at the end of `t/openhap/storage.t`,
+  which proved that the methods exist and never that they agree. Above all it
+  proves the increment rule that `Store.pod` calls a rule with no slack: each of
+  `save_pairing`, `remove_pairing`, and `remove_all_pairings` moves `c#` by one,
+  in both implementations.
 - `mkdir -p t/lib/App`, then `git mv t/lib/OpenHAP t/lib/App/OpenHAP`, and
   rename the `OpenHAP::TestMock::MQTT` package. Retarget the four
   `t/conformance/mqtt-*.t` files that load it.
@@ -106,8 +139,10 @@ The phase depends on phase 1. Phase 3 depends on this one.
 
 - `Makefile`: `install`, `package`, and `uninstall` name `$(LIBDIR)/OpenHAP`,
   `/OpenHAP/Tasmota`, and `/OpenHAP/Test`. Each gains the `App/` level, and
-  `install -d $(DESTDIR)$(LIBDIR)/App` comes first. The `Store/` subdirectory
-  needs a directory rule and a copy rule.
+  `install -d $(DESTDIR)$(LIBDIR)/App` comes first. The store needs no new rule:
+  the `lib/Protocol/HAP/Store/*` loops at `Makefile:137` and `Makefile:217`
+  already cover it, and the comment at `Makefile:130` that the loop accepts zero
+  files is now stale, because the directory holds two modules.
 - `uninstall` must not do `rm -rf $(DESTDIR)$(LIBDIR)/App`. `App/` is a shared
   parent that holds other distributions, such as `App::cpanminus`. Remove
   `App/OpenHAP` and then `rmdir` the parent, which fails harmlessly when the
@@ -130,6 +165,10 @@ The phase depends on phase 1. Phase 3 depends on this one.
   group and its `id="modules"` anchor vanish from `manuals.html`.
   `web/index.body.html` links `manuals.html#modules`, and `t/web/site.t`
   requires that anchor to resolve. Line 60 names the path in a comment.
+- The store sidecar changes group. `web/mkindex.sh:150` already covers it with
+  the `lib/Protocol/` prefix, so `Store/File.pod` leaves the `OpenHAP modules`
+  group and joins `Protocol::HAP modules` with no edit. The total sidecar count
+  does not change: the file moves, it does not appear.
 - `t/web/site.t:203` matches `^(?:OpenHAP|FuguVM|Protocol)::` and asserts one
   page per sidecar at line 206. This phase sets it to
   `^(?:App|FuguVM|Protocol)::`. `FuguVM` must stay until phase 3, because 11
@@ -149,10 +188,10 @@ The phase depends on phase 1. Phase 3 depends on this one.
 
 ## Deliverables
 
-- `lib/App/OpenHAP/` with `Host.pm`, `Devices.pm`, `Store/File.pm`,
-  `Tasmota/Device.pm`, the four device classes, and `Test/Integration.pm`, each
-  with a `.pod` sidecar.
-- `t/openhap/host.t`, `t/openhap/store-file.t`, and
+- `lib/App/OpenHAP/` with `Host.pm`, `Devices.pm`, `Tasmota/Device.pm`, the four
+  device classes, and `Test/Integration.pm`, each with a `.pod` sidecar.
+- `lib/Protocol/HAP/Store/File.pm` and `File.pod`, with no `Fugu::` import.
+- `t/openhap/host.t`, `t/protocol/store-file.t`, `t/protocol/store.t`, and
   `t/lib/App/OpenHAP/TestMock/MQTT.pm`.
 - Updated `Makefile`, `scripts/integration`, `scripts/vm-provision`,
   `.github/workflows/integration.yml`, `bin/openhapd`, `bin/hapctl`,
@@ -169,7 +208,15 @@ The phase depends on phase 1. Phase 3 depends on this one.
 - `t/protocol/boundary.t` fails correctly on a planted `use App::OpenHAP::Host;`
   inside `lib/Fugu/`. Prove it once by hand.
 - `make install DESTDIR=...` into an empty directory installs
-  `$(LIBDIR)/App/OpenHAP/Store/File.pm`, and no `$(LIBDIR)/OpenHAP` path.
+  `$(LIBDIR)/Protocol/HAP/Store/File.pm`, and no `$(LIBDIR)/OpenHAP` path.
+- `t/protocol/boundary.t` passes over the new `lib/Protocol/HAP/Store/File.pm`,
+  and fails correctly on a planted `use Fugu::File;` inside it.
+- `t/protocol/store.t` fails correctly when one implementation skips the
+  increment in `remove_pairing`. Prove it once by hand, in each implementation.
+- `t/protocol/store-file.t` asserts mode 0600 on `accessory_ltsk`,
+  `pairings.db`, and `state.json`, and mode 0644 on `accessory_ltpk`.
+- A paired daemon still starts: `make integration` covers this, and the store
+  reads a directory that the previous run wrote.
 - `make uninstall DESTDIR=...` against a directory that also holds
   `$(LIBDIR)/App/Other.pm` and `$(LIBDIR)/Protocol/Other.pm` leaves both files
   in place.

--- a/plans/008-cpan-namespaces/plan-2.md
+++ b/plans/008-cpan-namespaces/plan-2.md
@@ -34,6 +34,9 @@ together, and a move to `App::` would be a name that this task deletes.
 
 - `git mv lib/OpenHAP/Storage.pm lib/Protocol/HAP/Store/File.pm`, and the
   sidecar with it as `File.pod`. The directory already holds `Memory.pm`.
+- `File.pod` documents `new`, the layout on disk, and the mode of each file. It
+  does not document the twelve methods: `Store.pod` owns those, and every fact
+  lives in one place. `Memory.pod` is the model — follow what it does.
 - The twelve contract methods keep their behavior, and the layout on disk does
   not change. Three host dependencies go, as the design describes:
   - `FuguLib::Log` becomes a `logger` argument, with
@@ -121,6 +124,16 @@ together, and a move to `App::` would be a name that this task deletes.
   `t/conformance/mqtt-*.t` files that load it.
 - Retarget the six `t/conformance/hap-*.t` files and the 17 files under
   `t/openhap/integration/` that name an `OpenHAP::` module.
+- Two conformance files build the store themselves, and both need the new
+  constructor argument, not only the new package name:
+  - `t/conformance/hap-pairing.t:37` imports it, and `:51` and `:626` call
+    `new( db_path => tempdir(...) )`. Both become `path =>`.
+  - `t/conformance/hap-tlv8.t:219` does `require OpenHAP::Storage` inside a
+    subtest, and `:222` calls `new( db_path => ... )`. A grep for
+    `use OpenHAP::` does not find the `require`, so name it here.
+  - Both files now load a `Protocol::` module only. That is what they should
+    have done from the start: a conformance test of the pairing wire format has
+    no reason to build a host.
 - `t/protocol/boundary.t` needs both patterns changed in this phase:
   - Direction one, line 73, is `^(?:Fugu|FuguVM|OpenHAP)\b` after phase 1. It
     becomes `^(?:Fugu|FuguVM|App)\b`. `FuguVM` needs its own alternative until

--- a/plans/008-cpan-namespaces/plan-4.md
+++ b/plans/008-cpan-namespaces/plan-4.md
@@ -6,6 +6,11 @@ socket is host policy. This phase separates them.
 
 The phase depends on phase 1 only.
 
+Phase 2 does the same thing to the file store, and it lands earlier in the
+order. This phase does not depend on it, but it repeats its shape: a part with
+no host policy in it joins the `Protocol::` tier and keeps its behavior, while
+the caller keeps the policy — the socket here, the default path there.
+
 ## Tasks
 
 ### 4.1 Create Protocol::Imsg
@@ -122,8 +127,11 @@ them split rather than move.
 ### 4.7 Update the documentation
 
 - Root `CLAUDE.md`: the `lib/Protocol/` row in Layout describes the
-  `Protocol::HAP` library. It now holds two libraries. State that `Protocol::`
-  is the sans-IO tier.
+  `Protocol::HAP` library. It now holds two libraries. Do not call `Protocol::`
+  the sans-IO tier: `Protocol::HAP::Server` and `Protocol::Imsg` are sans-IO,
+  and `Protocol::HAP::Controller` and `Protocol::HAP::Store::File` are not.
+  State the rule that does hold: `Protocol::` uses core Perl and its declared
+  CPAN modules, and never `Fugu::` or `App::`.
 - `t/CLAUDE.md`: the `t/protocol/` tier row says "the Protocol::HAP library".
 - `TODO.md`: record that a `Protocol-Imsg` distribution needs descriptor passing
   or an explicit statement of the subset, and that the native-endian header

--- a/plans/008-cpan-namespaces/plan-5.md
+++ b/plans/008-cpan-namespaces/plan-5.md
@@ -34,8 +34,10 @@ The phase depends on phases 1 to 3. It does not depend on phase 4.
 - The rename also ends the three-`Store` problem. After it, `Store` in this tree
   means the `Protocol::HAP` persistence contract and its two implementations,
   and nothing else.
-- Users: `Fugu::Proxy`, `App::OpenHAP::Store::File`, `App::FuguVM::State` and
-  its `.pod`, `t/fugu/proxy.t`, and `t/fuguvm/proxy.t`.
+- Users: `Fugu::Proxy`, `App::FuguVM::State` and its `.pod`, `t/fugu/proxy.t`,
+  and `t/fuguvm/proxy.t`. `Protocol::HAP::Store::File` is not among them: phase
+  2 gave it a private JSON file, because `Fugu::` is closed to the protocol
+  tier.
 - `git mv t/fugu/store.t t/fugu/statefile.t`.
 
 ### 5.3 Fugu::MDNS becomes Fugu::Mdnsd


### PR DESCRIPTION
## What changes

Plan 008 accepted trade-off 3: `App::OpenHAP::Store::File` sits far from the contract it implements. Its stated reason was that the module uses `Fugu::File`, and the layering rules forbid that direction.

The reason does not hold, so the design no longer accepts the cost. `OpenHAP::Storage` goes to `Protocol::HAP::Store::File`, beside `Store::Memory` and `Store.pod`.

This PR changes `plans/` only. No code moves here.

## Why the reason does not hold

Three host dependencies, all shallow:

| Dependency | What the store uses | Why it is not a blocker |
| --- | --- | --- |
| `FuguLib::Log` | four log calls | The tier already injects loggers. `Protocol::HAP->null_logger` is the default, and every other class takes `logger =>`. |
| `FuguLib::File` | 4 of 11 functions | About 80 lines over `Fcntl` and `File::Path`, both core Perl. |
| `FuguLib::Store` | a JSON file of counters | About 40 lines over `JSON::PP`, core since Perl 5.14. |

Direction one of the layering rules already permits core Perl, so `t/protocol/boundary.t` needs no new entry.

## The new trade-off 3

The honest one: the protocol tier now opens files. Accept it, because sans-IO describes `Protocol::HAP::Server`, and `Protocol::HAP::Controller` already opens TCP sockets in the same tier. The repeated leaf names that the old trade-off 3 also covered become trade-off 4, so nothing is lost.

## Plan changes

- `design.md` — trade-off 3 rewritten, new `## The file store` section, goal 5 added, the rename table row, the mermaid node, and the phase-2 summary
- `plan-2.md` — task 2.3 becomes the extraction in a commit of its own; the test moves to `t/protocol/store-file.t`; a new `t/protocol/store.t` drives the twelve methods over both implementations; mode assertions on every file the store creates; the two conformance call sites that need `path =>` in place of `db_path =>`
- `plan-4.md` — task 4.7 no longer calls `Protocol::` the sans-IO tier, which the store move and `Controller` both contradict
- `plan-5.md` — the store leaves the `Fugu::StateFile` user list

## Two gains beyond the naming

- One test proves the increment rule over both implementations. Today `Store.pod` calls it a rule with no slack, and nothing checks that the two implementations agree.
- `plan-2.md` adds mode assertions. Nothing asserts the mode of `accessory_ltsk` or `pairings.db` today, and both hold secrets.

## Testing

`make prettier` passes. No code changed, so `make check` is unaffected.

## Note

`design.md` is now 312 lines against the 200-line aim in `CLAUDE.md`. It was 273 before. Trimming it, or splitting phase 2, is a separate decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNVdVYmCuWV3yZ3oMiT2NC)_