### PR TITLE
docs(plans): add plan 009 for the App::FuguWeb extraction

### DIFF
--- a/plans/009-app-fuguweb/design.md
+++ b/plans/009-app-fuguweb/design.md
@@ -1,0 +1,296 @@
+# App::FuguWeb extraction — Design
+
+## Problem
+
+`make web` builds the website from two `sh` scripts and a 60-line recipe. The
+recipe holds the project knowledge, not the tooling: the page list, the page
+titles, the four named mdoc pages, the manual-namespace prefix rule, the
+`pod2man` options, and the asset list. `web/mkindex.sh` holds a six-row group
+table in its own body. `web/head.html` holds the site name, the banner, and the
+navigation.
+
+No other project can reuse this. A second project must copy both scripts, copy
+the recipe, and then edit both copies. The same facts also exist four times: in
+the `Makefile` recipe, in `web/head.html`, in `@SITE` and `@NAV` in
+`t/web/site.t`, and in the path filter of `.github/workflows/web.yml`.
+
+Plan 008 measures the cost from the other side. It lists `web/mkindex.sh` among
+the six mechanisms that fail quietly under a rename, and four of its five phases
+must edit the same three web files by hand. Every project that copies this
+tooling inherits that tax.
+
+We plan to maintain more projects like OpenHAP. The tooling must become a Perl
+application that a project installs and configures.
+
+## Relation to plan 008
+
+**This effort starts after plan 008 lands.** Plan 008 renames every namespace,
+so this design names the results and not the current tree: `Fugu::` for every
+library the tool uses, `lib/App/OpenHAP/`, `lib/App/FuguVM/` and `lib/Protocol/`
+for the module groups, `man/fugu/` with the `Fugu::` staging prefix, and
+`fugu.html` in the navigation. It also extends two things plan 008 builds:
+`t/scripts/namespaces.t` and the layering rules.
+
+The dependency runs one way. Plan 008 does not need this effort. This effort
+cannot start before it, because every path and every package name would be
+wrong.
+
+Plan 008 also settles the naming question. PAUSE puts an application under
+`App::`, and `fuguweb` is an application. `App::FuguWeb` completes the trio and
+claims no new top-level name.
+
+## Goals
+
+1. `App::FuguWeb` builds a static documentation site for any Perl project that
+   uses mdoc(7) manuals, POD sidecars, and Markdown.
+2. `web/` holds content only: `*.body.html`, `robots.txt`, and `CNAME`.
+3. The `web` and `web-clean` targets run one command each.
+4. One file, `.fuguwebrc`, describes the site.
+5. The rendered site does not change. Every phase leaves the output
+   byte-identical to the reference build.
+6. The generic site checks become part of the tool, so every project gets them.
+
+## Non-goals
+
+- No CPAN release. PAUSE registration, `$VERSION` policy, and distribution
+  tooling are release work, recorded in `TODO.md`.
+- No new site features, and no change to the look of the site.
+- No `fuguweb.html` project page, and no seventh navigation item. The tool
+  reaches the site through `manuals.html`, like every other manual.
+- No replacement of `mandoc` or `lowdown` with Perl code.
+- No repository split.
+
+## Architecture
+
+### Modules
+
+New namespace under `lib/App/FuguWeb/`, with `bin/fuguweb` as the driver.
+`bin/fuguweb` copies `bin/fuguvm`: it adds `lib/` to `@INC` and calls
+`App::FuguWeb::CLI->run(@ARGV)`.
+
+| Module           | Source of the code                       | Function                                                        |
+| ---------------- | ---------------------------------------- | --------------------------------------------------------------- |
+| **App::FuguWeb** | new                                      | umbrella documentation and the shared escape                    |
+| **Config**       | the lists in `Makefile` and `mkindex.sh` | the site description over `Fugu::Config`                        |
+| **Page**         | `mkpage.sh`, `head.html`, `foot.html`    | build the chrome and wrap one body fragment                     |
+| **Render**       | the `Makefile` pipelines                 | run `mandoc`, `lowdown`, and `pod2man`; probe a missing tool    |
+| **Manual**       | `mkindex.sh` name and description code   | one manual source: path, name, section, page, description       |
+| **Index**        | `mkindex.sh`                             | build the body of `manuals.html` from the grouped manuals       |
+| **Site**         | the `web` target                         | probe, lint, stage, render, copy the assets, remove the staging |
+| **Check**        | the generic half of `t/web/site.t`       | check links, fragments, reachability, and the output inventory  |
+| **CLI**          | new                                      | subcommand dispatch over `Fugu::CLI`                            |
+
+### Layering
+
+Plan 008 states three rules: `Protocol::*` uses core Perl only, `Fugu::*` adds
+the `Protocol::` codecs on an allowlist, and `App::*` uses both. `App::FuguWeb`
+sits in the third group and adds one rule of its own:
+
+> A sibling application is not a library. `App::FuguWeb` never uses
+> `App::OpenHAP` or `App::FuguVM`, and neither uses `App::FuguWeb`.
+
+`t/fuguweb/boundary.t` enforces that rule in both directions.
+`t/protocol/boundary.t` keeps the three rules above; its `^App\b` pattern
+already covers the new namespace, so it needs no change.
+
+The tool uses `Fugu::CLI` for dispatch and the generic exit codes,
+`Fugu::Config` for the grammar and `find_project_root`, `Fugu::File` for reads,
+writes and `share_path`, `Fugu::Process` for the renderers, and `Fugu::Log` for
+diagnostics. The external tools stay external: `mandoc`, `lowdown`, and core
+`pod2man`. `App::FuguWeb` adds no CPAN dependency.
+
+`Fugu::Process->run` gains one option, `cwd`. `mandoc` resolves a `.Xr` target
+against its working directory, so the staging trick needs a child that starts
+somewhere else. A `chdir` in the parent would race every other relative path in
+the build. The option is generic, so it belongs in `Fugu`, with its own manual
+entry and its own test.
+
+### Subcommands
+
+```
+fuguweb build [--out <dir>]     render the whole site
+fuguweb clean [--out <dir>]     remove the output directory
+fuguweb check [--out <dir>]     check a built site
+fuguweb page <title>            wrap a body fragment from standard input
+fuguweb index                   write the body of the manual index
+fuguweb init                    write a starter .fuguwebrc
+```
+
+`page` and `index` exist because a project may want one page out of the set.
+`build` calls the same code.
+
+### The configuration file
+
+`.fuguwebrc` sits at the project root, and `Fugu::Config` parses it. The name
+and the discovery match `.fuguvmrc`. The grammar is line-based: a block header
+ends the line, and each setting takes a line of its own. A value may not hold a
+`#`, because the grammar has no escape for a comment.
+
+```
+site       = OpenHAP
+out_dir    = web/build
+source_dir = web
+entry      = index.html
+
+nav "fugu.html" {
+	label = Fugu
+}
+
+page "install.html" {
+	title    = Install
+	markdown = INSTALL.md
+}
+
+manuals "Fugu" {
+	dir       = man/fugu
+	anchor    = fugu
+	namespace = "Fugu::"
+}
+
+modules "OpenHAP modules" {
+	dir    = lib/App/OpenHAP
+	anchor = modules
+}
+```
+
+A `page` block names one of three sources: `body` for a fragment in
+`source_dir`, `markdown` for a Markdown file, or `index = yes` for the generated
+manual index. `unlinked = yes` marks a page that no other page links to, such as
+`404.html`. The other settings are `banner`, `lang`, `module_root`,
+`stylesheet`, `pod_center`, `pod_release`, `mandoc_os`, and `man_url`.
+
+Three rules keep lists out of the file:
+
+- A `manuals` block globs its directory for `*.1`, `*.3p`, `*.5`, and `*.8`. The
+  extension gives the section, and `namespace` prefixes the page name and the
+  staged file name.
+- A `modules` block finds every `*.pod` file below its directory. The name drops
+  the `module_root` prefix and maps `/` to `::`. A block must never name
+  `lib/App`, because that one directory holds three namespaces.
+- Every file in `source_dir` that does not end in `.body.html` is an asset, and
+  the build copies it. `robots.txt` and `CNAME` need no entry.
+
+The order of the index must not change, so the sort keys copy what the recipe
+produces today. A `manuals` group sorts by section, in the order 1, 3p, 5, 8,
+and then by file name in `LC_ALL=C` order. A `modules` group sorts by path in
+`LC_ALL=C` order, so `Store.pod` stays before `Store/Memory.pod`. The tool sorts
+the entries itself and never reads the locale of the builder.
+
+### The chrome and the theme
+
+`App::FuguWeb::Page` builds the document from the configuration and replaces the
+`sed` substitution, so a title may hold any character. The layout does not
+change. Two separators are not ASCII: an em dash between the title and the site
+name, and a middle dot between navigation entries. The module defines them as
+byte constants, because no file carries `use utf8` and `Fugu::File` reads and
+writes bytes.
+
+The footer text is project prose, so it stays content, in an optional
+`web/footer.body.html` fragment. `App::FuguWeb::Index` likewise puts an optional
+`web/manuals.body.html` fragment before the generated list.
+
+The tool ships the base stylesheet at `share/fuguweb/style.css`, found by
+`Fugu::File->share_path`. This is the current `web/style.css`, unchanged: both
+of its halves are project-neutral, the openbsd.org typography and the mandoc and
+`pod2man` class rules. A project may add `web/extra.css`; the asset rule copies
+it and `Page` links it after the base sheet.
+
+`share_path` resolves two levels above `lib/Fugu/File.pm` and then falls back to
+the working directory. That finds the sheet in a checkout, which is where
+`fuguweb` runs, as `fuguvm` does. It does not find the sheet from an installed
+CPAN distribution, where the data would sit under a `File::ShareDir` path.
+`TODO.md` records that with the other release work, and the `stylesheet` setting
+overrides the search, so a project is never blocked by it.
+
+### Facts that must survive the move
+
+`web/CLAUDE.md` records five findings, and each becomes a comment beside the
+code that depends on it. Two of them shape the design and not only a comment:
+
+1. `mandoc` picks a local or a remote `.Xr` target by looking for a file named
+   `%N.%S` in its working directory. That is why `Site` stages every mdoc source
+   in one directory, under its namespaced name, and why `Render` needs `cwd`.
+2. The build must not vary with the machine. `mandoc -I os=` pins the footer,
+   and `pod2man --date` gets the date of the last commit, because git does not
+   preserve file times.
+
+The other three are the `./` prefix on every local link, the `L<Module>` links
+that `pod2man` drops, and the named failure for a missing renderer.
+`mandoc -Tlint -W warning` over every mdoc source moves into `fuguweb build`.
+
+### The Makefile after the change
+
+```make
+FUGUWEB		?= bin/fuguweb
+
+web:
+	@$(FUGUWEB) build --out $(WEBOUT)
+
+web-clean:
+	@$(FUGUWEB) clean --out $(WEBOUT)
+```
+
+`LOWDOWN`, `POD2MAN`, `MKPAGE`, `MKINDEX`, `WEBMAN`, `FINDPOD`, and `MANHTML`
+all go. `MANDOC` stays only if the `%.cat*` rules of the `man` target still need
+it. `WEBOUT` stays: `t/web/site.t` and `.github/workflows/web.yml` both set it.
+
+`MAN1`, `MAN3P`, `MAN5`, and `MAN8` stay, because `install-man`, `package`,
+`uninstall`, and `man` still read them. The site no longer reads them, because a
+`manuals` block globs its directory instead. `fuguweb` is a development tool, so
+it joins `install`, `uninstall`, and `package` no more than `fuguvm` does.
+
+### Wiring after the change
+
+```mermaid
+graph TD
+    make[make web] --> bin[bin/fuguweb]
+    bin --> CLI[App::FuguWeb::CLI] --> Site[App::FuguWeb::Site]
+    CLI --> Check[App::FuguWeb::Check]
+    Site --> Config[App::FuguWeb::Config] --> FC[Fugu::Config]
+    Site --> Page[App::FuguWeb::Page]
+    Site --> Index[App::FuguWeb::Index] --> Manual[App::FuguWeb::Manual]
+    Site --> Render[App::FuguWeb::Render] --> FP[Fugu::Process]
+    Render --> tools[mandoc lowdown pod2man]
+    Site --> FF[Fugu::File]
+```
+
+## Rules
+
+- No package-level mutable state. Two sites in one process must not share state.
+- The build reads nothing from the network, writes nothing outside the output
+  directory, and gives the same bytes for the same checkout.
+- Documentation follows the root `CLAUDE.md` table: every `App::FuguWeb` module
+  gets a `.pod` sidecar, and `fuguweb` gets `man/fuguweb/fuguweb.1`. Only
+  `Fugu::` uses 3p pages.
+- The clean-break rule of plan 008 holds here. A deleted script never returns
+  under another name, and `t/scripts/namespaces.t` gains the retired file names.
+
+## Testing
+
+- New module tier `t/fuguweb/`, with the same rules as `t/fuguvm/`. A tier is
+  named after its product, so the `App::` prefix does not reach the directory
+  name. The `Makefile` test target and the tier table in `t/CLAUDE.md` gain the
+  entry.
+- The module tests build their sources in a `File::Temp` directory. They do not
+  read the repository, so a change under `man/` or `lib/` cannot break them.
+- `t/web/site.t` keeps its tooling-tier rule. It drives subprocesses:
+  `make web`, then `bin/fuguweb check`. It keeps only the OpenHAP-specific
+  assertions.
+- Take the reference build from the tip of the default branch, after plan 008
+  lands. Every phase then ends with a byte-for-byte comparison against it.
+- Each phase proves its failure mode once by hand before the commit.
+
+## Phases
+
+1. Page assembler: `App::FuguWeb`, `Config`, `Page`, `CLI`, `bin/fuguweb`, and
+   `.fuguwebrc`. `mkpage.sh`, `head.html`, and `foot.html` die.
+2. Manual index: `Manual` and `Index`. The group table moves into `.fuguwebrc`.
+   `mkindex.sh` dies, and `web/` holds no script.
+3. Whole build: `Render`, `Site`, and `cwd` in `Fugu::Process`. The stylesheet
+   moves to `share/fuguweb/`. The `web` target drops to one command.
+4. Checks and documentation: `Check`, the shrunk `t/web/site.t`,
+   `man/fuguweb/fuguweb.1`, and every affected `CLAUDE.md`, workflow, and
+   manifest.
+
+Each phase lands whole: the module, its callers, its tests, and its
+documentation change together, and `make check` passes at the end of each.

--- a/plans/009-app-fuguweb/plan-1.md
+++ b/plans/009-app-fuguweb/plan-1.md
@@ -1,0 +1,125 @@
+# Phase 1 — The page assembler
+
+This phase creates the `App::FuguWeb` namespace and the `.fuguwebrc` file. It
+moves the shared chrome out of `web/` and into the tool. The `Makefile` still
+drives the build, but it calls `fuguweb page` in place of `web/mkpage.sh`.
+
+Plan 008 must land first. This phase names `Fugu::` modules and the `fugu.html`
+page, and neither exists before it.
+
+## Tasks
+
+### 1.1 The umbrella module
+
+- Create `lib/App/FuguWeb.pm`. It holds the namespace overview comment, the
+  `CONFIG_FILE` constant, and the HTML escape that the other modules share.
+  Multiple packages in one file follow the style rules.
+- Create the `App/FuguWeb.pod` sidecar: what the tool is, the shape of
+  `.fuguwebrc`, and pointers to the per-module pods.
+- No `$VERSION`. Version policy is release work.
+
+### 1.2 App::FuguWeb::Config
+
+- Wrap `Fugu::Config`. The class reads `.fuguwebrc`, applies the defaults, and
+  validates the result.
+- Settings and their defaults: `site` (required), `banner` (defaults to `site`),
+  `lang` (`en`), `out_dir` (`web/build`), `source_dir` (`web`), `entry`
+  (`index.html`), `module_root` (`lib`), `pod_center`, `pod_release`,
+  `mandoc_os` (`OpenBSD`), `man_url` (`https://man.openbsd.org/`).
+- Accessors: `root`, `path`, `source_path`, one accessor for each setting, `nav`
+  (ordered list of `{ href, label }`), and `pages` (ordered list of
+  `{ file, title, source, value, unlinked }`).
+- `App::FuguWeb::Config->load(%args)` finds the root with
+  `Fugu::Config->find_project_root('.fuguwebrc')`, unless `root` says otherwise.
+  It returns undef and records the reason when the file is absent or does not
+  parse.
+- Reject a page block that names no source, or more than one source. Reject a
+  page file that two blocks declare. Reject a nav block with no label. Reject a
+  path setting that holds `..`, because a build must not write outside the
+  project. Name the file and the block in every message.
+- The manual and module groups arrive in phase 2. This phase ignores those
+  blocks.
+
+### 1.3 App::FuguWeb::Page
+
+- `App::FuguWeb::Page->new(config => $config)`.
+- `$page->document($title, $fragment)` returns the whole page as bytes.
+- `$page->write($path, $title, $fragment)` writes it with `Fugu::File`.
+- The chrome reproduces `web/head.html` and `web/foot.html` exactly: the
+  doctype, the `lang` attribute, the two meta elements, the title, the
+  stylesheet links, the banner, the navigation, a rule, `<main>`, the fragment,
+  a rule, the footer, and the closing tags.
+- Two separators are not ASCII: the em dash between the title and the site name
+  (`\xe2\x80\x94`) and the middle dot between navigation entries (`\xc2\xb7`).
+  Define both as byte constants. The file carries no `use utf8`, so the bytes
+  reach the output unchanged.
+- Escape `&`, `<`, and `>` in the title and in every navigation label. The `sed`
+  restriction on `/` and `&` goes away with `mkpage.sh`.
+- Read the footer from `<source_dir>/footer.body.html` when that file exists.
+  Emit no `<footer>` element when it does not.
+- Link `<source_dir>/extra.css` after `style.css` when that file exists.
+
+### 1.4 App::FuguWeb::CLI and bin/fuguweb
+
+- Copy the shape of `App::FuguVM::CLI`: a `%COMMANDS` table, a `_prepare` method
+  that applies the global options and loads the configuration, and one `cmd_`
+  method for each command.
+- This phase implements `page` only. `page <title>` reads a fragment on standard
+  input and writes the document to standard output.
+- Global options: `--project` (the project root) and `--quiet`.
+- Exit codes: import the five generic codes from `Fugu::CLI`. Add
+  `EXIT_RENDER_FAILED => 4`, `EXIT_CHECK_FAILED => 5`, and
+  `EXIT_TOOL_MISSING => 6`.
+- `bin/fuguweb` copies `bin/fuguvm`: the ISC header, `FindBin`, `use lib`, and
+  one `exit` line. Give it mode 755.
+
+### 1.5 The configuration file
+
+- Write `.fuguwebrc` with the settings, the six `nav` blocks, and the six `page`
+  blocks. The titles come from the `Makefile` recipe, unchanged. The navigation
+  names `fugu.html`, which plan 008 phase 1 created.
+- Move the licence sentence from `web/foot.html` into `web/footer.body.html`.
+- Delete `web/mkpage.sh`, `web/head.html`, and `web/foot.html`.
+
+### 1.6 The Makefile
+
+- Add `FUGUWEB ?= bin/fuguweb`. Replace `MKPAGE = web/mkpage.sh` with it.
+- Replace every `$(MKPAGE) '<title>'` call with `$(FUGUWEB) page '<title>'`.
+- Everything else in the `web` target stays until phase 3. `mkindex.sh` still
+  runs, and it still pipes into the assembler, so the target works throughout.
+
+### 1.7 Tests
+
+- Add `t/fuguweb/boundary.t`. It parses `use` and `require` lines under
+  `lib/App/FuguWeb/` and fails on `App::OpenHAP`, `App::FuguVM`, or
+  `Protocol::`, and on any non-core module outside `Fugu::`. It also reads
+  `lib/App/OpenHAP/` and `lib/App/FuguVM/` and fails on a file that names
+  `App::FuguWeb`. A sibling application is not a library.
+- Add `t/fuguweb/config.t`: the defaults, a page block with two sources, a page
+  declared twice, a nav block with no label, a path that holds `..`, an absent
+  file, and a parse error with a line number.
+- Add `t/fuguweb/page.t`: the chrome, the two byte constants, the escaping of a
+  title that holds `&` and `<`, the optional footer, and the optional
+  `extra.css`.
+- Add `prove -l -v t/fuguweb/*.t` to the `test` target, after the `t/fuguvm`
+  line. Add the tier row to `t/CLAUDE.md`.
+
+## Deliverables
+
+- `bin/fuguweb`, `lib/App/FuguWeb.pm`, `lib/App/FuguWeb/{Config,Page,CLI}.pm`,
+  each with a `.pod` sidecar.
+- `.fuguwebrc` and `web/footer.body.html`.
+- `t/fuguweb/{boundary,config,page}.t`.
+- Updated `Makefile` and `t/CLAUDE.md`.
+- Deleted `web/mkpage.sh`, `web/head.html`, and `web/foot.html`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `make web WEBOUT=<tmp>` gives a tree that `diff -r` reports as identical to
+  the reference build.
+- `prove -l t/web/site.t` passes with no change to that file.
+- `git grep -n 'mkpage\|head\.html\|foot\.html' -- Makefile web t` finds
+  nothing.
+- `fuguweb page 'A & B'` produces a correct title. Prove it once by hand: the
+  old `sed` would have mangled it.

--- a/plans/009-app-fuguweb/plan-2.md
+++ b/plans/009-app-fuguweb/plan-2.md
@@ -1,0 +1,118 @@
+# Phase 2 — The manual index
+
+This phase moves `web/mkindex.sh` into the tool. Its group table becomes
+`manuals` and `modules` blocks in `.fuguwebrc`. After this phase `web/` holds no
+script.
+
+The group table that this phase moves is the one plan 008 leaves behind. Plan
+008 edited it in four of its five phases, and its design names the file as a
+mechanism that fails quietly under a rename. This phase removes that failure
+mode: a group whose directory does not exist becomes an error, not silence.
+
+## Tasks
+
+### 2.1 App::FuguWeb::Manual
+
+- One object for one manual source. Fields: `path`, `name`, `section`, `page`,
+  `description`, and `group`.
+- `App::FuguWeb::Manual->from_mdoc($path, $group)` takes the section from the
+  file extension. It prefixes the name with the group namespace.
+- `App::FuguWeb::Manual->from_pod($path, $group, $module_root)` uses section
+  `3p`. It drops the `module_root` prefix from the path and maps `/` to `::`.
+- `$manual->page` is `<name>.<section>.html`.
+- `$manual->description` reads the source. An mdoc page gives the argument of
+  `.Nd`. A POD sidecar gives the text after `Module - ` on the first non-blank
+  line that follows `=head1 NAME`. The method returns undef when neither is
+  present.
+- `$manual->staged_name` is the file name that the mdoc staging directory needs.
+  For a group with a namespace it carries that prefix, so `man/fugu/Daemon.3p`
+  stages as `Fugu::Daemon.3p`.
+
+### 2.2 App::FuguWeb::Config, the groups
+
+- Parse the `manuals` and `modules` blocks. Each gives `heading` (the block
+  name), `anchor`, `dir`, and, for `manuals`, an optional `namespace`.
+- `$config->groups` returns the groups in file order.
+- `$group->manuals` reads the directory and returns `App::FuguWeb::Manual`
+  objects.
+- A `manuals` group globs `*.1`, `*.3p`, `*.5`, and `*.8` in its directory. It
+  sorts by section, in the order 1, 3p, 5, 8, and then by file name in
+  `LC_ALL=C` order. That reproduces the `$(MAN1) $(MAN3P) $(MAN5) $(MAN8)`
+  argument order of the current recipe.
+- A `modules` group finds every `*.pod` file below its directory and sorts by
+  path in `LC_ALL=C` order. That reproduces
+  `find lib -name '*.pod' | LC_ALL=C sort`, so `Store.pod` stays before
+  `Store/Memory.pod`.
+- The sort never reads the locale of the builder.
+- Reject a group whose directory does not exist. A silent empty group hides a
+  typo in a path, which is exactly how `emit_group` failed.
+
+### 2.3 App::FuguWeb::Index
+
+- `App::FuguWeb::Index->new(config => $config)`.
+- `$index->body` returns the body fragment of `manuals.html`.
+- The fragment starts with `<h1>` and the standard paragraph about the manual
+  sources. A `<source_dir>/manuals.body.html` file replaces that opening when it
+  exists.
+- Each group emits `<h2 id="<anchor>">`, a `<dl>`, and one blank line after the
+  closing `</dl>`. A group with no manual emits nothing.
+- Each manual emits `<dt><a href="./<page>"><name>(<section>)</a></dt>` and
+  `<dd><description></dd>`. The `./` prefix is mandatory, because a browser
+  reads a relative URL whose first segment holds a colon as a scheme.
+- Escape `&` and `<` in every description, as `mkindex.sh` does today.
+
+### 2.4 The CLI
+
+- Add the `index` command. It writes the body fragment to standard output.
+- `fuguweb page 'Manuals'` still wraps it, so the `Makefile` pipes one into the
+  other.
+
+### 2.5 The configuration file
+
+- Add three `manuals` blocks: `man/openhap` (anchor `openhap`), `man/fuguvm`
+  (anchor `fuguvm`), and `man/fugu` (anchor `fugu`, namespace `Fugu::`).
+- Add four `modules` blocks: `lib/App/OpenHAP` (anchor `modules`),
+  `lib/App/FuguVM` (anchor `vm-modules`), `lib/Protocol` (anchor
+  `protocol-modules`), and the new `lib/App/FuguWeb` (anchor `web-modules`).
+- Never name `lib/App` as a `modules` directory. That one directory holds three
+  namespaces, and one group would swallow all of them.
+- Take each heading from the state that plan 008 leaves: `Fugu`,
+  `OpenHAP modules`, `FuguVM modules`, and the heading that plan 008 phase 4
+  gave to `lib/Protocol` when `Protocol::Imsg` joined it.
+- Delete `web/mkindex.sh`. **`web/` now holds no script.**
+
+### 2.6 The Makefile
+
+- Replace `$(MKINDEX) ... | $(MKPAGE) 'Manuals'` with
+  `$(FUGUWEB) index | $(FUGUWEB) page 'Manuals'`.
+- Delete `MKINDEX` and `FINDPOD`.
+
+### 2.7 Tests
+
+- Add `t/fuguweb/manual.t`: the name and section of an mdoc page, the name of a
+  nested POD sidecar, the namespace prefix, the staged name, the `.Nd`
+  description, the `=head1 NAME` description, and a source with neither.
+- Add `t/fuguweb/index.t`: the group order, the two sort rules, the `./` prefix,
+  the escaping of `&` and `<`, an empty group, a missing directory, and the
+  optional opening fragment.
+- Both tests build their sources in a `File::Temp` directory. They do not read
+  the repository, so a change under `man/` cannot break them.
+
+## Deliverables
+
+- `lib/App/FuguWeb/{Manual,Index}.pm`, each with a `.pod` sidecar.
+- The group blocks in `.fuguwebrc`.
+- `t/fuguweb/{manual,index}.t`.
+- Updated `Makefile`, `lib/App/FuguWeb/Config.pm`, and `lib/App/FuguWeb/CLI.pm`.
+- Deleted `web/mkindex.sh`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `make web WEBOUT=<tmp>` gives a tree that `diff -r` reports as identical to
+  the reference build, except for the new `App::FuguWeb` module pages and their
+  index entries. Those pages are new sidecars, and the site publishes every
+  sidecar.
+- `ls web/*.sh` finds nothing.
+- A `manuals` block that names a directory which does not exist fails the build
+  and names the directory. Prove it once by hand.

--- a/plans/009-app-fuguweb/plan-3.md
+++ b/plans/009-app-fuguweb/plan-3.md
@@ -1,0 +1,129 @@
+# Phase 3 — The whole build
+
+This phase moves the rest of the `web` target into the tool. After this phase
+the target runs one command, and `web/` holds content only.
+
+## Tasks
+
+### 3.1 A working directory for Fugu::Process
+
+`Fugu::Process->run` runs its child in the working directory of the caller.
+`mandoc` resolves a `.Xr` target against the working directory, so the staging
+trick needs a child that starts somewhere else. A `chdir` in the parent would
+race every other relative path in the build.
+
+- Add a `cwd => $dir` option to `Fugu::Process->run` and to `_run_passthrough`.
+  The child calls `chdir` after the fork and before the `exec`, and reports a
+  failure through the existing exec pipe.
+- Update `man/fugu/Process.3p` with the new option.
+- Add a subtest to `t/fugu/process.t`: the child runs in the named directory,
+  and a directory that does not exist fails with a message and not a silent run
+  in the wrong place.
+- This is the only change outside `App::FuguWeb` in this phase. The option is
+  generic, so it belongs in the nexus, not in a copy inside the tool.
+
+### 3.2 App::FuguWeb::Render
+
+- One class for the three external renderers. It runs them with
+  `Fugu::Process->run` and returns the output as bytes.
+- `$render->probe` checks `mandoc`, `lowdown`, and `pod2man`. It returns the
+  name of the first tool that is absent. The caller reports the name and exits
+  with `EXIT_TOOL_MISSING`.
+- `$render->lint(@paths)` runs `mandoc -Tlint -W warning`. A malformed page must
+  fail the build, not render badly.
+- `$render->markdown($path)` runs `lowdown -Thtml`.
+- `$render->mdoc($file, $dir)` runs `mandoc` with `cwd => $dir` and the shared
+  HTML options. The directory decides whether a `.Xr` target becomes a local
+  link or a link to the manual host.
+- `$render->pod($path, $name, $date)` runs
+  `pod2man --section=3p --name --date --center --release` and feeds the result
+  to `mdoc` as standard input.
+- The HTML options come from the configuration: `-I os=<mandoc_os>` and
+  `-O fragment,man='./%N.%S.html;<man_url>%N.%S'`. The `-I os=` flag pins the
+  footer, so the site does not vary with the build host.
+- The tool names are overridable, so a caller can name another binary.
+
+### 3.3 App::FuguWeb::Site
+
+- `App::FuguWeb::Site->new(config => $config, out => $dir)`.
+- `$site->build` runs the whole pipeline:
+  1. probe the renderers;
+  2. lint every mdoc source;
+  3. create the output directory and the `.man/` staging directory inside it;
+  4. copy every mdoc source into the staging directory under its staged name;
+  5. copy the base stylesheet and every asset;
+  6. render each `page` block;
+  7. render one page for each manual in each group;
+  8. remove the staging directory.
+- `$site->clean` removes the output directory.
+- `$site->pod_date` returns the date of the last commit, and today's date when
+  git does not answer. git does not preserve file times, so a file time would
+  make the build vary.
+- Create the output directory explicitly. The current recipe gets it as a side
+  effect of `mkdir -p $(WEBOUT)/.man`, which breaks the moment the staging step
+  moves or goes away.
+- The staging directory lives inside the output directory and never reaches the
+  published tree.
+
+### 3.4 The stylesheet
+
+- `git mv web/style.css share/fuguweb/style.css`. The content does not change.
+- `Site` finds it with `Fugu::File->share_path('share/fuguweb/style.css')` and
+  copies it to `<out>/style.css`.
+- Add a `stylesheet` setting to `App::FuguWeb::Config`. It names the base sheet
+  and overrides the search. `share_path` finds the sheet in a checkout, but not
+  in an installed CPAN distribution, so a project must have a way to say where
+  the file is.
+- Fail the build with a named path when the stylesheet is not found. A site with
+  no stylesheet must not look like a success.
+- **`web/` now holds content only:** the `*.body.html` files, `robots.txt`,
+  `CNAME`, and `CLAUDE.md`.
+
+### 3.5 The CLI
+
+- Add the `build` and `clean` commands. Both take `--out <dir>`, which overrides
+  `out_dir` from the configuration.
+- Add the `init` command. It writes a starter `.fuguwebrc` into a directory that
+  holds none, as `fuguvm init` does.
+
+### 3.6 The Makefile
+
+- Cut `web` and `web-clean` down to one command each.
+- Delete `LOWDOWN`, `MANDOC`, `POD2MAN`, `MKPAGE`, `WEBMAN`, and `MANHTML`.
+- Keep `WEBOUT`: `t/web/site.t` and `.github/workflows/web.yml` both set it.
+- Keep `MAN1`, `MAN3P`, `MAN5`, and `MAN8`. `install-man`, `package`,
+  `uninstall`, and `man` still read them.
+- `MANDOC` also serves the `%.cat1`, `%.cat3p`, `%.cat5`, and `%.cat8` rules of
+  the `man` target. Keep the variable if those rules still need it, and delete
+  only the web use.
+
+### 3.7 Tests
+
+- Add `t/fuguweb/render.t`: the probe names an absent tool, the lint fails a
+  malformed page, and the mdoc options carry the configured OS and manual URL.
+  Skip the whole file when `mandoc` is absent.
+- Add `t/fuguweb/site.t`: a small site in a `File::Temp` directory builds, holds
+  the expected files, drops the staging directory, and builds a second time to
+  the same bytes.
+- These tests do not read the repository. `t/web/site.t` covers the real site.
+
+## Deliverables
+
+- `lib/App/FuguWeb/{Render,Site}.pm`, each with a `.pod` sidecar.
+- `share/fuguweb/style.css`, moved from `web/style.css`.
+- `t/fuguweb/{render,site}.t`.
+- Updated `lib/Fugu/Process.pm`, `man/fugu/Process.3p`, `t/fugu/process.t`,
+  `Makefile`, and `lib/App/FuguWeb/CLI.pm`.
+- Deleted `web/style.css`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `make web WEBOUT=<tmp>` gives a tree that `diff -r` reports as identical to
+  the phase-2 output.
+- `sed -n '/^web:/,/^$/p' Makefile` shows one command.
+- `ls web/` shows only `*.body.html`, `robots.txt`, `CNAME`, and `CLAUDE.md`.
+- `fuguweb build` fails and names `mandoc` when `mandoc` is not on the path.
+  Prove it once by hand.
+- Two builds in a row give the same bytes.
+- `make man` still builds the cat pages.

--- a/plans/009-app-fuguweb/plan-4.md
+++ b/plans/009-app-fuguweb/plan-4.md
@@ -1,0 +1,135 @@
+# Phase 4 — The checks and the documentation
+
+This phase moves the generic site checks into the tool, so every project gets
+them. It then updates every document, workflow, and manifest that the three
+earlier phases changed.
+
+## Tasks
+
+### 4.1 App::FuguWeb::Check
+
+- `App::FuguWeb::Check->new(config => $config, out => $dir)`.
+- `$check->run` returns a list of problems. Each problem names the page and says
+  what is wrong. An empty list means the site is good.
+- The checks come from the generic half of `t/web/site.t`:
+  - every expected page and asset exists and is not empty;
+  - no page holds an unsubstituted `@TITLE@`;
+  - every page has a title;
+  - every page carries the whole navigation;
+  - no reference starts with `/`, because the host may serve the site from a
+    path below the root;
+  - no reference uses a `file:` URL;
+  - every relative reference resolves to a file in the output;
+  - every fragment resolves to an `id` on the target page;
+  - no relative href reads as a URL scheme, so every local link keeps its `./`;
+  - no local `.Xr` cross-reference dangles;
+  - every page is reachable from `entry`, except a page marked `unlinked`;
+  - the output holds the site and nothing else.
+- The check never fetches a link. It collects the external links and reports
+  them, because the build and its checks touch no network.
+
+### 4.2 The CLI
+
+- Add the `check` command. It takes `--out <dir>`.
+- The command prints one line for each problem to standard error and exits with
+  `EXIT_CHECK_FAILED`. It exits 0 and says nothing when the list is empty.
+- Add `--verbose`, which also notes every external link.
+
+### 4.3 t/web/site.t
+
+- The file keeps its tooling-tier rule: it drives subprocesses and asserts on
+  exit status and output. It does not load a module from `lib/`.
+- It runs `make web WEBOUT=<tmp>`, then `bin/fuguweb check --out <tmp>`, and
+  asserts that both exit 0.
+- It keeps only the OpenHAP-specific assertions:
+  - `install.html` carries content from `INSTALL.md`;
+  - `hapctl.8.html` links `.Xr openhapd 8` locally and sends `.Xr rc 8` to the
+    manual host;
+  - `Fugu::Daemon.3p.html` links `.Xr Fugu::Pidfile 3p` locally;
+  - every manual source in `man/` and every `.pod` sidecar under `lib/` produces
+    a page, and the index shows its description verbatim;
+  - two builds give the same bytes.
+- Delete `@SITE`, `@ASSETS`, and `@NAV`. `App::FuguWeb::Check` gets those from
+  `.fuguwebrc`, so the third copy of the page list goes away.
+- The discovery loop at the top matches `man/([^/]+)/` and applies the `Fugu::`
+  prefix for one directory. Replace that special case with the group namespaces
+  that `.fuguwebrc` declares, read as text. Plan 008 had to edit this same rule;
+  nobody should edit it again.
+
+### 4.4 The manual page
+
+- Write `man/fuguweb/fuguweb.1` in mdoc(7). Model it on `man/fuguvm/fuguvm.1`:
+  `NAME`, `SYNOPSIS`, `DESCRIPTION` with a tagged list of the subcommands,
+  `FILES` for `.fuguwebrc` and `share/fuguweb/style.css`, `EXIT STATUS`,
+  `EXAMPLES`, `SEE ALSO`, and `AUTHORS`.
+- Add it to `MAN1` in the `Makefile`. `install-man` does not ship `MAN1` today,
+  and `fuguweb` is a development tool, so that stays true.
+- Add a `manuals "FuguWeb"` group to `.fuguwebrc` for `man/fuguweb`, with the
+  anchor `fuguweb`. The page then reaches the site and the index.
+
+### 4.5 Documentation
+
+- Rewrite `web/CLAUDE.md` for the new shape: what `web/` holds, how `.fuguwebrc`
+  describes the site, and how to add a page or a manual. Keep the five findings;
+  point at the code that carries each one.
+- Update the root `CLAUDE.md`:
+  - add `App::FuguWeb::` to the namespace list that plan 008 rewrote, with one
+    line on its purpose;
+  - add `lib/App/FuguWeb/`, `bin/fuguweb`, `man/fuguweb/`, and the `t/fuguweb/`
+    tier to the Layout section;
+  - correct the sentence that says the site renders `README.md`. It renders
+    `INSTALL.md`; the front page is hand-written framing.
+- Add the `t/fuguweb/` row to the tier table in `t/CLAUDE.md`, if phase 1 has
+  not already.
+- Extend `t/scripts/namespaces.t` with the retired file names: `mkpage.sh`,
+  `mkindex.sh`, `web/head.html`, `web/foot.html`, and `web/style.css`. Plan 008
+  built that gate for retired module names; the same clean-break rule covers a
+  retired script.
+- Record the CPAN release work in `TODO.md`, under a new "App::FuguWeb CPAN
+  release" section beside the sections that plan 008 leaves there.
+
+### 4.6 CI and dependencies
+
+- Update both path filters in `.github/workflows/web.yml`:
+  - drop `web/*.sh`;
+  - add `lib/App/FuguWeb/**`, `bin/fuguweb`, `.fuguwebrc`, `share/fuguweb/**`,
+    and `t/fuguweb/**`.
+- The workflow installs `lowdown` and `mandoc` from apt and uses the system
+  perl. `fuguweb` needs no CPAN module, so that step does not change.
+- Confirm that `.github/workflows/web.yml` still uploads `web/build`. The
+  artifact path repeats the `WEBOUT` default; a change to one needs a change to
+  the other.
+- Add `develop pkg mandoc` to `deps/Darwin.txt`. The manifest lacks it today,
+  and the web build needs it on every platform except OpenBSD, where it is in
+  the base system.
+- Check the path filters in `check.yml` and `test.yml`. They must watch
+  `lib/App/**` and `t/fuguweb/**`.
+
+### 4.7 Tests
+
+- Add `t/fuguweb/check.t`. Build a small broken site in a `File::Temp` directory
+  and assert one problem for each check: a dead link, a dead fragment, a
+  root-absolute reference, a link that reads as a scheme, an unreachable page,
+  and a stray file in the output.
+
+## Deliverables
+
+- `lib/App/FuguWeb/Check.pm` with its `.pod` sidecar.
+- `man/fuguweb/fuguweb.1`.
+- `t/fuguweb/check.t`, and the shrunk `t/web/site.t`.
+- Updated `web/CLAUDE.md`, `CLAUDE.md`, `t/CLAUDE.md`, `TODO.md`, `Makefile`,
+  `.fuguwebrc`, `t/scripts/namespaces.t`, `.github/workflows/web.yml`, and
+  `deps/Darwin.txt`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `make web WEBOUT=<tmp>` gives a tree that `diff -r` reports as identical to
+  the phase-3 output, plus the new `fuguweb.1.html` page and its index entry.
+- `make web && bin/fuguweb check --out web/build` exits 0.
+- A dead link in a body fragment fails `fuguweb check` and names the link. Prove
+  it once by hand.
+- `git grep -n 'mkpage\|mkindex' -- . ':!plans'` finds nothing.
+- `make spec-coverage` reports no stale citation.
+- `make install DESTDIR=<empty dir>` succeeds and installs no `App/FuguWeb`
+  file, as it installs no `App/FuguVM` file.


### PR DESCRIPTION
## Problem

`make web` builds the website from two `sh` scripts and a 60-line recipe. Both
hold project knowledge, not tooling: the page list, the page titles, the four
named mdoc pages, the namespace prefix rule, the `pod2man` options, and the
asset list. `web/mkindex.sh` carries a six-row group table in its own body, and
`web/head.html` carries the site name, the banner, and the navigation.

No second project can reuse any of it. The same facts also exist four times: in
the `Makefile` recipe, in `web/head.html`, in `@SITE` and `@NAV` in
`t/web/site.t`, and in the path filter of `.github/workflows/web.yml`.

Plan 008 measures the same cost from the other side. It names `web/mkindex.sh`
among the six mechanisms that fail quietly under a rename, and four of its five
phases edit the same three web files by hand.

## What the plan proposes

Extract the tooling into `App::FuguWeb`, a Perl application that any project
configures with one `.fuguwebrc` file. The outcome:

- `web/` holds content only: `*.body.html`, `robots.txt`, and `CNAME`. No
  scripts, no chrome templates, no stylesheet.
- The `web` and `web-clean` targets run one command each.
- The generic site checks become `fuguweb check`, so every project gets them.
- The rendered site does not change. Every phase ends with a byte-for-byte
  comparison against a reference build.

Four phases, each independently shippable: the page assembler, the manual
index, the whole build, then the checks and the documentation.

## Dependency on plan 008

Plan 009 starts after plan 008 lands. It names the results of that rename and
not the current tree: `Fugu::` for every library it builds on, `lib/App/OpenHAP`
and `lib/App/FuguVM` and `lib/Protocol` for the module groups, `man/fugu/` with
the `Fugu::` staging prefix, and `fugu.html` in the navigation. It also extends
`t/scripts/namespaces.t` and adopts the layering rules.

The dependency runs one way; plan 008 does not need this effort. Plan 008 also
settles the naming question: PAUSE puts an application under `App::`, so
`App::FuguWeb` completes the trio and claims no new top-level name.

This does not conflict with #35. That PR moves `OpenHAP::Storage` to
`Protocol::HAP::Store::File`, which plan 009 never names, and whose sidecar the
`lib/Protocol` module group already covers.

## Findings that shaped the plan

Reading the current code changed four decisions:

- **`Fugu::Config` is line-based.** A block header must end its line, so a
  one-line block does not parse, and a value may not hold a `#`.
- **Byte-identity is tighter than it looks.** The chrome uses an em dash and a
  middle dot. Both become byte constants: no `use utf8`, no encoding layer.
- **The index order is not alphabetical.** It follows the `$(MAN1) $(MAN3P)
  $(MAN5) $(MAN8)` argument order and `find | LC_ALL=C sort`. The plan pins both
  sort keys, so `openhapd.conf(5)` stays before `hapctl(8)` and `Store.pod`
  before `Store/Memory.pod`.
- **`Fugu::Process->run` cannot set a working directory,** which `mandoc` needs
  to resolve `.Xr` locally. Phase 3 adds a `cwd` option to `Fugu::Process` with
  its manual entry and test, rather than a `chdir` that would race the build.

The plan also records one limit it cannot design away: `share_path` finds the
shipped stylesheet in a checkout but not in an installed CPAN distribution. A
`stylesheet` setting overrides it, and `TODO.md` carries the release work.

## Scope

Documents only — five files under `plans/009-app-fuguweb/`, 803 lines. No code
changes. `make check` and `make prettier` pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WLTXHsqNs4PLeK4X2TRDLp)_