### PR TITLE
docs(plans): add plan 010 for the simplification effort

### DIFF
--- a/plans/010-simplify/design.md
+++ b/plans/010-simplify/design.md
@@ -2,44 +2,57 @@
 
 ## Problem
 
-An audit of the whole tree found about 2,800 removable lines in `lib/` and
-`bin/` (12–13%), plus about 330 test lines and 250 documentation lines. The
-design is not at fault, and no tier carries an abstraction too many. The bloat
-has six recurring shapes, and backward compatibility — the usual suspect — is
-almost absent: the clean-break rule from plan 008 works.
+An audit of the whole tree found about 3,000 candidate lines in `lib/` and
+`bin/`. A five-angle cold review then refuted part of the audit: some
+"defensive" code turned out to be load-bearing, and some "dead" code has live
+callers. What survives both passes is about 2,400 lines of `lib/` and `bin/`
+(10–11%), plus about 330 test lines and 250 documentation lines. The bloat has
+six recurring shapes. Backward compatibility — the usual suspect — is almost
+absent: the clean-break rule from plan 008 works.
 
 | Shape                    | Example                                                         |
 | ------------------------ | --------------------------------------------------------------- |
-| Test-only API            | `Fugu::Process` `check_alive`; `Pairing::get_failed_attempts`   |
+| Test-only API            | `Fugu::Process` `check_alive`; `Fugu::Pidfile` `release`        |
 | Unreachable option       | Tasmota `fulltopic`; `Characteristic` `maxLen`                  |
 | Documentation–code drift | `openhapd.conf.5` documents six thermostat options nobody reads |
-| Multi-layer validation   | `Pairing::new` re-checks what `Server::new` proved              |
+| Multi-layer validation   | `App::FuguVM::CLI` validates one timeout three times            |
 | Copy-paste blocks        | the ChaCha20 frame loop exists three times                      |
 | Refactor leftovers       | the QGA subsystem; `fuguweb page` and `fuguweb index`           |
 
-The audit also found real bugs that hide inside the bloat: an integer `%` in
-`_rgb_to_hsb` that no production path reaches, a shared lock in the file store
-that the write side defeats, and config keys (`arch`, `hap_model`) that the
-manuals promise and no code reads.
+The audit and the review also found real bugs that the plan fixes in passing.
+Each is named in the decision that owns it:
+
+1. `_rgb_to_hsb` computes hue with an integer `%` on a live inbound path
+   (decision 3).
+2. `Host::_write` has no SIGPIPE handling, so a controller that closes mid-write
+   can kill the daemon (decision 19).
+3. Unknown `log_level` and `log_facility` values fall back silently, and the
+   manual promises spellings the code rejects (decision 11).
+4. The file store takes a shared lock the writer defeats (decision 12).
+5. `arch` and `hap_model` are documented keys no code reads (decisions 7, 8),
+   and `has_humidity` is a working key no manual documents (decision 2).
+6. `State::mark_running` is called only from a fallback branch, so crash
+   detection almost never arms (decision 17).
 
 Nothing in `make check` detects any of the six shapes today. `.perlcriticrc`
-runs at severity 4, so the policies that find unused code never run — and nine
-of its sixteen entries disable policies that the severity filter already
-excludes. The config file is itself an instance of the problem.
+runs at severity 4, so policies that find unused code never run — and nine of
+its fifteen entries are inert: eight name policies below severity 4, and one
+configures a policy the severity filter excludes.
 
 ## Goals
 
-1. Delete about 2,800 lines from `lib/` and `bin/`, with the matching test and
+1. Delete about 2,400 lines from `lib/` and `bin/`, with the matching test and
    documentation lines, and with no change to module boundaries.
 2. The observable HAP behavior of a paired accessory does not change. The
    decisions below list every user-visible exception.
 3. Every deletion is verified first: a grep across `lib/ bin/ t/` proves the
-   code is unreachable, test-only, or duplicated, before it goes.
+   code is unreachable, test-only, or duplicated, before it goes. The audit is
+   input, not proof — the review killed a dozen audit claims this way.
 4. Code, tests, and documentation leave together. No orphaned `.pod` section, no
    `.3p` entry for a deleted method, no test of a deleted layer.
 5. Two of the six shapes get permanent gates: compatibility vocabulary
    (extending `t/scripts/namespaces.t`) and undeclared or unused API surface (a
-   new `t/scripts/symbols.t` plus two Perl::Critic policies).
+   new `t/scripts/symbols.t` plus Perl::Critic enables).
 6. The root `CLAUDE.md` grows by three rules. The audit procedure lives in a new
    `shrink` skill, per the placement table.
 
@@ -48,143 +61,195 @@ excludes. The config file is itself an instance of the problem.
 - No module folds. `Fugu::Sandbox` + `Fugu::Privdrop` + `Fugu::Daemon`,
   `Fugu::StateFile`, `Fugu::Timeout`, and `Fugu::Random` each have one consumer
   and could merge, but that is a structure change for another effort.
-- No new base classes. A shared-accessor generator would shrink twelve
-  accessors, at the cost of a new inheritance root. Not worth it.
-- No complexity-ceiling policies (`ProhibitExcessComplexity`,
-  `ProhibitDeepNests`). A numeric ceiling misfires on protocol dispatch code,
-  and the unused-code policies carry the enforcement without it.
+- No new base classes, and no accessor-generator module.
+- No complexity-ceiling policies, and no `ProhibitUnusedPrivateSubroutines`:
+  measured on this tree, that policy flags seven live template-method overrides
+  in `Tasmota/*.pm` and none of the real dead code. The `symbols.t` floor covers
+  private subs without those false positives.
 - No code-coverage tooling. `Devel::Cover` is a new dependency, against the
-  minimal-dependency rule. `spec-coverage` stays the one coverage tool.
-- No comment trimming. The comment style is deliberate. A comment leaves only
-  when its code leaves.
-- No rewrite of `plans/001`–`009`. They record what was true when written.
+  minimal-dependency rule.
+- No comment trimming. A comment leaves only when its code leaves.
+- No unknown-key rejection in `Fugu::Config`. Deleted config keys become ignored
+  keys; the gates and manuals carry the vocabulary, not a parser feature no tier
+  has.
+- No rewrite of `plans/001`–`009`.
 
 ## Decisions
 
-Fifteen findings need a call between delete and wire-up. Take these knowingly.
+Nineteen calls, each verified against the tree. Take them knowingly.
 
-1. **`validate_setup_code` is wired in, not deleted.** `bin/openhapd` gains the
-   two-line call. Rejecting the trivial setup codes is documented policy and a
-   fail-closed default; deleting it would drop a security check to save twenty
-   lines.
-2. **`has_humidity` becomes a config option.** The HumiditySensor code and its
-   conformance tests work; only the config path is missing. Wiring costs a few
-   lines in `Devices.pm` and `openhapd.conf.5`. Deleting would remove a real
-   capability of the product's core purpose.
-3. **`default_vm` is wired in.** `fuguvm init` writes the setting and
-   `fuguvm(1)` documents it, but `App::FuguVM::CLI::_prepare` hardcodes
-   `'default'`. Honor the setting.
+1. **`validate_setup_code` replaces the `normalize_setup_code` call in
+   `bin/openhapd`.** It normalizes internally and also rejects the trivial
+   codes, so the boundary validates once and gains the documented check.
+2. **`has_humidity` gets documented, not rebuilt.** `Devices.pm:67` already
+   reads it from the sensor block; only `openhapd.conf.5` never mentions it. The
+   no-op "auto-detected humidity" log branch in `Sensor.pm` goes — it sets
+   nothing and can add no service after construction.
+3. **The color pipeline stays; its bug goes.** `_parse_color` runs on every
+   inbound `STATE`/`RESULT` payload and feeds hue and saturation to HomeKit, so
+   it is live. Fix the integer-`%` hue bug. Delete only the outbound surface
+   nothing calls: `set_color`, `dimmer_step`, `dimmer_min`, `dimmer_max`,
+   `toggle_power`, `blink`, `force_telemetry`, with their subtests, under
+   decision 15.
 4. **The QGA subsystem goes whole.** Nothing ever runs `firstboot.exp`, so no
-   guest has an agent, so every `App::FuguVM::QGA` path is dead at runtime and
-   costs about forty seconds on every failed graceful shutdown. Delete the
-   module, its sidecar, its test, the fallback branch in `Guest`, the
-   virtio-serial arguments, and `firstboot.exp`. This is the one module deletion
-   in the effort.
-5. **`fuguvm image` goes.** Its `download` subcommand does not download, and
-   `list` restates what `up` reports. `Miniroot::list` and `_release_root` exist
-   only for it.
-6. **`fuguweb page` and `fuguweb index` go.** Plan 009 kept them because "a
-   project may want one page out of the set". No caller appeared. The `mdoc`
-   pipeline example in `fuguweb(1)` goes with them.
+   guest has an agent and every `App::FuguVM::QGA` path is dead at runtime.
+   Delete the module, sidecar, test, the `Guest` fallback and virtio-serial
+   arguments, `firstboot.exp`, and the `QMP.pod` SEE ALSO entry. This is the one
+   module deletion in the effort. `share/fuguvm/cache-generation` stays and
+   increments to 2: it exists to rotate the disk-cache key when the install
+   driver changes invisibly, and deleting the virtio-serial device is such a
+   change.
+5. **`fuguvm image` goes**, with `Miniroot::list`, `_release_root`, and their
+   subtests in `t/fuguvm/miniroot.t` and `cli.t`.
+6. **`fuguweb page` and `fuguweb index` go**, with their subtests in
+   `t/fuguweb/cli.t` and the stale pipeline example in `fuguweb(1)`.
 7. **The `arch` key goes.** No code reads it, so `arch amd64` silently produces
-   an arm64 VM. `fuguvm(1)` states the fixed architecture instead.
+   an arm64 VM. It leaves `.fuguvmrc`, all three `share/fuguvm` samples, and
+   `fuguvm(1)`, which states the fixed architecture once.
 8. **`hap_model` and `hap_manufacturer` go from the documentation.** The daemon
-   hardcodes both values. Deleting two sample lines and four manual lines is
-   smaller than plumbing two knobs nobody set.
+   hardcodes both values.
 9. **The six thermostat options go from `openhapd.conf.5`.** None appears in any
-   code. The manual stops promising them.
-10. **The FuguWeb knobs `banner`, `pod_center`, `pod_release`, and the
-    `extra.css` hook go.** Only their own round-trip tests set them. `lang`
-    stays: a non-English project needs it on day one.
-11. **The `warn`/`err` level aliases go from `Fugu::Log`.** No config file or
-    fixture uses either spelling. This is the tier's only backward-compat
-    construct.
-12. **The file store loses its shared lock.** `load_pairings` takes `LOCK_SH`,
-    but the writer unlinks and recreates the file, which the lock cannot see.
-    One daemon process owns the store; the honest fix is no lock, not more lock.
-13. **`openhapd -n` stays.** Config-check flags are OpenBSD daemon convention,
-    even though `hapctl check` covers the same ground.
-14. **The non-falsifiable subtests of `t/openhap/integration/hap-protocol.t`
-    go.** Eleven of them accept every plausible status code, and exact
-    assertions for the same endpoints exist in `accessories.t` and
-    `characteristics.t`.
-15. **`t/conformance/` assertions of deleted layers go with their code**, the
-    way commit 0ae2b25 did it: every spec citation the deleted subtest carried
-    must stay covered elsewhere, and `make spec-coverage` proves no citation
-    went stale.
+   code.
+10. **FuguWeb sheds four knobs.** `banner` goes — `Page` renders
+    `$config->site`, which was the default. `pod_center` and `pod_release` go as
+    config keys, but their values stay as `Render` constants: they pin `pod2man`
+    output so the site does not vary with the build host. The `extra.css` hook
+    goes — the only site has no such file. `lang` stays.
+11. **One spelling per log level, validated at the boundary.** The manual
+    promises `err`, `crit`, `alert`, and `emerg`; the code accepts `warn`,
+    `err`, and `crit` as extras and silently maps everything unknown to `info`,
+    and unknown facilities to `daemon`. The vocabulary becomes the five method
+    names of `Fugu::Log`; the alias rows and the `crit` priority row go; the
+    facility rows stay — the manual documents them and its own example uses
+    `local0`. `bin/openhapd` validates both keys at startup and fails closed
+    with a named value. `openhapd.conf.5:138` changes to match.
+12. **The file store loses its shared lock.** The writer unlinks and recreates
+    the file, which `LOCK_SH` cannot see, and one process owns the store. The
+    `flock` pledge promise and its comment leave `bin/openhapd` with it. The
+    `/^\d+$/` counter guards **stay**: they are the only type checks on values
+    read back from `state.json`, and `get_auth_attempts` feeds the pair-setup
+    lockout. The `O_EXCL` pre-unlink **stays**: it is crash recovery for a
+    pid-recycled daemon.
+13. **`openhapd -n` stays.** Config-check flags are OpenBSD daemon convention.
+14. **The non-falsifiable integration subtests go.** Eleven `hap-protocol.t`
+    tests accept every plausible status code; exact assertions exist in
+    `accessories.t` and `characteristics.t`.
+15. **Spec coverage is checked by diff, not by the tool's exit code.**
+    `scripts/spec-coverage` fails only on stale citations; it cannot see a
+    deleted one. Every phase that deletes a cited subtest diffs the coverage
+    matrix before and after, re-homes citations whose behavior survives (the
+    `[HAP-Characteristics §2]` and `[§3]` citations move to the catalog rows),
+    and lists every dropped citation in the commit message. A citation may drop
+    only when its behavior leaves the tree.
+16. **`default_vm` is honored.** `_prepare` resolves the VM name from the
+    option, then from `Config::default_vm`, once the config exists; offline
+    commands keep `'default'`.
+17. **`mark_running` moves to the main start path**, so `was_unclean_shutdown`
+    detects a crash again. This is a bug fix, and the fallback branch that held
+    the only call goes.
+18. **`Controller` sheds its test-harness defaults.** `controller_id` becomes a
+    required argument; the `OPENHAP_TEST_TIMEOUT` fallback moves into the
+    integration harness; the `timeout // 5` default stays. The conformance and
+    protocol tests that relied on the literal pass it explicitly.
+19. **`Host::_write` is rebuilt, not stripped.** The audit called its three
+    guards redundant; the review proved none of them handles SIGPIPE and the
+    `syswrite` return is discarded. It becomes one checked write through
+    `Fugu::File`'s shared loop with a local SIGPIPE guard.
+
+**Verified keeps.** The review refuted these audit claims; the code stays, and
+the `shrink` skill cites them as cautionary examples: `get_failed_attempts`
+(eight test callers, two conformance-cited), the nine `IMSG_*` constants
+(`mdns-control.t` pins the positional enum), the `Host::listen` memoization (the
+pairing-exchange test forks after binding port 0), the `Session` pass-through
+guards (`hap-encryption.t` asserts them), `Pairing::new` validation (the
+sidecar's SYNOPSIS depends on it), `Store::Memory`'s deep copy (documented
+contract), the `Privdrop` pre-check (distinct diagnostic), both `hapctl uptime`
+checks, `Control`'s `MAX_REPLY` bound and encode `eval` (a blocking write and an
+else-unanswered request), the `Devices.pm` eval (it guards `require` of
+config-named classes after daemonize), the `EventLoop` `fileno` guard
+(reachable: a callback can close a sibling handle mid-pass), and
+`Miniroot::_ftp_script` (a production call site, and a seam against silent
+rename breakage).
 
 ## The gates
 
-The clean-break rule got `t/scripts/namespaces.t`; the simplicity rules get
-gates in the same style. Every gate must fail on a planted violation before its
-phase closes.
+Every gate must fail on a planted, `git add`-ed violation before its phase
+closes — `namespaces.t` sweeps tracked files only.
 
 1. **Vocabulary.** `namespaces.t` gains a `@BANNED` table beside `@RETIRED`,
-   with the same self-testing pattern shape: `deprecat`, `backward compat`,
-   `for compatibility`, `compatibility shim|layer|alias|wrapper|path`. The sweep
-   skips `plans/` and `spec/` — the specs quote other projects' deprecations,
-   and the plans are history.
-2. **API surface.** A new `t/scripts/symbols.t` proves three invariants over the
-   tracked tree: every public sub in `Fugu::` and `App::` has a caller in `lib/`
-   or `bin/` (with `App::OpenHAP::Test::` exempt — the integration tier is its
-   caller — and a named allowlist for the rest); every module has its sidecar or
-   `.3p` page and every sidecar has its module; every non-core import in `lib/`
-   appears in `cpanfile` and the `deps/` manifests. `Protocol::` is exempt from
-   the caller rule: it is a library, and its `.pod` contract is its caller.
-3. **Perl::Critic.** `Subroutines::ProhibitUnusedPrivateSubroutines` and
-   `Variables::ProhibitUnusedVariables` run at severity 4 via per-policy
-   overrides. `Miscellanea::ProhibitUnrestrictedNoCritic` and
-   `ProhibitUselessNoCritic` join them, so suppression cannot become the escape
-   hatch. The nine no-op entries leave the file.
-4. **`make check` gains `spec-coverage`.** The script is core Perl, so the gate
-   costs nothing locally. `prettier` stays CI-only: it needs `npx`, and no
-   `deps/` manifest provides node.
+   same self-testing shape: `deprecat`, `backward compat`, `for compatibility`,
+   `compatibility shim|layer|alias|wrapper|path`. The sweep skips `plans/` and
+   `spec/` — the specs quote other projects' deprecations. The gate is
+   line-based; a phrase split across a comment wrap escapes it. Accept that: the
+   gate catches vocabulary, review catches intent.
+2. **API surface.** A new `t/scripts/symbols.t` proves three invariants: every
+   sub defined in `lib/Fugu/` and `lib/App/` — public or private — is named at
+   least once in `lib/` or `bin/` outside its definition line; every module has
+   its sidecar or `.3p` page, both directions, with an exemption table seeded
+   with `Protocol/HAP/Store.pod` (the contract POD); every non-core import in
+   `lib/` and `bin/` appears in `cpanfile`. `Protocol::` is exempt from the
+   caller floor (its `.pod` contract is its caller), and `App::OpenHAP::Test::`
+   counts `t/openhap/integration/` as its caller. The floor is textual and
+   therefore a floor: a name that collides across the CPAN boundary (both
+   `Random` modules define `random_bytes`) passes wrongly, and the allowlist
+   names such cases.
+3. **Perl::Critic.** `Variables::ProhibitUnusedVariables`,
+   `Miscellanea::ProhibitUnrestrictedNoCritic`, and `ProhibitUselessNoCritic`
+   run at severity 4 via per-policy overrides. The nine inert entries leave the
+   file.
+4. **`make check` gains `spec-coverage`.** The script is core Perl. CI already
+   runs it; the gain is local parity. `prettier` stays CI-only: it needs `npx`,
+   and no `deps/` manifest provides node.
 
-What stays review discipline, not a gate: multi-layer validation, copy-paste
-blocks, and unreachable options. Text analysis cannot decide those; the `shrink`
-skill carries the hunt procedure and the keep list.
+What stays review discipline: multi-layer validation, copy-paste blocks,
+unreachable options. The `shrink` skill carries the hunt procedure, the keep
+list, and the verified-keeps list above.
 
 ## The keep list
 
 Deletion must not touch:
 
-- Checks on external input: HAP wire data, MQTT payloads, config files, and
-  anything a controller or a device sends. Fail closed.
-- The deliberate duplication across the CPAN boundary. `Protocol::` stays
-  self-contained; `Fugu::Random` documents why it will not be the single source
-  of randomness.
-- The OpenBSD/Linux/Darwin split. Production is OpenBSD; the other two run
-  development and CI.
-- `plan skip_all` on missing dependencies in module tests, and the never-skip
-  rule in integration tests.
+- Checks on external input: HAP wire data, MQTT payloads, config files,
+  control-socket messages, and state files read back from disk. Fail closed.
+- Behavior a conformance test asserts with a spec citation, unless the decision
+  list names it and decision 15 accounts for the citation.
+- The deliberate duplication across the CPAN boundary: `Protocol::` stays
+  self-contained.
+- The OpenBSD/Linux/Darwin split; `plan skip_all` in module tests; the
+  never-skip rule in integration tests.
 - Both store implementations, the sans-IO engine, and the store contract.
 
 ## Phases
 
-1. **The ground rules.** The vocabulary gate, the `.perlcriticrc` cleanup,
-   `spec-coverage` in `make check`, the three `CLAUDE.md` rules, and the
-   `shrink` skill. Two comments reword so the gate passes.
-2. **`Protocol::`.** About 470 lines: the `Server.pm` and `Controller.pm` dedup,
-   the dead constants, the store fixes, and decision 1.
-3. **`Fugu::`.** About 600 lines plus the mirrored `.3p` entries: the dead
-   graceful-exit facility, the test-only options, the four-fold idioms, and
-   decision 11.
-4. **`App::OpenHAP`.** About 740 lines of lib and bin plus 330 test lines: the
-   unreachable Tasmota surface, the base-class dedup, the manual cleanup, the
-   integration-harness dedup, and decisions 2, 8, 9, 14.
-5. **`App::FuguVM` and `App::FuguWeb`.** About 1,000 lines: the QGA deletion,
-   the CLI dedup, the extraction leftovers, and decisions 3–7, 10.
+The phases land in order; phase N may rely on every phase before it. They are
+not mutually independent: `bin/openhapd` is edited by phases 2 and 4, `Guest.pm`
+by phases 3 and 5, and the phase-4 `blink` grep is clean only after phase 2
+deletes the `identify` hook whose comment names it.
+
+1. **The ground rules.** The vocabulary gate, three cleanups it forces (two
+   comments, one `TODO.md` line), the `.perlcriticrc` cleanup, `spec-coverage`
+   in `make check`, the three `CLAUDE.md` rules, and the `shrink` skill.
+2. **`Protocol::`.** About 350 lines: the `Server.pm` and `Controller.pm` dedup,
+   dead constants, the store lock, and decisions 1, 15, 18.
+3. **`Fugu::`.** About 500 lines plus mirrored `.3p` entries: the dead
+   graceful-exit facility, test-only options, four-fold idioms.
+4. **`App::OpenHAP`.** About 700 lines of lib and bin plus 330 test lines: the
+   unreachable Tasmota surface, base-class dedup, the manual cleanup, the
+   integration-harness dedup, and decisions 2, 3, 8, 9, 11, 14, 19.
+5. **`App::FuguVM` and `App::FuguWeb`.** About 850 lines: the QGA deletion, CLI
+   dedup, extraction leftovers, and decisions 4–7, 10, 16, 17.
 6. **The lock.** `t/scripts/symbols.t` and the Perl::Critic enables land last,
    because they only pass after the sweeps.
 
-Phases 2 to 5 depend only on phase 1 and are mutually independent. Phase 6
-depends on all of them. Each phase lands whole — code, tests, sidecars, manuals,
-and samples together — and `make check` passes at its end.
+Each phase lands whole — code, tests, sidecars, manuals, and samples together —
+and `make check` passes at its end.
 
 ## Testing
 
-Every phase re-verifies its deletions with the greps in its acceptance criteria;
-the audit that produced the counts is input, not proof. Phase 2 ends with the
-conformance tier green. Phase 4 ends with `make integration` green in CI. Phase
-5 ends with the double-build check of `t/web/site.t`. Phases 1 and 6 plant one
-violation per gate and watch the gate fail, then remove the plant.
+Every phase re-verifies its deletions with the greps in its acceptance criteria.
+Phase 2 ends with the conformance tier green. Phase 4 ends with
+`make integration` green in CI. Phase 5 ends with the double-build check of
+`t/web/site.t` byte-identical to the pre-phase build. Phases 1 and 6 plant one
+violation per gate rule, tracked with `git add`, watch the gate fail, then
+remove the plant. Phases that delete cited subtests attach the
+`scripts/spec-coverage` matrix diff (decision 15).

--- a/plans/010-simplify/design.md
+++ b/plans/010-simplify/design.md
@@ -1,0 +1,190 @@
+# Simplification — Design
+
+## Problem
+
+An audit of the whole tree found about 2,800 removable lines in `lib/` and
+`bin/` (12–13%), plus about 330 test lines and 250 documentation lines. The
+design is not at fault, and no tier carries an abstraction too many. The bloat
+has six recurring shapes, and backward compatibility — the usual suspect — is
+almost absent: the clean-break rule from plan 008 works.
+
+| Shape                    | Example                                                         |
+| ------------------------ | --------------------------------------------------------------- |
+| Test-only API            | `Fugu::Process` `check_alive`; `Pairing::get_failed_attempts`   |
+| Unreachable option       | Tasmota `fulltopic`; `Characteristic` `maxLen`                  |
+| Documentation–code drift | `openhapd.conf.5` documents six thermostat options nobody reads |
+| Multi-layer validation   | `Pairing::new` re-checks what `Server::new` proved              |
+| Copy-paste blocks        | the ChaCha20 frame loop exists three times                      |
+| Refactor leftovers       | the QGA subsystem; `fuguweb page` and `fuguweb index`           |
+
+The audit also found real bugs that hide inside the bloat: an integer `%` in
+`_rgb_to_hsb` that no production path reaches, a shared lock in the file store
+that the write side defeats, and config keys (`arch`, `hap_model`) that the
+manuals promise and no code reads.
+
+Nothing in `make check` detects any of the six shapes today. `.perlcriticrc`
+runs at severity 4, so the policies that find unused code never run — and nine
+of its sixteen entries disable policies that the severity filter already
+excludes. The config file is itself an instance of the problem.
+
+## Goals
+
+1. Delete about 2,800 lines from `lib/` and `bin/`, with the matching test and
+   documentation lines, and with no change to module boundaries.
+2. The observable HAP behavior of a paired accessory does not change. The
+   decisions below list every user-visible exception.
+3. Every deletion is verified first: a grep across `lib/ bin/ t/` proves the
+   code is unreachable, test-only, or duplicated, before it goes.
+4. Code, tests, and documentation leave together. No orphaned `.pod` section, no
+   `.3p` entry for a deleted method, no test of a deleted layer.
+5. Two of the six shapes get permanent gates: compatibility vocabulary
+   (extending `t/scripts/namespaces.t`) and undeclared or unused API surface (a
+   new `t/scripts/symbols.t` plus two Perl::Critic policies).
+6. The root `CLAUDE.md` grows by three rules. The audit procedure lives in a new
+   `shrink` skill, per the placement table.
+
+## Non-goals
+
+- No module folds. `Fugu::Sandbox` + `Fugu::Privdrop` + `Fugu::Daemon`,
+  `Fugu::StateFile`, `Fugu::Timeout`, and `Fugu::Random` each have one consumer
+  and could merge, but that is a structure change for another effort.
+- No new base classes. A shared-accessor generator would shrink twelve
+  accessors, at the cost of a new inheritance root. Not worth it.
+- No complexity-ceiling policies (`ProhibitExcessComplexity`,
+  `ProhibitDeepNests`). A numeric ceiling misfires on protocol dispatch code,
+  and the unused-code policies carry the enforcement without it.
+- No code-coverage tooling. `Devel::Cover` is a new dependency, against the
+  minimal-dependency rule. `spec-coverage` stays the one coverage tool.
+- No comment trimming. The comment style is deliberate. A comment leaves only
+  when its code leaves.
+- No rewrite of `plans/001`–`009`. They record what was true when written.
+
+## Decisions
+
+Fifteen findings need a call between delete and wire-up. Take these knowingly.
+
+1. **`validate_setup_code` is wired in, not deleted.** `bin/openhapd` gains the
+   two-line call. Rejecting the trivial setup codes is documented policy and a
+   fail-closed default; deleting it would drop a security check to save twenty
+   lines.
+2. **`has_humidity` becomes a config option.** The HumiditySensor code and its
+   conformance tests work; only the config path is missing. Wiring costs a few
+   lines in `Devices.pm` and `openhapd.conf.5`. Deleting would remove a real
+   capability of the product's core purpose.
+3. **`default_vm` is wired in.** `fuguvm init` writes the setting and
+   `fuguvm(1)` documents it, but `App::FuguVM::CLI::_prepare` hardcodes
+   `'default'`. Honor the setting.
+4. **The QGA subsystem goes whole.** Nothing ever runs `firstboot.exp`, so no
+   guest has an agent, so every `App::FuguVM::QGA` path is dead at runtime and
+   costs about forty seconds on every failed graceful shutdown. Delete the
+   module, its sidecar, its test, the fallback branch in `Guest`, the
+   virtio-serial arguments, and `firstboot.exp`. This is the one module deletion
+   in the effort.
+5. **`fuguvm image` goes.** Its `download` subcommand does not download, and
+   `list` restates what `up` reports. `Miniroot::list` and `_release_root` exist
+   only for it.
+6. **`fuguweb page` and `fuguweb index` go.** Plan 009 kept them because "a
+   project may want one page out of the set". No caller appeared. The `mdoc`
+   pipeline example in `fuguweb(1)` goes with them.
+7. **The `arch` key goes.** No code reads it, so `arch amd64` silently produces
+   an arm64 VM. `fuguvm(1)` states the fixed architecture instead.
+8. **`hap_model` and `hap_manufacturer` go from the documentation.** The daemon
+   hardcodes both values. Deleting two sample lines and four manual lines is
+   smaller than plumbing two knobs nobody set.
+9. **The six thermostat options go from `openhapd.conf.5`.** None appears in any
+   code. The manual stops promising them.
+10. **The FuguWeb knobs `banner`, `pod_center`, `pod_release`, and the
+    `extra.css` hook go.** Only their own round-trip tests set them. `lang`
+    stays: a non-English project needs it on day one.
+11. **The `warn`/`err` level aliases go from `Fugu::Log`.** No config file or
+    fixture uses either spelling. This is the tier's only backward-compat
+    construct.
+12. **The file store loses its shared lock.** `load_pairings` takes `LOCK_SH`,
+    but the writer unlinks and recreates the file, which the lock cannot see.
+    One daemon process owns the store; the honest fix is no lock, not more lock.
+13. **`openhapd -n` stays.** Config-check flags are OpenBSD daemon convention,
+    even though `hapctl check` covers the same ground.
+14. **The non-falsifiable subtests of `t/openhap/integration/hap-protocol.t`
+    go.** Eleven of them accept every plausible status code, and exact
+    assertions for the same endpoints exist in `accessories.t` and
+    `characteristics.t`.
+15. **`t/conformance/` assertions of deleted layers go with their code**, the
+    way commit 0ae2b25 did it: every spec citation the deleted subtest carried
+    must stay covered elsewhere, and `make spec-coverage` proves no citation
+    went stale.
+
+## The gates
+
+The clean-break rule got `t/scripts/namespaces.t`; the simplicity rules get
+gates in the same style. Every gate must fail on a planted violation before its
+phase closes.
+
+1. **Vocabulary.** `namespaces.t` gains a `@BANNED` table beside `@RETIRED`,
+   with the same self-testing pattern shape: `deprecat`, `backward compat`,
+   `for compatibility`, `compatibility shim|layer|alias|wrapper|path`. The sweep
+   skips `plans/` and `spec/` — the specs quote other projects' deprecations,
+   and the plans are history.
+2. **API surface.** A new `t/scripts/symbols.t` proves three invariants over the
+   tracked tree: every public sub in `Fugu::` and `App::` has a caller in `lib/`
+   or `bin/` (with `App::OpenHAP::Test::` exempt — the integration tier is its
+   caller — and a named allowlist for the rest); every module has its sidecar or
+   `.3p` page and every sidecar has its module; every non-core import in `lib/`
+   appears in `cpanfile` and the `deps/` manifests. `Protocol::` is exempt from
+   the caller rule: it is a library, and its `.pod` contract is its caller.
+3. **Perl::Critic.** `Subroutines::ProhibitUnusedPrivateSubroutines` and
+   `Variables::ProhibitUnusedVariables` run at severity 4 via per-policy
+   overrides. `Miscellanea::ProhibitUnrestrictedNoCritic` and
+   `ProhibitUselessNoCritic` join them, so suppression cannot become the escape
+   hatch. The nine no-op entries leave the file.
+4. **`make check` gains `spec-coverage`.** The script is core Perl, so the gate
+   costs nothing locally. `prettier` stays CI-only: it needs `npx`, and no
+   `deps/` manifest provides node.
+
+What stays review discipline, not a gate: multi-layer validation, copy-paste
+blocks, and unreachable options. Text analysis cannot decide those; the `shrink`
+skill carries the hunt procedure and the keep list.
+
+## The keep list
+
+Deletion must not touch:
+
+- Checks on external input: HAP wire data, MQTT payloads, config files, and
+  anything a controller or a device sends. Fail closed.
+- The deliberate duplication across the CPAN boundary. `Protocol::` stays
+  self-contained; `Fugu::Random` documents why it will not be the single source
+  of randomness.
+- The OpenBSD/Linux/Darwin split. Production is OpenBSD; the other two run
+  development and CI.
+- `plan skip_all` on missing dependencies in module tests, and the never-skip
+  rule in integration tests.
+- Both store implementations, the sans-IO engine, and the store contract.
+
+## Phases
+
+1. **The ground rules.** The vocabulary gate, the `.perlcriticrc` cleanup,
+   `spec-coverage` in `make check`, the three `CLAUDE.md` rules, and the
+   `shrink` skill. Two comments reword so the gate passes.
+2. **`Protocol::`.** About 470 lines: the `Server.pm` and `Controller.pm` dedup,
+   the dead constants, the store fixes, and decision 1.
+3. **`Fugu::`.** About 600 lines plus the mirrored `.3p` entries: the dead
+   graceful-exit facility, the test-only options, the four-fold idioms, and
+   decision 11.
+4. **`App::OpenHAP`.** About 740 lines of lib and bin plus 330 test lines: the
+   unreachable Tasmota surface, the base-class dedup, the manual cleanup, the
+   integration-harness dedup, and decisions 2, 8, 9, 14.
+5. **`App::FuguVM` and `App::FuguWeb`.** About 1,000 lines: the QGA deletion,
+   the CLI dedup, the extraction leftovers, and decisions 3–7, 10.
+6. **The lock.** `t/scripts/symbols.t` and the Perl::Critic enables land last,
+   because they only pass after the sweeps.
+
+Phases 2 to 5 depend only on phase 1 and are mutually independent. Phase 6
+depends on all of them. Each phase lands whole — code, tests, sidecars, manuals,
+and samples together — and `make check` passes at its end.
+
+## Testing
+
+Every phase re-verifies its deletions with the greps in its acceptance criteria;
+the audit that produced the counts is input, not proof. Phase 2 ends with the
+conformance tier green. Phase 4 ends with `make integration` green in CI. Phase
+5 ends with the double-build check of `t/web/site.t`. Phases 1 and 6 plant one
+violation per gate and watch the gate fail, then remove the plant.

--- a/plans/010-simplify/plan-1.md
+++ b/plans/010-simplify/plan-1.md
@@ -3,7 +3,7 @@
 This phase lands the rules and the gates that pass on today's tree: the
 vocabulary gate, the `.perlcriticrc` cleanup, `spec-coverage` in `make check`,
 the three `CLAUDE.md` rules, and the `shrink` skill. It depends on no other
-phase. The sweeps in phases 2–5 cite the rules this phase writes down.
+phase.
 
 ## Tasks
 
@@ -14,57 +14,65 @@ phase. The sweeps in phases 2–5 cite the rules this phase writes down.
   - `deprecation` — `qr/\bdeprecat/i`
   - `backward compatibility` — `qr/backwards?[ -]compat/i`
   - `for compatibility` — `qr/for compatibility/i`
-  - `compatibility construct` —
+  - `compatibility shim` —
     `qr/compatibility (?:shim|layer|alias|wrapper|path)/i`
-- Sweep the same `git ls-files` list the retired names use, and assert each
-  pattern against its own name, as the file already does for `@RETIRED`.
-- Skip `plans/` (already skipped) and add `spec/` to the skip set for the
-  `@BANNED` sweep only. The specs quote other projects' deprecations
-  (`spec/HAP-Services.md` names a deprecated service; `spec/MQTT-Transport.md`
-  recommends defaults "for compatibility"), and the retired-name sweep must keep
-  reading them.
+- Each name must match its own pattern; the file's self-test subtest enforces
+  that, so check the fourth entry: "compatibility shim" matches its alternation.
+- Sweep the same `git ls-files` list the retired names use. Skip `plans/`
+  (already skipped) and add `spec/` to the skip set for the `@BANNED` sweep
+  only: `spec/HAP-Services.md` names a deprecated service and
+  `spec/MQTT-Transport.md` recommends defaults "for compatibility", and the
+  retired-name sweep must keep reading both.
 - Do not ban the bare word "legacy". The Tasmota and HAP specs use it as a term
-  of art, and `t/conformance/mqtt-control.t` quotes it from a spec table.
+  of art, and `t/conformance/mqtt-control.t` quotes a spec table.
+- The gate reads line by line, so a phrase split across a comment wrap escapes
+  it. Accepted: the gate catches vocabulary, review catches intent.
 
-### 1.2 Two comments reword
+### 1.2 Three cleanups the gate forces
 
-The gate must pass on a clean tree, and two lines trip it today. Users: the gate
-in 1.1.
+The gate must pass on the clean tree. Exactly three tracked lines outside
+`plans/` and `spec/` trip the four patterns today. Users: the gate in 1.1.
 
 - `lib/Protocol/HAP/Server.pm:356-358`: the `/prepare` comment ends with "Accept
-  both methods for compatibility." The reason is spec ambiguity, not
-  compatibility. Reword to: "The spec shows POST in the table, but the later
-  text uses PUT. Accept both."
+  both methods for compatibility." The reason is spec ambiguity. Reword to: "The
+  spec shows POST in the table, but the later text uses PUT. Accept both."
 - `lib/App/FuguVM/Config.pm:111-112`: the comment disclaims "a compatibility
   path". Keep the disclaimer, drop the phrase: "This is not a fallback: 'fuguvm
   init' writes vms/default.conf, and fuguvm(1) documents the directory."
+- `TODO.md:803`: the bullet "Maintain backward compatibility where possible"
+  contradicts the clean-break rule. Delete the bullet.
 
 ### 1.3 The `.perlcriticrc` cleanup
 
-- Confirm the default severity of every `[-Policy]` entry with
-  `perlcritic --profile .perlcriticrc --list`. Delete each entry whose policy
-  defaults below severity 4 — the severity filter already excludes it, so the
-  entry never did anything. Expected deletions, to confirm rather than trust:
-  `ProhibitExplicitISA`, `ProhibitPostfixControls`,
-  `ProhibitParensWithBuiltins`, `ProhibitUnlessBlocks`,
-  `RequireExtendedFormatting`, `ProhibitMagicNumbers`, `RequirePodSections`,
-  `RequirePodAtEnd`, and the `[CodeLayout::ProhibitHardTabs]` block.
-- Keep every entry whose policy defaults to severity 4 or 5.
-- Keep the section comments that still describe a kept entry; delete the rest.
+- Confirm the default severity of every entry with `perlcritic --list`
+  (severities print in column one). Delete each entry whose policy defaults
+  below severity 4 — the severity filter already excludes it, so the entry never
+  did anything. Verified deletions, nine entries: `ProhibitExplicitISA` (3),
+  `ProhibitPostfixControls` (2), `ProhibitParensWithBuiltins` (1),
+  `ProhibitUnlessBlocks` (2), `RequireExtendedFormatting` (3),
+  `ProhibitMagicNumbers` (2), `RequirePodSections` (2), `RequirePodAtEnd` (1),
+  and the `[CodeLayout::ProhibitHardTabs]` block (3) — the last is a configuring
+  block for a policy the filter excludes, not a disable.
+- Keep the six entries whose policies default to severity 4 or 5, including
+  `[-InputOutput::RequireBriefOpen]`.
+- Keep the section comments that still describe a kept entry.
 
 ### 1.4 `make check` gains `spec-coverage`
 
 - Change the `check` target to `check: lint test tidy spec-coverage`.
+- Update the stale comment at `CLAUDE.md:48` that lists the target's parts.
 - `prettier` stays out: it runs through `npx`, and no `deps/` manifest provides
-  node. Note this in the Makefile comment above the target.
+  node. Note this in a Makefile comment above the target. CI already runs
+  `spec-coverage` in `test.yml`; the gain is local parity.
 
 ### 1.5 The three rules in `CLAUDE.md`
 
 Add a `## Simplicity` section after "Error handling and security", three
-bullets, nothing more:
+bullets, nothing more. The wording below is chosen to pass the 1.1 patterns —
+keep it, or check any rewording against them:
 
-- The project has no users. Delete a compatibility path; never deprecate, alias,
-  or migrate.
+- The project has no users. Delete old code paths outright; never keep an alias,
+  a bridge, or a migration.
 - Do not keep test-only API. Delete a sub or option that only tests use,
   together with its test.
 - Validate each input once, at its boundary. Do not check the same invariant
@@ -78,33 +86,43 @@ bullets, nothing more:
 - Content, in order:
   - The six shapes of creep from the design, one line each, with one former
     in-repo example each.
-  - The keep list from the design, verbatim in substance.
-  - The procedure: grep `lib/ bin/ t/` for callers before every deletion; delete
-    code, test, and documentation together; run `make check`; commit as
-    `refactor` with `!` when observable behavior changes.
+  - The keep list from the design, and the design's verified-keeps list — the
+    audit claims the review refuted — as cautionary examples.
+  - The procedure: grep `lib/ bin/ t/` for callers before every deletion; check
+    conformance tests for spec citations on the code; delete code, test, and
+    documentation together; run `make check`; commit as `refactor` with `!` when
+    observable behavior changes.
 - The skill points to the design for background; it restates nothing from
   `CLAUDE.md`.
+
+### 1.7 `t/CLAUDE.md`
+
+- The tooling-test paragraph describes `deps.t` and `conventions.t`. Add one
+  sentence for `namespaces.t`'s two sweeps: retired names and banned vocabulary.
 
 ## Deliverables
 
 - Extended `t/scripts/namespaces.t`.
-- Two reworded comments in `lib/Protocol/HAP/Server.pm` and
-  `lib/App/FuguVM/Config.pm`.
+- Reworded lines in `lib/Protocol/HAP/Server.pm`, `lib/App/FuguVM/Config.pm`,
+  and `TODO.md`.
 - A shorter `.perlcriticrc`.
-- Updated `Makefile` and `CLAUDE.md`.
+- Updated `Makefile`, `CLAUDE.md`, and `t/CLAUDE.md`.
 - New `.claude/skills/shrink/SKILL.md`.
 
 ## Acceptance criteria
 
 - `make check` passes, and now runs `spec-coverage`.
 - `prove -l t/scripts/namespaces.t` passes on the clean tree.
-- Plant one violation per pattern — a `# kept for backward compatibility`
-  comment in a scratch module under `lib/` — and the test fails naming the file
-  and the pattern. Remove the plant.
-- Add a `@BANNED` entry with a pattern that cannot match its own name, and the
+- Plant four violations — one line per pattern, in a scratch module under
+  `lib/`, added with `git add` (the sweep reads tracked files only) — and the
+  test fails four times, naming the file and the pattern each time. Remove the
+  plants.
+- Add a `@BANNED` entry whose pattern cannot match its own name, and the
   self-test subtest fails. Remove it.
-- `perlcritic --profile .perlcriticrc --list` reports the same enabled policy
-  set before and after the cleanup.
-- `grep -n 'for compatibility' lib` finds nothing.
-- `grep -c '^-' .claude/skills/shrink/SKILL.md` confirms the file exists;
-  `make prettier` (where npx exists) accepts it.
+- `perlcritic --profile .perlcriticrc --list-enabled` reports the same policy
+  set before and after the cleanup (`--list` ignores the profile;
+  `--list-enabled` is the falsifiable form).
+- `grep -rn 'for compatibility' lib` finds nothing, and
+  `grep -n 'backward compatibility' TODO.md` finds nothing.
+- The new `CLAUDE.md` bullets themselves pass the gate:
+  `prove -l t/scripts/namespaces.t` stays green after the `CLAUDE.md` edit.

--- a/plans/010-simplify/plan-1.md
+++ b/plans/010-simplify/plan-1.md
@@ -1,0 +1,110 @@
+# Phase 1 — The ground rules
+
+This phase lands the rules and the gates that pass on today's tree: the
+vocabulary gate, the `.perlcriticrc` cleanup, `spec-coverage` in `make check`,
+the three `CLAUDE.md` rules, and the `shrink` skill. It depends on no other
+phase. The sweeps in phases 2–5 cite the rules this phase writes down.
+
+## Tasks
+
+### 1.1 The vocabulary gate
+
+- Add a `@BANNED` table to `t/scripts/namespaces.t`, beside `@RETIRED`, with the
+  same `{ name, pattern }` shape. Entries:
+  - `deprecation` — `qr/\bdeprecat/i`
+  - `backward compatibility` — `qr/backwards?[ -]compat/i`
+  - `for compatibility` — `qr/for compatibility/i`
+  - `compatibility construct` —
+    `qr/compatibility (?:shim|layer|alias|wrapper|path)/i`
+- Sweep the same `git ls-files` list the retired names use, and assert each
+  pattern against its own name, as the file already does for `@RETIRED`.
+- Skip `plans/` (already skipped) and add `spec/` to the skip set for the
+  `@BANNED` sweep only. The specs quote other projects' deprecations
+  (`spec/HAP-Services.md` names a deprecated service; `spec/MQTT-Transport.md`
+  recommends defaults "for compatibility"), and the retired-name sweep must keep
+  reading them.
+- Do not ban the bare word "legacy". The Tasmota and HAP specs use it as a term
+  of art, and `t/conformance/mqtt-control.t` quotes it from a spec table.
+
+### 1.2 Two comments reword
+
+The gate must pass on a clean tree, and two lines trip it today. Users: the gate
+in 1.1.
+
+- `lib/Protocol/HAP/Server.pm:356-358`: the `/prepare` comment ends with "Accept
+  both methods for compatibility." The reason is spec ambiguity, not
+  compatibility. Reword to: "The spec shows POST in the table, but the later
+  text uses PUT. Accept both."
+- `lib/App/FuguVM/Config.pm:111-112`: the comment disclaims "a compatibility
+  path". Keep the disclaimer, drop the phrase: "This is not a fallback: 'fuguvm
+  init' writes vms/default.conf, and fuguvm(1) documents the directory."
+
+### 1.3 The `.perlcriticrc` cleanup
+
+- Confirm the default severity of every `[-Policy]` entry with
+  `perlcritic --profile .perlcriticrc --list`. Delete each entry whose policy
+  defaults below severity 4 — the severity filter already excludes it, so the
+  entry never did anything. Expected deletions, to confirm rather than trust:
+  `ProhibitExplicitISA`, `ProhibitPostfixControls`,
+  `ProhibitParensWithBuiltins`, `ProhibitUnlessBlocks`,
+  `RequireExtendedFormatting`, `ProhibitMagicNumbers`, `RequirePodSections`,
+  `RequirePodAtEnd`, and the `[CodeLayout::ProhibitHardTabs]` block.
+- Keep every entry whose policy defaults to severity 4 or 5.
+- Keep the section comments that still describe a kept entry; delete the rest.
+
+### 1.4 `make check` gains `spec-coverage`
+
+- Change the `check` target to `check: lint test tidy spec-coverage`.
+- `prettier` stays out: it runs through `npx`, and no `deps/` manifest provides
+  node. Note this in the Makefile comment above the target.
+
+### 1.5 The three rules in `CLAUDE.md`
+
+Add a `## Simplicity` section after "Error handling and security", three
+bullets, nothing more:
+
+- The project has no users. Delete a compatibility path; never deprecate, alias,
+  or migrate.
+- Do not keep test-only API. Delete a sub or option that only tests use,
+  together with its test.
+- Validate each input once, at its boundary. Do not check the same invariant
+  again downstream.
+
+### 1.6 The `shrink` skill
+
+- Create `.claude/skills/shrink/SKILL.md`, modeled on `ship-it`: frontmatter
+  with name and description, then the procedure. Do not name it `simplify` — a
+  harness skill already holds that name.
+- Content, in order:
+  - The six shapes of creep from the design, one line each, with one former
+    in-repo example each.
+  - The keep list from the design, verbatim in substance.
+  - The procedure: grep `lib/ bin/ t/` for callers before every deletion; delete
+    code, test, and documentation together; run `make check`; commit as
+    `refactor` with `!` when observable behavior changes.
+- The skill points to the design for background; it restates nothing from
+  `CLAUDE.md`.
+
+## Deliverables
+
+- Extended `t/scripts/namespaces.t`.
+- Two reworded comments in `lib/Protocol/HAP/Server.pm` and
+  `lib/App/FuguVM/Config.pm`.
+- A shorter `.perlcriticrc`.
+- Updated `Makefile` and `CLAUDE.md`.
+- New `.claude/skills/shrink/SKILL.md`.
+
+## Acceptance criteria
+
+- `make check` passes, and now runs `spec-coverage`.
+- `prove -l t/scripts/namespaces.t` passes on the clean tree.
+- Plant one violation per pattern — a `# kept for backward compatibility`
+  comment in a scratch module under `lib/` — and the test fails naming the file
+  and the pattern. Remove the plant.
+- Add a `@BANNED` entry with a pattern that cannot match its own name, and the
+  self-test subtest fails. Remove it.
+- `perlcritic --profile .perlcriticrc --list` reports the same enabled policy
+  set before and after the cleanup.
+- `grep -n 'for compatibility' lib` finds nothing.
+- `grep -c '^-' .claude/skills/shrink/SKILL.md` confirms the file exists;
+  `make prettier` (where npx exists) accepts it.

--- a/plans/010-simplify/plan-2.md
+++ b/plans/010-simplify/plan-2.md
@@ -1,0 +1,140 @@
+# Phase 2 — The Protocol:: sweep
+
+This phase removes about 470 lines from `lib/Protocol/` and its tests: the
+copy-paste blocks in `Server.pm` and `Controller.pm`, the dead constants and
+test-only accessors, the redundant validation, and the store fixes. It wires in
+`validate_setup_code` (design decision 1). Phase 1 must land first — the
+vocabulary gate guards the comments this phase edits.
+
+Every task re-verifies its deletion with a grep before the code goes. A grep
+that finds a caller stops the deletion and updates this plan.
+
+## Tasks
+
+### 2.1 Server.pm dedup
+
+- Add three private helpers and replace their copies:
+  `_char_status($aid, $iid, $code)` for the seven per-characteristic error
+  blocks; `_resolve_char($aid, $iid)` for the duplicated accessory-then-
+  characteristic lookup in the GET and PUT handlers; `_tlv_response($body)` for
+  the seven `application/pairing+tlv8` response blocks.
+- Replace the hand-built unknown-method error at `Server.pm:672-683` with
+  `_pairings_error`, and fold the three copies of the admin check into one
+  `_require_admin($session)`.
+- Let `queue_event` resolve the characteristic value when the caller omits it,
+  and delete the `_queue_change_event` wrapper.
+- Delete the dead `$session->{timed_write}` capture in `_handle_prepare`; the
+  repo's only mention of `timed_write` is that assignment. The 200/400 responses
+  stay.
+- Flatten `_handle_identify`: `{bridge}` is set unconditionally in
+  `_initialize`, so the `if ($bridge)` branch cannot be false.
+- Pass `status_text` at the one 470 call site and shrink `_response`; return a
+  400 directly from `_serve_request` on a malformed request; drop the
+  unreachable `// -1` on `last_paired_state`.
+
+### 2.2 Controller.pm and Session.pm
+
+- Hold a `Protocol::HAP::Session` with the key roles swapped and delegate
+  `_encrypt`/`_decrypt` to it. Rework `_drain_frames` to consume only whole
+  frames through the same path, then delete `_decrypt_peek`.
+- Inline `_build_request` and `_parse_response` at their single call sites.
+- Extract the error TLV before the separator split in `list_pairings`, so
+  `_tlv_request` stays the one decoder of error responses.
+- Move the test-harness defaults out of the library: the two integration tests
+  pass `timeout` and `controller_id`; the `OPENHAP_TEST_TIMEOUT` fallback and
+  the `openhap-test-ctrl` literal leave `Controller.pm`.
+- Delete the two unread `my $result =` assignments, and the unreachable
+  `return $data unless $self->{encrypted}` guards in `Session::encrypt` and
+  `decrypt` — every call site already gates on the session state.
+
+### 2.3 Pairing.pm and SRP.pm
+
+- Delete the re-validation in `Pairing::new` of the setup code and store that
+  `Server::new` proved three lines earlier. Users: `Server::_initialize`,
+  `Server::_regenerate_identity`, and `t/protocol/pairing.t` (the store `die`
+  subtest goes with the check).
+- Fold the two auth-failure blocks into one `_auth_failure` helper, and the
+  identical decode-and-check preambles of `handle_pair_setup` and
+  `handle_pair_verify` into another.
+- Keep one copy of the MAC-format rule: `Server::get_device_id` calls it;
+  `Pairing::_get_accessory_pairing_id` goes.
+- Delete the constants nothing references: `kTLVType_RetryDelay`,
+  `kTLVType_Certificate`, `kTLVType_FragmentData`, `kTLVType_FragmentLast`, and
+  the four referenced only by existence asserts in `t/protocol/pairing.t` (those
+  asserts go too).
+- Delete `get_failed_attempts`; its comment says "(for testing)". The tests read
+  `{failed_auth_attempts}` directly.
+- In `SRP.pm`: drop the Client's duplicate `N_LEN` and `_i2b`; drop the
+  pre-declared `undef` state slots; drop the redundant parameters of
+  `compute_verifier`; keep one accessor name for the session key (the
+  specification's term wins) and rename the one caller of the other; drop the
+  two `die` guards in `generate_server_proof` that only `t/protocol/srp.t`
+  reaches, with those subtests.
+
+### 2.4 The data model
+
+- Delete `%FORMATS` and `%PERMISSIONS` from `Characteristic.pm`; nothing reads
+  them, and `new` validates neither. The two conformance subtests that assert
+  the tables contain their own entries go with them; both cite catalog sections
+  that `t/conformance/hap-characteristics.t` still covers with data-driven rows.
+- Delete `maxLen` and the `$include_value` parameter of `to_json`; no caller
+  passes either.
+- Keep one copy of `HAP_BASE_UUID` and `_uuid_to_short`, in `Protocol::HAP`, and
+  point `Characteristic`, `Service`, and `Server.pm:944` at it.
+- Replace the six boilerplate `Characteristic->new` blocks in `Accessory.pm`
+  with a table and a loop; delete the empty `identify` hook that no subclass
+  overrides.
+- Lift the unconditional `require` calls in `Accessory`, `Bridge`, and `Service`
+  to top-level `use` lines. `t/protocol/boundary.t` parses both forms, so the
+  dependency rule keeps holding.
+
+### 2.5 The stores
+
+- Delete the shared lock from `Store::File::load_pairings` (design decision 12)
+  and collapse the log-then-die pairs to `open ... or die` with `_reason`.
+- Delete: the `path` accessor (no caller anywhere), the `/^\d+$/` re-validation
+  of counters this module wrote itself, the `$data //= ''` fallback, and the
+  `unlink` before `sysopen O_EXCL` that defeats the exclusivity check.
+- Delete the defensive deep-copy in `Store::Memory::load_pairings`; no caller
+  mutates the result. Drop the unread `%args` of `new`.
+
+### 2.6 SetupCode and TLV
+
+- Wire `validate_setup_code` into `bin/openhapd` beside the existing
+  `normalize_setup_code` call: a configured code that validation rejects is a
+  fatal config error. Update `openhapd.conf.5` with one sentence.
+- Keep one definition of the separator type: `TLV::kTLVType_Separator` goes,
+  `Pairing.pm` keeps its constant, and `encode_separator` moves its two test
+  callers to `TLV::encode`.
+- Delete `Imsg::_decode_header`; inline the `unpack` at its one call site.
+
+### 2.7 Documentation and tests
+
+- Update the `.pod` sidecars for every deleted public name: `Store/File.pod`,
+  `Characteristic.pod`, `Pairing.pod`, `SRP.pod`, `TLV.pod`, `Controller.pod`,
+  `SetupCode.pod`.
+- Follow commit 0ae2b25 for every conformance subtest that leaves: name the spec
+  citations it carried and the surviving subtest that still covers each.
+
+## Deliverables
+
+- Smaller
+  `lib/Protocol/HAP/{Server,Controller,Session,Pairing,SRP, Characteristic,Service,Accessory,Bridge,SetupCode,TLV}.pm`,
+  `Store/{File,Memory}.pm`, and `lib/Protocol/Imsg.pm`.
+- `bin/openhapd` validates the configured setup code.
+- Updated sidecars and `man/openhap/openhapd.conf.5`.
+- Trimmed `t/protocol/` and `t/conformance/` files.
+
+## Acceptance criteria
+
+- `make check` passes; `make spec-coverage` reports no stale citation.
+- `prove -l t/conformance/*.t` passes.
+- `grep -rn 'timed_write\|%FORMATS\|%PERMISSIONS\|get_failed_attempts' lib t`
+  finds nothing.
+- `grep -rn 'encode_separator\|_decrypt_peek\|_queue_change_event' lib t` finds
+  nothing.
+- `grep -c '_uuid_to_short' lib -r` reports exactly one defining file.
+- `openhapd -n` on a config with setup code `000-00-000` fails with a
+  human-readable message; the same config with a valid code passes.
+- Byte-level pairing behavior is unchanged: `t/conformance/hap-pairing.t` and
+  `hap-encryption.t` pass without edits to their vectors.

--- a/plans/010-simplify/plan-2.md
+++ b/plans/010-simplify/plan-2.md
@@ -1,13 +1,14 @@
 # Phase 2 — The Protocol:: sweep
 
-This phase removes about 470 lines from `lib/Protocol/` and its tests: the
-copy-paste blocks in `Server.pm` and `Controller.pm`, the dead constants and
-test-only accessors, the redundant validation, and the store fixes. It wires in
-`validate_setup_code` (design decision 1). Phase 1 must land first — the
-vocabulary gate guards the comments this phase edits.
+This phase removes about 350 lines from `lib/Protocol/` and its tests: the
+copy-paste blocks in `Server.pm` and `Controller.pm`, the dead constants, the
+redundant wrappers, and the store lock. It executes decisions 1, 12, 15, and 18.
+Phase 1 must land first.
 
 Every task re-verifies its deletion with a grep before the code goes. A grep
-that finds a caller stops the deletion and updates this plan.
+that finds a caller stops the deletion and updates this plan — the review
+already moved `get_failed_attempts`, the `Session` guards, and the
+`Pairing::new` validation to the design's verified-keeps list this way.
 
 ## Tasks
 
@@ -15,9 +16,10 @@ that finds a caller stops the deletion and updates this plan.
 
 - Add three private helpers and replace their copies:
   `_char_status($aid, $iid, $code)` for the seven per-characteristic error
-  blocks; `_resolve_char($aid, $iid)` for the duplicated accessory-then-
-  characteristic lookup in the GET and PUT handlers; `_tlv_response($body)` for
-  the seven `application/pairing+tlv8` response blocks.
+  blocks; `_resolve_char($aid, $iid)` for the duplicated
+  accessory-then-characteristic lookup in the GET and PUT handlers;
+  `_tlv_response($body)` for the seven `application/pairing+tlv8` response
+  blocks.
 - Replace the hand-built unknown-method error at `Server.pm:672-683` with
   `_pairings_error`, and fold the three copies of the admin check into one
   `_require_admin($session)`.
@@ -25,34 +27,45 @@ that finds a caller stops the deletion and updates this plan.
   and delete the `_queue_change_event` wrapper.
 - Delete the dead `$session->{timed_write}` capture in `_handle_prepare`; the
   repo's only mention of `timed_write` is that assignment. The 200/400 responses
-  stay.
+  stay, and the malformed-request fallback at `:263-267` stays as it is — it
+  routes through the same encrypted tail as every response.
 - Flatten `_handle_identify`: `{bridge}` is set unconditionally in
-  `_initialize`, so the `if ($bridge)` branch cannot be false.
-- Pass `status_text` at the one 470 call site and shrink `_response`; return a
-  400 directly from `_serve_request` on a malformed request; drop the
+  `_initialize`, so the `if ($bridge)` branch cannot be false. This also deletes
+  the comment whose "blink an LED" wording the phase-4 grep matches.
+- Pass `status_text` at the one 470 call site and shrink `_response`; drop the
   unreachable `// -1` on `last_paired_state`.
+- Keep the `Host::listen`-side contract in mind: `Server` state set in
+  `_initialize` is relied on by forked conformance tests; delete nothing that
+  `t/conformance/hap-pairing-exchange.t` exercises across its fork.
 
 ### 2.2 Controller.pm and Session.pm
 
 - Hold a `Protocol::HAP::Session` with the key roles swapped and delegate
-  `_encrypt`/`_decrypt` to it. Rework `_drain_frames` to consume only whole
-  frames through the same path, then delete `_decrypt_peek`.
+  `_encrypt`/`_decrypt` framing to it, so the frame codec exists once.
+- Rework the read path: `_round_trip`'s accumulate loop currently re-decrypts
+  the whole buffer via `_decrypt_peek` on every read. Buffer until the 2-byte
+  length header shows a whole frame, decrypt each frame exactly once through the
+  session, then delete `_decrypt_peek`. This is a rewrite of the accumulation
+  loop, not a drop-in: `Session::decrypt` advances its counter per consumed
+  frame and has no peek mode. `_drain_frames` then reuses the same one-frame
+  step.
 - Inline `_build_request` and `_parse_response` at their single call sites.
 - Extract the error TLV before the separator split in `list_pairings`, so
   `_tlv_request` stays the one decoder of error responses.
-- Move the test-harness defaults out of the library: the two integration tests
-  pass `timeout` and `controller_id`; the `OPENHAP_TEST_TIMEOUT` fallback and
-  the `openhap-test-ctrl` literal leave `Controller.pm`.
-- Delete the two unread `my $result =` assignments, and the unreachable
-  `return $data unless $self->{encrypted}` guards in `Session::encrypt` and
-  `decrypt` — every call site already gates on the session state.
+- Decision 18: `controller_id` becomes a required argument (die without it); the
+  `OPENHAP_TEST_TIMEOUT` fallback leaves the library; the `timeout // 5` default
+  stays. Users to update, verified:
+  `lib/App/OpenHAP/Test/Integration.pm:138-144` (passes `controller_id` and
+  `timeout => $ENV{OPENHAP_TEST_TIMEOUT} // 30`),
+  `t/conformance/hap-pairing-exchange.t`,
+  `t/conformance/hap-encryption-exchange.t`, `t/protocol/controller.t`, and
+  `t/protocol/server.t`. The `Integration.pm` edit is minimal here; phase 4
+  rewrites the harness later.
+- Delete the two unread `my $result =` assignments in `add_pairing` and
+  `remove_pairing`.
 
 ### 2.3 Pairing.pm and SRP.pm
 
-- Delete the re-validation in `Pairing::new` of the setup code and store that
-  `Server::new` proved three lines earlier. Users: `Server::_initialize`,
-  `Server::_regenerate_identity`, and `t/protocol/pairing.t` (the store `die`
-  subtest goes with the check).
 - Fold the two auth-failure blocks into one `_auth_failure` helper, and the
   identical decode-and-check preambles of `handle_pair_setup` and
   `handle_pair_verify` into another.
@@ -62,47 +75,56 @@ that finds a caller stops the deletion and updates this plan.
   `kTLVType_Certificate`, `kTLVType_FragmentData`, `kTLVType_FragmentLast`, and
   the four referenced only by existence asserts in `t/protocol/pairing.t` (those
   asserts go too).
-- Delete `get_failed_attempts`; its comment says "(for testing)". The tests read
-  `{failed_auth_attempts}` directly.
 - In `SRP.pm`: drop the Client's duplicate `N_LEN` and `_i2b`; drop the
   pre-declared `undef` state slots; drop the redundant parameters of
-  `compute_verifier`; keep one accessor name for the session key (the
-  specification's term wins) and rename the one caller of the other; drop the
-  two `die` guards in `generate_server_proof` that only `t/protocol/srp.t`
-  reaches, with those subtests.
+  `compute_verifier`; keep one accessor name for the session key and update the
+  one caller of the other; drop the two `die` guards in `generate_server_proof`
+  that only `t/protocol/srp.t` reaches, with those subtests.
 
 ### 2.4 The data model
 
 - Delete `%FORMATS` and `%PERMISSIONS` from `Characteristic.pm`; nothing reads
-  them, and `new` validates neither. The two conformance subtests that assert
-  the tables contain their own entries go with them; both cite catalog sections
-  that `t/conformance/hap-characteristics.t` still covers with data-driven rows.
+  them and `new` validates neither. Decision 15 applies: their two subtests
+  carry the only `[HAP-Characteristics §2]` and `[§3]` citations in the tree, so
+  re-home both onto the data-driven catalog subtest — it already asserts each
+  row's format and permissions strings — before the tables go. Attach the
+  coverage-matrix diff.
 - Delete `maxLen` and the `$include_value` parameter of `to_json`; no caller
   passes either.
-- Keep one copy of `HAP_BASE_UUID` and `_uuid_to_short`, in `Protocol::HAP`, and
-  point `Characteristic`, `Service`, and `Server.pm:944` at it.
+- Keep one copy of the short-UUID rule: a documented public `uuid_to_short` in
+  `Protocol::HAP` (with a `HAP.pod` entry), used by `Characteristic`, `Service`,
+  and `Server.pm:944`. A private sub there would have no same-file caller and a
+  cross-package `_` name is a poor CPAN contract.
 - Replace the six boilerplate `Characteristic->new` blocks in `Accessory.pm`
   with a table and a loop; delete the empty `identify` hook that no subclass
-  overrides.
+  overrides, and the Identify characteristic's `on_set` call into it.
 - Lift the unconditional `require` calls in `Accessory`, `Bridge`, and `Service`
-  to top-level `use` lines. `t/protocol/boundary.t` parses both forms, so the
-  dependency rule keeps holding.
+  to top-level `use` lines; `t/protocol/boundary.t` parses both forms.
 
 ### 2.5 The stores
 
-- Delete the shared lock from `Store::File::load_pairings` (design decision 12)
-  and collapse the log-then-die pairs to `open ... or die` with `_reason`.
-- Delete: the `path` accessor (no caller anywhere), the `/^\d+$/` re-validation
-  of counters this module wrote itself, the `$data //= ''` fallback, and the
-  `unlink` before `sysopen O_EXCL` that defeats the exclusivity check.
-- Delete the defensive deep-copy in `Store::Memory::load_pairings`; no caller
-  mutates the result. Drop the unread `%args` of `new`.
+- Decision 12: delete the shared lock from `Store::File::load_pairings`, and
+  with it the `flock` promise and its comment in `bin/openhapd` (`:301`, `:311`)
+  — the only post-pledge `flock` callers are these two lines; `Fugu::Pidfile`'s
+  lock happens before the pledge. Collapse the log-then-die pairs to
+  `open ... or die` with `_reason`.
+- Delete the `path` accessor and its one subtest (`t/protocol/store-file.t:29`),
+  and the unread `%args` of `Store::Memory::new`.
+- Keep, per the design: the `/^\d+$/` counter guards (sole type checks on
+  `state.json` values; `get_auth_attempts` feeds the lockout), the `O_EXCL`
+  pre-unlink (crash recovery for a recycled pid), the `$data //= ''` line goes
+  only if a fresh grep shows both callers pass defined strings — it did at audit
+  time.
+- Delete the deep copy in `Store::Memory::load_pairings` only if
+  `Store/Memory.pod:24-25` changes in the same commit — the copy is a documented
+  contract. Otherwise keep both. Prefer keeping both; the saving is three lines.
 
-### 2.6 SetupCode and TLV
+### 2.6 SetupCode, TLV, Imsg
 
-- Wire `validate_setup_code` into `bin/openhapd` beside the existing
-  `normalize_setup_code` call: a configured code that validation rejects is a
-  fatal config error. Update `openhapd.conf.5` with one sentence.
+- Decision 1: `bin/openhapd` calls `validate_setup_code` in place of
+  `normalize_setup_code` — it normalizes internally, so the boundary validates
+  once. A rejected code is a fatal config error before daemonize. Update
+  `openhapd.conf.5` with one sentence.
 - Keep one definition of the separator type: `TLV::kTLVType_Separator` goes,
   `Pairing.pm` keeps its constant, and `encode_separator` moves its two test
   callers to `TLV::encode`.
@@ -110,31 +132,41 @@ that finds a caller stops the deletion and updates this plan.
 
 ### 2.7 Documentation and tests
 
-- Update the `.pod` sidecars for every deleted public name: `Store/File.pod`,
-  `Characteristic.pod`, `Pairing.pod`, `SRP.pod`, `TLV.pod`, `Controller.pod`,
-  `SetupCode.pod`.
-- Follow commit 0ae2b25 for every conformance subtest that leaves: name the spec
-  citations it carried and the surviving subtest that still covers each.
+- Update the sidecars for every deleted or changed public name:
+  `Store/File.pod`, `Characteristic.pod`, `SRP.pod`, `TLV.pod`, `Controller.pod`
+  (the `controller_id` contract), `SetupCode.pod`, `HAP.pod` (the new
+  `uuid_to_short`).
+- Follow commit 0ae2b25 for every conformance subtest that leaves or moves: name
+  the citations and where each lands, per decision 15.
 
 ## Deliverables
 
 - Smaller
   `lib/Protocol/HAP/{Server,Controller,Session,Pairing,SRP, Characteristic,Service,Accessory,Bridge,SetupCode,TLV}.pm`,
   `Store/{File,Memory}.pm`, and `lib/Protocol/Imsg.pm`.
-- `bin/openhapd` validates the configured setup code.
+- `bin/openhapd`: setup-code validation wired, `flock` promise gone.
 - Updated sidecars and `man/openhap/openhapd.conf.5`.
-- Trimmed `t/protocol/` and `t/conformance/` files.
+- Trimmed `t/protocol/` and `t/conformance/` files, plus the `Integration.pm`
+  constructor-argument edit.
 
 ## Acceptance criteria
 
-- `make check` passes; `make spec-coverage` reports no stale citation.
-- `prove -l t/conformance/*.t` passes.
-- `grep -rn 'timed_write\|%FORMATS\|%PERMISSIONS\|get_failed_attempts' lib t`
+- `make check` passes; `prove -l t/conformance/*.t` passes.
+- `scripts/spec-coverage` (without `--quiet`) shows the same per-file section
+  counts as before the phase; the §2/§3 citations moved, not vanished. The diff
+  is attached to the commit.
+- `git grep -n 'timed_write\|_decrypt_peek\|_queue_change_event\|encode_separator' lib t`
   finds nothing.
-- `grep -rn 'encode_separator\|_decrypt_peek\|_queue_change_event' lib t` finds
-  nothing.
-- `grep -c '_uuid_to_short' lib -r` reports exactly one defining file.
+- `git grep -n 'FORMATS\|PERMISSIONS' lib t` finds nothing — the conformance
+  test spells them `$Protocol::HAP::Characteristic::FORMATS`, so the pattern
+  must not require the `%` sigil.
+- `git grep -n 'sub uuid_to_short' lib` reports exactly one definition, in
+  `lib/Protocol/HAP.pm`.
+- `git grep -n 'flock' bin/openhapd` finds nothing, and
+  `git grep -n 'flock' lib/Protocol` finds nothing.
 - `openhapd -n` on a config with setup code `000-00-000` fails with a
   human-readable message; the same config with a valid code passes.
-- Byte-level pairing behavior is unchanged: `t/conformance/hap-pairing.t` and
-  `hap-encryption.t` pass without edits to their vectors.
+- Byte-level pairing behavior is unchanged: `hap-pairing.t`,
+  `hap-pairing-exchange.t`, `hap-encryption.t`, and `hap-encryption-exchange.t`
+  pass, with their only edits being explicit `controller_id`/`timeout`
+  arguments.

--- a/plans/010-simplify/plan-3.md
+++ b/plans/010-simplify/plan-3.md
@@ -1,0 +1,124 @@
+# Phase 3 — The Fugu:: sweep
+
+This phase removes about 600 lines from `lib/Fugu/`, with the mirrored entries
+in `man/fugu/*.3p` and the tests of deleted layers. It deletes the `warn`/`err`
+level aliases (design decision 11). Phase 1 must land first. Phases 2, 4, and 5
+are independent of it.
+
+Every deletion re-verifies with a grep across `lib/ bin/ scripts/ t/` first. A
+grep that finds a production caller stops the deletion and updates this plan.
+
+## Tasks
+
+### 3.1 Dead code
+
+- `Fugu::Signal`: delete the graceful-exit facility — `setup_graceful_exit` (no
+  caller at all), `add_cleanup` and `_run_cleanup_handlers` (test-only), and the
+  `cleanups`/`exit_status` state. `bin/openhapd` uses `setup_interrupt_flag`
+  only; the event loop made the rest obsolete. Delete `reset_all_interrupted`
+  and move its eleven test call sites to fresh handler objects.
+- `Fugu::SSH`: delete `make_remote_dir` — zero callers, including tests. (Phase
+  5 removes the `Guest.pm` hand-rolled equivalent; the two phases do not
+  conflict, because `Guest` never called this method.)
+- `Fugu::StateFile`: delete `increment` and `exists`. The HAP stores own their
+  counters, and `App::FuguVM::State` tests the raw hash.
+- `Fugu::Config`: delete `bool`; every consumer calls `parse_bool`.
+- `Fugu::Proxy`: delete `host_url` (the subclass exists because `host_url` is
+  not what a guest can reach) and the test-only `Meta->remove` and
+  `Meta->clear`.
+- Delete the test-only accessors and methods: `EventLoop::has_fd`,
+  `Config::block_types`, `Control::commands`, `Control::Client->exists`,
+  `Pidfile::release`, `Process::reap`, `Process::reap_all`, `MQTT::unsubscribe`,
+  `Log::crit` and its `%priority_map` row. Each takes its subtests with it.
+- `Fugu::Mdnsd`: delete the nine `IMSG_*` constants with no reference. The
+  positional enum lives in `spec/MDNS-Control.md §2`.
+
+### 3.2 Test-only options
+
+- `Fugu::Process`: delete the `check_alive` block — the only production caller
+  passes `check_alive => 0` — with the `exited`/`exit_code` result keys that
+  exist for it. Delete the `on_error`/`on_success` callbacks and their nine
+  guards; every production caller reads the result hash.
+- `Fugu::Proxy`: delete the `child` constructor option (never passed; subclasses
+  override `run_child`). Keep `ports` — its test is the only cheap way to prove
+  the range walk.
+- `Fugu::Control`: delete the loop-less serving path — `serve_client`, the
+  `unless ($loop)` branch, and the threaded `$timeout` parameter. `listen`
+  already requires the loop for production. Move `t/fugu/control.t` to a real
+  `Fugu::EventLoop`.
+- `Fugu::Daemon`: delete `on_fork` (one test caller) and the `umask` option (no
+  caller ever passed it; `022` stays as the constant).
+- `Fugu::Log`: delete the `local0`–`local7` and `user` facility rows — only
+  `daemon` is ever configured — and the `warn`/`err` aliases with
+  `_canonical_level`, per decision 11. `openhapd.conf.5` documents the remaining
+  level spellings already.
+
+### 3.3 Redundant checks
+
+- `Fugu::Mdnsd::_encode_service`: delete the `SERVICE_LEN` re-check; `new`
+  proves the template and `_check_service` bounds every field. One layer keeps
+  the check — the one at construction.
+- `Fugu::Process`: keep one validation of the command argument (the arrayref
+  check subsumes the truthiness check); hoist the PID guard pair into `is_alive`
+  alone and let `terminate`, `reap`-callers, and `wait_exit` rely on it.
+- `Fugu::Privdrop`: delete the pre-check at `:157-159`; the post-`setuid(0)`
+  probe is strictly stronger.
+- `Fugu::Sandbox`: delete the shape pre-pass over the unveil list; the
+  destructure fails loudly on malformed entries, and the only caller builds the
+  list from literals.
+- Delete the `defined fileno`/`defined $key` guards in `EventLoop` and
+  `Control::_drop_client` for handles the loop just dispatched on.
+- `Fugu::Control`: delete the server-side `MAX_REPLY` check and the `eval`
+  around encoding its own reply. The client keeps its bound — a hostile server
+  is real; the server's own handlers are not.
+
+### 3.4 Duplication
+
+- `Fugu::Process`: extract `_fork_exec` and collapse `run` and
+  `_run_passthrough` onto it.
+- Promote `Fugu::File::_write_all` to a class method and call it from
+  `Fugu::Proxy`, `Fugu::JSONSocket`, and `Fugu::Imsg`; delete their copies.
+- `Fugu::SSH`: add `_with_connection(sub ($ssh2) {...})` and collapse the four
+  open/branch/disconnect copies, including the duplicated SFTP guard.
+- `Fugu::MQTT`: keep one warning-capture block and one subscribe closure;
+  `resubscribe` loops over `subscribe`.
+- `Fugu::Proxy`: serve the whole-file case through the streaming path and delete
+  `_serve_whole`; hoist the repeated lazy `require` lines into `serve`.
+- `Fugu::File`: fold `_temp_name` and `_make_temp_dir` onto one attempt loop.
+- Keep the accessors, drop their weight: each `error`/`path` accessor shrinks to
+  its minimal form with a one-line comment. No generator module (design
+  non-goal).
+- Apply the `Proxy.pm:63-66` loop idiom to the required-parameter `die` sites
+  with three or more parameters; leave the one-parameter sites alone.
+- Define `EXIT_ERROR` once in `Fugu::CLI` and import it in `Process` and `SSH`;
+  fold the four usage `printf` shapes in `Fugu::CLI` into one.
+
+### 3.5 Documentation and tests
+
+- Update `man/fugu/<Module>.3p` for every deleted method: `Signal.3p`, `SSH.3p`,
+  `StateFile.3p`, `Config.3p`, `Proxy.3p`, `EventLoop.3p`, `Control.3p`,
+  `Pidfile.3p`, `Process.3p`, `MQTT.3p`, `Log.3p`, `Daemon.3p`, `Mdnsd.3p`,
+  `Sandbox.3p`, `Privdrop.3p`, `File.3p`.
+- Trim the matching subtests in `t/fugu/`, and keep `t/fugu/coreperl.t`
+  untouched — nothing in this phase adds an import.
+
+## Deliverables
+
+- Smaller `lib/Fugu/*.pm` across sixteen modules.
+- Updated `man/fugu/*.3p` pages.
+- Trimmed `t/fugu/*.t`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `mandoc -Tlint -W warning man/fugu/*.3p` reports nothing new.
+- `grep -rn 'setup_graceful_exit\|make_remote_dir\|check_alive\|on_fork' lib bin t scripts`
+  finds nothing.
+- `grep -rn "'warn'\|'err'" lib/Fugu/Log.pm` finds nothing, and
+  `prove -l t/fugu/log.t` still proves one name per level.
+- `grep -c '_write_all' lib -r` reports one defining file.
+- `t/fugu/sandbox.t` passes unchanged — the enforcement subtests it ships into
+  the VM do not depend on the deleted pre-pass.
+- `bin/openhapd` starts, pairs, and stops in the integration tier
+  (`make integration` in CI) — the daemon path exercises `Signal`, `Process`,
+  `Control`, `Mdnsd`, and `Log` together.

--- a/plans/010-simplify/plan-3.md
+++ b/plans/010-simplify/plan-3.md
@@ -1,12 +1,15 @@
 # Phase 3 — The Fugu:: sweep
 
-This phase removes about 600 lines from `lib/Fugu/`, with the mirrored entries
-in `man/fugu/*.3p` and the tests of deleted layers. It deletes the `warn`/`err`
-level aliases (design decision 11). Phase 1 must land first. Phases 2, 4, and 5
-are independent of it.
+This phase removes about 500 lines from `lib/Fugu/`, with the mirrored entries
+in `man/fugu/*.3p` and the tests of deleted layers. Phases 1 and 2 must land
+first. The log-vocabulary work (design decision 11) is **not** here: it spans
+`Fugu::Log`, `bin/openhapd`, and `openhapd.conf.5`, so phase 4 owns it whole.
 
 Every deletion re-verifies with a grep across `lib/ bin/ scripts/ t/` first. A
-grep that finds a production caller stops the deletion and updates this plan.
+grep that finds a production caller stops the deletion and updates this plan —
+the review moved the `MAX_REPLY` bound, the encode `eval`, the `Privdrop`
+pre-check, and the `EventLoop` `fileno` guard to the design's verified-keeps
+list this way.
 
 ## Tasks
 
@@ -16,78 +19,78 @@ grep that finds a production caller stops the deletion and updates this plan.
   caller at all), `add_cleanup` and `_run_cleanup_handlers` (test-only), and the
   `cleanups`/`exit_status` state. `bin/openhapd` uses `setup_interrupt_flag`
   only; the event loop made the rest obsolete. Delete `reset_all_interrupted`
-  and move its eleven test call sites to fresh handler objects.
-- `Fugu::SSH`: delete `make_remote_dir` — zero callers, including tests. (Phase
-  5 removes the `Guest.pm` hand-rolled equivalent; the two phases do not
-  conflict, because `Guest` never called this method.)
+  and rework its eleven call sites across `t/fugu/signal.t`, `t/fugu/timeout.t`,
+  and `t/fugu/eventloop.t` to use fresh handler objects.
+- `Fugu::SSH`: delete `make_remote_dir` — zero callers, including tests.
 - `Fugu::StateFile`: delete `increment` and `exists`. The HAP stores own their
   counters, and `App::FuguVM::State` tests the raw hash.
 - `Fugu::Config`: delete `bool`; every consumer calls `parse_bool`.
-- `Fugu::Proxy`: delete `host_url` (the subclass exists because `host_url` is
-  not what a guest can reach) and the test-only `Meta->remove` and
-  `Meta->clear`.
+- `Fugu::Proxy`: delete `host_url` and the test-only `Meta->remove` and
+  `Meta->clear`. `host_url`'s callers are all tests: `t/fugu/proxy.t:214, 246`
+  and `t/fuguvm/proxy.t:76-77`; edit both files and drop the mention in
+  `lib/App/FuguVM/Proxy.pod:52` — cross-tier fallout this phase owns.
 - Delete the test-only accessors and methods: `EventLoop::has_fd`,
   `Config::block_types`, `Control::commands`, `Control::Client->exists`,
   `Pidfile::release`, `Process::reap`, `Process::reap_all`, `MQTT::unsubscribe`,
-  `Log::crit` and its `%priority_map` row. Each takes its subtests with it.
-- `Fugu::Mdnsd`: delete the nine `IMSG_*` constants with no reference. The
-  positional enum lives in `spec/MDNS-Control.md §2`.
+  `Log::crit` (zero callers of any kind; its vocabulary row falls under phase
+  4's decision 11). Each takes its subtests with it.
+- Keep the nine `IMSG_*` constants: `t/conformance/mdns-control.t:70-86` pins
+  the whole positional enum via `->can`, the only drift check against mdnsd's C
+  enum.
 
 ### 3.2 Test-only options
 
 - `Fugu::Process`: delete the `check_alive` block — the only production caller
   passes `check_alive => 0` — with the `exited`/`exit_code` result keys that
-  exist for it. Delete the `on_error`/`on_success` callbacks and their nine
-  guards; every production caller reads the result hash.
+  exist for it, the `on_error`/`on_success` callbacks, and their nine guards.
+  Remove the now-meaningless `check_alive => 0` argument and its comment at
+  `lib/App/FuguVM/Guest.pm:1085` in the same commit; phase 5 rewrites the
+  surrounding wait separately.
 - `Fugu::Proxy`: delete the `child` constructor option (never passed; subclasses
   override `run_child`). Keep `ports` — its test is the only cheap way to prove
   the range walk.
 - `Fugu::Control`: delete the loop-less serving path — `serve_client`, the
-  `unless ($loop)` branch, and the threaded `$timeout` parameter. `listen`
-  already requires the loop for production. Move `t/fugu/control.t` to a real
-  `Fugu::EventLoop`.
-- `Fugu::Daemon`: delete `on_fork` (one test caller) and the `umask` option (no
-  caller ever passed it; `022` stays as the constant).
-- `Fugu::Log`: delete the `local0`–`local7` and `user` facility rows — only
-  `daemon` is ever configured — and the `warn`/`err` aliases with
-  `_canonical_level`, per decision 11. `openhapd.conf.5` documents the remaining
-  level spellings already.
+  `unless ($loop)` branch, and the threaded `$timeout` parameter — and make
+  `listen` require its loop (`die` without one). `t/fugu/control.t:34` currently
+  listens with no loop; give the test a real `Fugu::EventLoop`.
+- `Fugu::Daemon`: delete `on_fork` and `umask` — both are test-only
+  (`t/fugu/daemon.t:79` passes `umask => 027`, `:99` asserts it; those subtests
+  go). `022` stays as the constant.
 
 ### 3.3 Redundant checks
 
 - `Fugu::Mdnsd::_encode_service`: delete the `SERVICE_LEN` re-check; `new`
-  proves the template and `_check_service` bounds every field. One layer keeps
-  the check — the one at construction.
+  proves the template and `_check_service` bounds every field. The check at
+  construction is the one that stays.
 - `Fugu::Process`: keep one validation of the command argument (the arrayref
-  check subsumes the truthiness check); hoist the PID guard pair into `is_alive`
-  alone and let `terminate`, `reap`-callers, and `wait_exit` rely on it.
-- `Fugu::Privdrop`: delete the pre-check at `:157-159`; the post-`setuid(0)`
-  probe is strictly stronger.
+  check subsumes the truthiness check); keep the PID guard in `is_alive` and
+  delete the copies in `terminate` and `wait_exit`.
 - `Fugu::Sandbox`: delete the shape pre-pass over the unveil list; the
   destructure fails loudly on malformed entries, and the only caller builds the
   list from literals.
-- Delete the `defined fileno`/`defined $key` guards in `EventLoop` and
-  `Control::_drop_client` for handles the loop just dispatched on.
-- `Fugu::Control`: delete the server-side `MAX_REPLY` check and the `eval`
-  around encoding its own reply. The client keeps its bound — a hostile server
-  is real; the server's own handlers are not.
+- `Fugu::Control::_drop_client`: delete the `defined $key` arm — its only caller
+  passes a handle that is still open (`recv` marks `{dead}` without closing).
+  The similar guard in `EventLoop` **stays**: a callback earlier in the same
+  ready-pass can close a sibling handle.
 
 ### 3.4 Duplication
 
 - `Fugu::Process`: extract `_fork_exec` and collapse `run` and
   `_run_passthrough` onto it.
-- Promote `Fugu::File::_write_all` to a class method and call it from
-  `Fugu::Proxy`, `Fugu::JSONSocket`, and `Fugu::Imsg`; delete their copies.
-- `Fugu::SSH`: add `_with_connection(sub ($ssh2) {...})` and collapse the four
-  open/branch/disconnect copies, including the duplicated SFTP guard.
+- Promote `Fugu::File::_write_all` to a class method and point `Fugu::Proxy`'s
+  private copy at it. `Fugu::JSONSocket` and `Fugu::Imsg` keep their inline
+  loops: theirs set transport failure state (`{error}`/disconnect, `{dead}`),
+  which the shared helper must not absorb. `Protocol::HAP::Store::File` keeps
+  its own copy — the CPAN boundary.
+- `Fugu::SSH`: add `_with_connection(sub ($ssh2) {...})` and collapse the
+  connect/branch/disconnect copies, including the duplicated SFTP guard.
 - `Fugu::MQTT`: keep one warning-capture block and one subscribe closure;
   `resubscribe` loops over `subscribe`.
 - `Fugu::Proxy`: serve the whole-file case through the streaming path and delete
   `_serve_whole`; hoist the repeated lazy `require` lines into `serve`.
 - `Fugu::File`: fold `_temp_name` and `_make_temp_dir` onto one attempt loop.
 - Keep the accessors, drop their weight: each `error`/`path` accessor shrinks to
-  its minimal form with a one-line comment. No generator module (design
-  non-goal).
+  its minimal form with a one-line comment. No generator module.
 - Apply the `Proxy.pm:63-66` loop idiom to the required-parameter `die` sites
   with three or more parameters; leave the one-parameter sites alone.
 - Define `EXIT_ERROR` once in `Fugu::CLI` and import it in `Process` and `SSH`;
@@ -97,28 +100,30 @@ grep that finds a production caller stops the deletion and updates this plan.
 
 - Update `man/fugu/<Module>.3p` for every deleted method: `Signal.3p`, `SSH.3p`,
   `StateFile.3p`, `Config.3p`, `Proxy.3p`, `EventLoop.3p`, `Control.3p`,
-  `Pidfile.3p`, `Process.3p`, `MQTT.3p`, `Log.3p`, `Daemon.3p`, `Mdnsd.3p`,
-  `Sandbox.3p`, `Privdrop.3p`, `File.3p`.
-- Trim the matching subtests in `t/fugu/`, and keep `t/fugu/coreperl.t`
-  untouched — nothing in this phase adds an import.
+  `Pidfile.3p`, `Process.3p`, `MQTT.3p`, `Daemon.3p`, `Sandbox.3p`, `File.3p`.
+- Trim the matching subtests in `t/fugu/`, plus the two cross-tier files named
+  above (`t/fuguvm/proxy.t`, `lib/App/FuguVM/Proxy.pod`). Keep
+  `t/fugu/coreperl.t` untouched — nothing in this phase adds an import.
 
 ## Deliverables
 
-- Smaller `lib/Fugu/*.pm` across sixteen modules.
-- Updated `man/fugu/*.3p` pages.
-- Trimmed `t/fugu/*.t`.
+- Smaller `lib/Fugu/*.pm` across fifteen modules.
+- One line removed from `lib/App/FuguVM/Guest.pm` (the dead `check_alive`
+  argument).
+- Updated `man/fugu/*.3p`, `lib/App/FuguVM/Proxy.pod`.
+- Trimmed `t/fugu/*.t` and `t/fuguvm/proxy.t`.
 
 ## Acceptance criteria
 
 - `make check` passes.
 - `mandoc -Tlint -W warning man/fugu/*.3p` reports nothing new.
-- `grep -rn 'setup_graceful_exit\|make_remote_dir\|check_alive\|on_fork' lib bin t scripts`
+- `git grep -n 'setup_graceful_exit\|make_remote_dir\|check_alive\|on_fork\|serve_client\|host_url' lib bin t scripts`
   finds nothing.
-- `grep -rn "'warn'\|'err'" lib/Fugu/Log.pm` finds nothing, and
-  `prove -l t/fugu/log.t` still proves one name per level.
-- `grep -c '_write_all' lib -r` reports one defining file.
+- `git grep -n 'sub _write_all' lib` reports exactly two definitions:
+  `lib/Fugu/File.pm` and `lib/Protocol/HAP/Store/File.pm`.
+- `prove -l t/conformance/mdns-control.t` passes unchanged — the enum is intact.
 - `t/fugu/sandbox.t` passes unchanged — the enforcement subtests it ships into
   the VM do not depend on the deleted pre-pass.
-- `bin/openhapd` starts, pairs, and stops in the integration tier
-  (`make integration` in CI) — the daemon path exercises `Signal`, `Process`,
-  `Control`, `Mdnsd`, and `Log` together.
+- `make integration` in CI is green: the daemon path exercises `Signal`,
+  `Process`, `Control`, and `Mdnsd` together, and `fuguvm` exercises `Proxy` and
+  `SSH`.

--- a/plans/010-simplify/plan-4.md
+++ b/plans/010-simplify/plan-4.md
@@ -1,55 +1,108 @@
 # Phase 4 — The App::OpenHAP sweep
 
-This phase removes about 740 lines from `lib/App/OpenHAP/`, `bin/openhapd`, and
+This phase removes about 700 lines from `lib/App/OpenHAP/`, `bin/openhapd`, and
 `bin/hapctl`, plus about 330 lines from the integration tier and the drifted
-sections of `openhapd.conf.5`. It wires in the humidity option and deletes the
-unreachable Tasmota surface (design decisions 2, 8, 9, 14). Phase 1 must land
-first. Phases 2, 3, and 5 are independent of it.
+sections of `openhapd.conf.5`. It executes decisions 2, 3, 8, 9, 11, 14, and 19,
+and fixes two bugs (the hue `%`, the SIGPIPE hole). Phases 1–3 must land first:
+phase 2 deleted the `identify` hook this phase's `blink` grep would otherwise
+match, and phase 3 provides the shared write loop that 4.4 uses.
 
 Every deletion re-verifies with a grep across `lib/ bin/ t/ etc/ man/ share/`
 first.
 
 ## Tasks
 
-### 4.1 The unreachable Tasmota surface
+### 4.1 The Tasmota surface
 
 `App::OpenHAP::Devices` is the only production constructor of device objects.
 Everything its argument list cannot reach goes:
 
 - `fulltopic` and its `_build_topic` token substitution: with the fixed default,
   the method is one interpolated string. The `setoption26` branches in
-  `_get_power_key` and `_get_power_topic` go the same way. Users of both: the
-  four subclass pass-throughs and `t/conformance/mqtt-transport.t`.
-- The color pipeline nothing drives: `_parse_color`, `_rgb_to_hsb` (with its
-  integer-`%` hue bug), `set_color`, `dimmer_step`, `dimmer_min`, `dimmer_max`.
-  HAP writes hue and saturation as separate characteristics; no path constructs
-  a `Color` command.
-- `toggle_power`, `blink`, `force_telemetry`: no HAP path calls them.
-- The `_on_availability_changed` hook: zero overrides in the repo, so the hook
-  and its change-detection go.
-- The write-only `sensor_id` field and its three `Id` extractions.
+  `_get_power_key` and `_get_power_topic` go the same way. Users, verified:
+  `fulltopic` pass-throughs in all four subclasses; `setoption26` in `Heater`,
+  `Thermostat`, `Lightbulb` (not `Sensor`); `t/conformance/mqtt-transport.t` and
+  `mqtt-control.t:95,106`. Decision 15 applies: `mqtt-transport.t:50,70,152`
+  carry the only `[MQTT-Transport §1.2]`, `[§1.3]`, `[§3.1]`, `[§3.2]`
+  citations; the §1.x subtests re-target the fixed-default `_build_topic`, and
+  the §3.x citations drop with the feature — list them in the commit with the
+  matrix diff.
+- Decision 3: the color pipeline stays; fix the hue bug at `Lightbulb.pm:496` —
+  Perl's `%` truncates, so red-dominant colors get hue 0; use a floating-point
+  modulus. Keep `_parse_color`, `_rgb_to_hsb`, and the `[MQTT-Control §3.2]`
+  subtest. Delete the outbound surface nothing calls: `set_color`,
+  `dimmer_step`, `dimmer_min`, `dimmer_max`, `toggle_power`, `blink`,
+  `force_telemetry`. Test fallout, verified: `t/openhap/tasmota.t:88` (`can`
+  list) and `:148-163` (direct `_rgb_to_hsb` calls — these stay, now asserting
+  the fixed hue), and `t/conformance/mqtt-control.t:71-78` (the BLINK/BLINKOFF
+  asserts inside the §1 subtest go; the set_power asserts keep the citation).
+- The `_on_availability_changed` hook: zero overrides, so the hook and its
+  change-detection go.
+- The write-only `sensor_id` field, its three `Id` extractions, and the no-op
+  "auto-detected humidity support" branch beside them (decision 2: it sets
+  nothing and cannot add a service after construction).
 - `Host.pm`: the `loop => $args{loop}` pass-through nothing supplies.
-
-Wire in `has_humidity` instead of deleting it (decision 2): a `humidity` option
-on the sensor block in `Devices.pm`, one paragraph in `openhapd.conf.5`, one
-line in the sample config.
+- Decision 2: document `has_humidity` — it already works. One paragraph in
+  `openhapd.conf.5`, one line in the sample config. No new key.
 
 ### 4.2 Dead code and drifted documentation
 
 - Delete `Host::stop` (zero callers; shutdown runs on signal flags),
   `Tasmota::Device::get_availability`, and the merged-but-never-read
   `last_state` hash.
-- Delete the Exporter plumbing of `App::OpenHAP::Test::Integration`; no test
-  imports a symbol. Delete `clear_logs`, `get_log_lines`, `_count_log_lines`,
-  and the `log_baseline` capture — orphaned when plan 001 moved the assertions
-  to `mdnsctl browse`. `SYSLOG_FILE` stays for `_read_syslog_tail`.
-- `openhapd.conf.5`: delete the six thermostat options that no code reads and
-  the `min_temp`/`max_temp` example rows (decision 9); delete `hap_model` and
-  `hap_manufacturer` and their two sample lines (decision 8).
-- Delete the unreachable `_device_type_name` fallback and the memoization guard
-  on `Host::listen`.
+- Delete the Exporter plumbing of `App::OpenHAP::Test::Integration`, and its
+  orphaned helpers `clear_logs`, `get_log_lines`, `_count_log_lines`, and the
+  `log_baseline` capture. `SYSLOG_FILE` stays for `_read_syslog_tail`.
+- `openhapd.conf.5`: delete the six thermostat options no code reads and the
+  `min_temp`/`max_temp` example rows (decision 9); delete `hap_model` and
+  `hap_manufacturer` with their two sample lines (decision 8).
+- Delete the unreachable `_device_type_name` fallback. Keep the `Host::listen`
+  memoization — `hap-pairing-exchange.t` forks after binding port 0 and the
+  guard is what keeps the child on the parent's port.
 
-### 4.3 Base-class dedup across Tasmota/\*.pm
+### 4.3 Decision 11 — one spelling per log level
+
+This decision spans two tiers, so it lands here whole:
+
+- `lib/Fugu/Log.pm`: the vocabulary becomes the five method names (`debug`,
+  `info`, `notice`, `warning`, `error`). The `warn`/`err` alias rows,
+  `_canonical_level`, and the `crit` rows go. The facility rows stay — `daemon`,
+  `local0`–`local7`, `user` are documented operator surface.
+- `bin/openhapd` validates `log_level` and `log_facility` against the accepted
+  sets at config load and fails closed with the offending value, before
+  daemonize. `Fugu::Log` keeps its internal defaults; the boundary owns the
+  validation.
+- `man/openhap/openhapd.conf.5:138` changes to list exactly the five levels — it
+  currently promises `err`, `crit`, `alert`, and `emerg`, two of which the code
+  never accepted. The facility line and its `log_facility = local0` example
+  stay. `man/fugu/Log.3p` matches.
+- `t/fugu/log.t` updates: the alias subtests go; the one-name-per-level
+  assertions stay; `t/openhap/` gains a config-validation case (bad level, bad
+  facility → fatal, named value).
+
+### 4.4 Defensive checks in the host and the commands
+
+- Decision 19: rebuild `Host::_write`. None of its three guards handles SIGPIPE
+  — no `$SIG{PIPE}` exists anywhere on the daemon path — and the `syswrite`
+  return is discarded, so a controller closing mid-write can kill the daemon or
+  truncate a frame. Replace the body with `Fugu::File`'s shared write loop (from
+  phase 3) under a `local $SIG{PIPE} = 'IGNORE'`, dropping the connection on
+  failure.
+- `Host.pm`: delete the ternary chains over the `by_fileno`/`connections` pair
+  that `_accept` installs together, the `ref $socket` guard in `shutdown`, the
+  `can('subscribe_mqtt')` probe, and the five pre-declared `undef` fields.
+  Collapse the two-stage mDNS guard to one condition.
+- `bin/openhapd`: read `hap_pin` once. The read stays where the first one is now
+  — before the `-n` exit and before daemonize — so the fatal setup-code error
+  from phase 2 keeps reaching the terminal.
+- `bin/hapctl`: fold the two printf blocks into one formatter over a field list;
+  inline the two option-wrapper subs. Keep both `uptime` checks (shape and
+  future-timestamp — different faults) and keep `openhapd -n` (decision 13).
+- Keep the `Devices.pm` eval: it guards a runtime `require` and a constructor of
+  config-named classes, after daemonize. Deduplicate only the `%DEVICE` lookup
+  that `_is_supported_device` and `_instantiate_device` both perform.
+
+### 4.5 Base-class dedup across Tasmota/\*.pm
 
 - One `_handle_status_sns($payload, $label)` in `Tasmota::Device` with an
   overridable extractor replaces the four copies of the STATUS8/STATUS10 handler
@@ -57,80 +110,63 @@ line in the sample config.
 - `Thermostat::_find_temperature` becomes a call into the sensor walk it is a
   subset of; `SENSOR_TYPES` moves to `Tasmota::Device`.
 - One `_subscribe_plain_power($field, $iid)` base helper replaces the three
-  copies of the plain-text POWER subscription; the thermostat keeps its change
-  guard as an argument.
+  copies of the plain-text POWER subscription.
 - One `_decode($payload, $label)` helper replaces the eight
   `eval { decode_json } / if ($@)` wrappers.
 - The four subclass constructors pass `%args` through:
-  `$class->SUPER::new(%args, model => ...)` replaces the retyped key lists.
-  `relay_index` defaults once, in `Tasmota::Device`.
+  `$class->SUPER::new(%args, model => ...)`. `relay_index` defaults once.
 - The `add_characteristic` boilerplate in `Lightbulb` and `Thermostat` becomes a
-  spec table and a loop; the CT clamp becomes one helper; the three derived
-  capability booleans become mask tests at the use sites.
+  spec table and a loop; the CT clamp becomes one helper; the three capability
+  booleans become mask tests.
 - `Devices.pm`: the four lightbulb-family `%DEVICE` closures become one entry
-  shape with a `caps` bitmask, and the two duplicate entries become aliases.
-  `_is_supported_device` and `_instantiate_device` share one lookup, which
-  removes the `eval` that guarded only the impossible miss.
+  shape with a `caps` bitmask; the two duplicate entries become aliases.
 
-### 4.4 Defensive checks in the host and the commands
+### 4.6 The integration tier
 
-- `Host.pm`: delete the ternary chains over the `by_fileno`/`connections` pair
-  that `_accept` installs together, the `ref $socket` guard in `shutdown`, two
-  of the three failure layers in `_write`, the `can('subscribe_mqtt')` probe,
-  and the five pre-declared `undef` fields. Collapse the two-stage mDNS guard to
-  one condition.
-- `bin/openhapd`: read `hap_pin` once; hoist the duplicated `set_mqtt_client`
-  call out of the MQTT-connect branches.
-- `bin/hapctl`: delete the double validation in `uptime`; fold the two printf
-  blocks into one formatter over a field list; inline the two option-wrapper
-  subs. `openhapd -n` stays (decision 13).
+- Add to `App::OpenHAP::Test::Integration`: `status($response)`,
+  `find_char($type)`, `wait_value`, `browse`/`browse_txt`, and `restart_daemon`.
+  Replace the seventeen fully-qualified `parse_http_response` calls, the four
+  `find_char` copies, the two poll loops, the three `browse` definitions, the
+  hand-rolled port wait in `shutdown.t`, and the eleven restart incantations.
+- `_parse_config` calls `App::OpenHAP::Devices->devices($config)`;
+  `get_device_topics` derives from `get_devices`.
+- Decision 14: delete the eleven status-disjunction subtests in
+  `hap-protocol.t`, the `_verify_system` restatement in `environment.t` (the GMP
+  assertion stays), the disjunction and repeat tests in `hapctl.t`, and the
+  `configuration.t` tests that duplicate `hapctl.t` and `daemon.t`. The commit
+  lists, per deleted subtest, its surviving duplicate or why it could not fail.
 
-### 4.5 The integration tier
-
-- Add to `App::OpenHAP::Test::Integration`: a `status($response)` wrapper, a
-  `find_char($type)` lookup, a `wait_value` poll, a `browse` / `browse_txt`
-  pair, and a `restart_daemon` method. Replace the seventeen fully-qualified
-  `parse_http_response` calls, the four `find_char` copies, the two poll loops,
-  the three `browse` definitions, the hand-rolled port wait in `shutdown.t`, and
-  the eleven restart incantations.
-- `_parse_config` calls `App::OpenHAP::Devices->devices($config)` — the
-  duplication its own comment warns against — and `get_device_topics` derives
-  from `get_devices`.
-- Delete the non-falsifiable subtests (decision 14): the eleven
-  status-disjunction tests in `hap-protocol.t`, the `_verify_system` restatement
-  in `environment.t` (the GMP assertion stays), the disjunction and repeat tests
-  in `hapctl.t`, and the `configuration.t` tests that duplicate `hapctl.t` and
-  `daemon.t`. Integration tests never skip; these never fail, which is the same
-  defect mirrored.
-
-### 4.6 Documentation
+### 4.7 Documentation
 
 - Update the sidecars: `Host.pod`, `Devices.pod`, `Tasmota/*.pod`,
   `Test/Integration.pod`.
-- `openhapd.conf.5` gains the `humidity` option and loses the drifted sections
-  (4.2).
+- `openhapd.conf.5` changes land in one commit: `has_humidity` in, the drifted
+  sections out, the log vocabulary corrected.
 
 ## Deliverables
 
 - Smaller `lib/App/OpenHAP/{Host,Devices}.pm`, `Tasmota/*.pm`, and
   `Test/Integration.pm`, with updated sidecars.
-- Smaller `bin/openhapd` and `bin/hapctl`.
+- `lib/Fugu/Log.pm` and `man/fugu/Log.3p` (decision 11).
+- Smaller `bin/openhapd` (with the new config validation) and `bin/hapctl`.
 - Corrected `man/openhap/openhapd.conf.5` and sample config.
-- A leaner `t/openhap/integration/` tier.
+- A leaner `t/openhap/integration/` tier and updated `t/fugu/log.t`.
 
 ## Acceptance criteria
 
-- `make check` passes; `make spec-coverage` reports no stale citation.
-- `make integration` passes in CI.
-- `grep -rn 'fulltopic\|setoption26\|_rgb_to_hsb\|set_color\|blink' lib bin t`
+- `make check` passes; `make integration` passes in CI.
+- `scripts/spec-coverage` matrix diff is attached; the only dropped citations
+  are the `setoption26`/`blink` rows the commit lists.
+- `git grep -n 'fulltopic\|setoption26\|set_color\|toggle_power\|blink\|force_telemetry' lib bin t`
   finds nothing.
-- `grep -rn 'get_log_lines\|clear_logs\|log_baseline' lib t` finds nothing.
-- `grep -n 'min_temp\|hap_model' man/openhap/openhapd.conf.5 share` finds
-  nothing.
-- A config with `humidity 1` on a sensor block builds a HumiditySensor service;
-  `t/conformance/mqtt-sensors.t` proves it through the config path rather than
-  direct construction.
-- `grep -rn 'parse_http_response' t/openhap/integration` finds only the module
-  and the `status` wrapper.
-- Every deleted integration subtest either had a duplicate that stays or could
-  not fail; the commit message lists which, per subtest.
+- `git grep -n 'get_log_lines\|clear_logs\|log_baseline' lib t` finds nothing.
+- `git grep -rn 'min_temp\|hap_model' man share` finds nothing.
+- `git grep -nE '\b(warn|err|crit)\b' lib/Fugu/Log.pm` finds nothing, and
+  `openhapd -n` on a config with `log_level err` or `log_facility local9` fails
+  naming the value; `log_facility local0` passes.
+- A config with `has_humidity 1` on a sensor block builds a HumiditySensor
+  service, proven through the config path in `t/conformance/mqtt-sensors.t`.
+- RGB(255,128,0) through `_rgb_to_hsb` yields hue 30, asserted in
+  `t/openhap/tasmota.t`.
+- `git grep -n 'parse_http_response' t/openhap/integration` finds only the
+  module and the `status` wrapper.

--- a/plans/010-simplify/plan-4.md
+++ b/plans/010-simplify/plan-4.md
@@ -1,0 +1,136 @@
+# Phase 4 — The App::OpenHAP sweep
+
+This phase removes about 740 lines from `lib/App/OpenHAP/`, `bin/openhapd`, and
+`bin/hapctl`, plus about 330 lines from the integration tier and the drifted
+sections of `openhapd.conf.5`. It wires in the humidity option and deletes the
+unreachable Tasmota surface (design decisions 2, 8, 9, 14). Phase 1 must land
+first. Phases 2, 3, and 5 are independent of it.
+
+Every deletion re-verifies with a grep across `lib/ bin/ t/ etc/ man/ share/`
+first.
+
+## Tasks
+
+### 4.1 The unreachable Tasmota surface
+
+`App::OpenHAP::Devices` is the only production constructor of device objects.
+Everything its argument list cannot reach goes:
+
+- `fulltopic` and its `_build_topic` token substitution: with the fixed default,
+  the method is one interpolated string. The `setoption26` branches in
+  `_get_power_key` and `_get_power_topic` go the same way. Users of both: the
+  four subclass pass-throughs and `t/conformance/mqtt-transport.t`.
+- The color pipeline nothing drives: `_parse_color`, `_rgb_to_hsb` (with its
+  integer-`%` hue bug), `set_color`, `dimmer_step`, `dimmer_min`, `dimmer_max`.
+  HAP writes hue and saturation as separate characteristics; no path constructs
+  a `Color` command.
+- `toggle_power`, `blink`, `force_telemetry`: no HAP path calls them.
+- The `_on_availability_changed` hook: zero overrides in the repo, so the hook
+  and its change-detection go.
+- The write-only `sensor_id` field and its three `Id` extractions.
+- `Host.pm`: the `loop => $args{loop}` pass-through nothing supplies.
+
+Wire in `has_humidity` instead of deleting it (decision 2): a `humidity` option
+on the sensor block in `Devices.pm`, one paragraph in `openhapd.conf.5`, one
+line in the sample config.
+
+### 4.2 Dead code and drifted documentation
+
+- Delete `Host::stop` (zero callers; shutdown runs on signal flags),
+  `Tasmota::Device::get_availability`, and the merged-but-never-read
+  `last_state` hash.
+- Delete the Exporter plumbing of `App::OpenHAP::Test::Integration`; no test
+  imports a symbol. Delete `clear_logs`, `get_log_lines`, `_count_log_lines`,
+  and the `log_baseline` capture — orphaned when plan 001 moved the assertions
+  to `mdnsctl browse`. `SYSLOG_FILE` stays for `_read_syslog_tail`.
+- `openhapd.conf.5`: delete the six thermostat options that no code reads and
+  the `min_temp`/`max_temp` example rows (decision 9); delete `hap_model` and
+  `hap_manufacturer` and their two sample lines (decision 8).
+- Delete the unreachable `_device_type_name` fallback and the memoization guard
+  on `Host::listen`.
+
+### 4.3 Base-class dedup across Tasmota/\*.pm
+
+- One `_handle_status_sns($payload, $label)` in `Tasmota::Device` with an
+  overridable extractor replaces the four copies of the STATUS8/STATUS10 handler
+  pair.
+- `Thermostat::_find_temperature` becomes a call into the sensor walk it is a
+  subset of; `SENSOR_TYPES` moves to `Tasmota::Device`.
+- One `_subscribe_plain_power($field, $iid)` base helper replaces the three
+  copies of the plain-text POWER subscription; the thermostat keeps its change
+  guard as an argument.
+- One `_decode($payload, $label)` helper replaces the eight
+  `eval { decode_json } / if ($@)` wrappers.
+- The four subclass constructors pass `%args` through:
+  `$class->SUPER::new(%args, model => ...)` replaces the retyped key lists.
+  `relay_index` defaults once, in `Tasmota::Device`.
+- The `add_characteristic` boilerplate in `Lightbulb` and `Thermostat` becomes a
+  spec table and a loop; the CT clamp becomes one helper; the three derived
+  capability booleans become mask tests at the use sites.
+- `Devices.pm`: the four lightbulb-family `%DEVICE` closures become one entry
+  shape with a `caps` bitmask, and the two duplicate entries become aliases.
+  `_is_supported_device` and `_instantiate_device` share one lookup, which
+  removes the `eval` that guarded only the impossible miss.
+
+### 4.4 Defensive checks in the host and the commands
+
+- `Host.pm`: delete the ternary chains over the `by_fileno`/`connections` pair
+  that `_accept` installs together, the `ref $socket` guard in `shutdown`, two
+  of the three failure layers in `_write`, the `can('subscribe_mqtt')` probe,
+  and the five pre-declared `undef` fields. Collapse the two-stage mDNS guard to
+  one condition.
+- `bin/openhapd`: read `hap_pin` once; hoist the duplicated `set_mqtt_client`
+  call out of the MQTT-connect branches.
+- `bin/hapctl`: delete the double validation in `uptime`; fold the two printf
+  blocks into one formatter over a field list; inline the two option-wrapper
+  subs. `openhapd -n` stays (decision 13).
+
+### 4.5 The integration tier
+
+- Add to `App::OpenHAP::Test::Integration`: a `status($response)` wrapper, a
+  `find_char($type)` lookup, a `wait_value` poll, a `browse` / `browse_txt`
+  pair, and a `restart_daemon` method. Replace the seventeen fully-qualified
+  `parse_http_response` calls, the four `find_char` copies, the two poll loops,
+  the three `browse` definitions, the hand-rolled port wait in `shutdown.t`, and
+  the eleven restart incantations.
+- `_parse_config` calls `App::OpenHAP::Devices->devices($config)` — the
+  duplication its own comment warns against — and `get_device_topics` derives
+  from `get_devices`.
+- Delete the non-falsifiable subtests (decision 14): the eleven
+  status-disjunction tests in `hap-protocol.t`, the `_verify_system` restatement
+  in `environment.t` (the GMP assertion stays), the disjunction and repeat tests
+  in `hapctl.t`, and the `configuration.t` tests that duplicate `hapctl.t` and
+  `daemon.t`. Integration tests never skip; these never fail, which is the same
+  defect mirrored.
+
+### 4.6 Documentation
+
+- Update the sidecars: `Host.pod`, `Devices.pod`, `Tasmota/*.pod`,
+  `Test/Integration.pod`.
+- `openhapd.conf.5` gains the `humidity` option and loses the drifted sections
+  (4.2).
+
+## Deliverables
+
+- Smaller `lib/App/OpenHAP/{Host,Devices}.pm`, `Tasmota/*.pm`, and
+  `Test/Integration.pm`, with updated sidecars.
+- Smaller `bin/openhapd` and `bin/hapctl`.
+- Corrected `man/openhap/openhapd.conf.5` and sample config.
+- A leaner `t/openhap/integration/` tier.
+
+## Acceptance criteria
+
+- `make check` passes; `make spec-coverage` reports no stale citation.
+- `make integration` passes in CI.
+- `grep -rn 'fulltopic\|setoption26\|_rgb_to_hsb\|set_color\|blink' lib bin t`
+  finds nothing.
+- `grep -rn 'get_log_lines\|clear_logs\|log_baseline' lib t` finds nothing.
+- `grep -n 'min_temp\|hap_model' man/openhap/openhapd.conf.5 share` finds
+  nothing.
+- A config with `humidity 1` on a sensor block builds a HumiditySensor service;
+  `t/conformance/mqtt-sensors.t` proves it through the config path rather than
+  direct construction.
+- `grep -rn 'parse_http_response' t/openhap/integration` finds only the module
+  and the `status` wrapper.
+- Every deleted integration subtest either had a duplicate that stays or could
+  not fail; the commit message lists which, per subtest.

--- a/plans/010-simplify/plan-5.md
+++ b/plans/010-simplify/plan-5.md
@@ -1,12 +1,13 @@
 # Phase 5 — The App::FuguVM and App::FuguWeb sweeps
 
-This phase removes about 1,000 lines across the two development tools: the QGA
-subsystem, the CLI dedup, the cache-key speculation, and the extraction
-leftovers of plan 009. It executes design decisions 3–7 and 10. Phase 1 must
-land first. Phases 2, 3, and 4 are independent of it.
+This phase removes about 850 lines across the two development tools: the QGA
+subsystem, the CLI dedup, and the extraction leftovers of plan 009. It executes
+decisions 4–7, 10, 16, and 17. Phases 1–4 must land first (phase 3 already
+removed the dead `check_alive` argument from `Guest.pm`).
 
 Every deletion re-verifies with a grep across
-`lib/ bin/ t/ scripts/ share/ .fuguvmrc .fuguwebrc` first.
+`lib/ bin/ t/ scripts/ share/ .github/ .fuguvmrc .fuguwebrc` first — `.github/`
+is in scope because the integration workflow reads `share/` paths.
 
 ## Tasks
 
@@ -18,8 +19,15 @@ Every deletion re-verifies with a grep across
   `-chardev`, and `virtserialport` arguments. `_graceful_shutdown` becomes: SSH
   sync, ACPI powerdown, report.
 - Delete `share/fuguvm/expect/firstboot.exp`; installing an agent nothing talks
-  to was its only job. `login.exp` and `command.exp` stay — they are operator
-  tools for `fuguvm expect`.
+  to was its only job. `login.exp` and `command.exp` stay — operator tools for
+  `fuguvm expect`.
+- Edit `lib/App/FuguVM/QMP.pod:70`: drop `App::FuguVM::QGA` from SEE ALSO (the
+  only remaining QGA reference outside the deleted files).
+- Increment `share/fuguvm/cache-generation` to `2`: the file exists to rotate
+  the disk-cache key when the install driver changes in ways the `install.exp`
+  hash cannot see, and removing the virtio-serial device is such a change. The
+  mechanism stays (decision 4); the `integration.yml` paths and cache key
+  already hash it.
 - Update `fuguvm(1)` and `Guest.pod` where they mention the agent.
 
 ### 5.2 FuguVM dedup
@@ -30,59 +38,66 @@ Every deletion re-verifies with a grep across
   `_wait_ssh_password` fold into one method with a `password` flag; the
   hand-rolled remote mkdir uses one quoted command in one place.
 - `CLI.pm`: the five load-and-call commands dispatch through the `method` field
-  that `%COMMANDS` already carries; `_current_cache_key` folds its diagnostic
-  in, removing four copies; the snapshot-lookup diagnostic and the sorted
-  key-dump loop each keep one copy; `run` stops copying `%COMMANDS` field by
-  field.
-- `DiskCache.pm`: `_tree_size` calls `Fugu::Proxy::Cache::dir_size`; the four
-  hand-rolled unlink-on-failure paths in `snapshot_store` use the `Fugu::File`
-  atomics that `store` already uses.
+  `%COMMANDS` already carries; `_current_cache_key` folds its diagnostic in,
+  removing four copies; the snapshot-lookup diagnostic and the sorted key-dump
+  loop each keep one copy; `run` stops copying `%COMMANDS` field by field.
+- `DiskCache.pm`: fold `_tree_size` onto `Fugu::Proxy::Cache`'s walk. `dir_size`
+  is an instance method (`sub dir_size ($self, $dir)`), so first verify it reads
+  nothing from `$self` and lift it to a class-callable form; otherwise keep
+  `_tree_size` and drop only the duplicated inner loop. The four hand-rolled
+  unlink-on-failure paths in `snapshot_store` use the `Fugu::File` atomics that
+  `store` already uses.
 
 ### 5.3 FuguVM dead code and redundant checks
 
 - Delete from `State.pm`: the seven proxy pid/port methods (production reaches
   the pidfile and store directly), `is_ssh_key_installed`, and
-  `ssh_key_matches`. Resolve the near-dead `running` key: `mark_running` moves
-  to the main start path, so `was_unclean_shutdown` detects a crash again — or,
-  when that costs more than it returns, the key and its four no-op `delete`
-  calls go. Decide in review; record the choice in the commit.
-- Delete: `Disk::disk_exists` and `Disk::remove`, `QMP::socket_path` and
-  `QMP::is_available`, `Guest::pid`, `Config::project_root`, the three
-  never-returned exit codes in `CLI.pm` and one in `Guest.pm`,
-  `DiskCache::cache_dir`, the unreachable `return EXIT_ERROR` in `cmd_disk`,
-  `Miniroot::_ftp_script` (a test-only seam, per its own comment), and the
+  `ssh_key_matches`. Their subtests in `t/fuguvm/state.t:102-178` go.
+- Decision 17: `mark_running` moves to the main start path — its only call today
+  sits inside the pidfile fallback branch this phase deletes, which is why crash
+  detection almost never armed. With it on the main path,
+  `was_unclean_shutdown`'s `running` branch works; the three no-op `delete`
+  calls become live.
+- Delete: `Disk::disk_exists` and `Disk::remove` (with `t/fuguvm/disk.t:33` and
+  the `state.t:202` caller moving to `State::disk_exists`), `QMP::socket_path`
+  and `QMP::is_available` (with their `t/fuguvm/qmp.t` subtests), `Guest::pid`,
+  `Config::project_root`, the three never-returned exit codes in `CLI.pm` and
+  one in `Guest.pm`, `DiskCache::cache_dir` (with its `diskcache.t` and
+  `guest.t` callers), the unreachable `return EXIT_ERROR` in `cmd_disk`, and the
   self-cancelling `timeout` round trip in `Console.pm`.
-- Wire in `default_vm` (decision 3): `_prepare` reads
-  `$cli->option('vm') // $config->default_vm // 'default'`.
-- Delete the `arch` key from `.fuguvmrc`, the samples, and `fuguvm(1)` (decision
-  7); the manual states the fixed architecture once.
-- Delete `cmd_image`, `Miniroot::list`, `_release_root`, and the `image` entries
-  in `%COMMANDS` and `fuguvm(1)` (decision 5).
-- Delete the `cache-generation` mechanism: the constant, the `share_path`
-  lookup, the file read, and `share/fuguvm/cache-generation` itself. The cache
-  key already hashes every real input, and the file never changed.
+- Keep `Miniroot::_ftp_script`: it has a production caller (`Miniroot.pm:106`),
+  and its comment explains the seam guards against silent rename breakage.
+- Decision 16: after `_prepare` loads the config, resolve the VM name as
+  `$cli->option('vm') // $config->default_vm` — `Config::default_vm` already
+  ends in `// 'default'`. Offline commands, which return before the config
+  exists, keep the literal `'default'`.
+- Decision 7: delete the `arch` key from `.fuguvmrc`,
+  `share/fuguvm/fuguvm.conf.sample`, `share/fuguvm/vms/default.conf.sample:9`,
+  `share/fuguvm/vms/minimal.conf.sample:8`, and the `fuguvm(1)` entry; the
+  manual states the fixed architecture once. `DiskCache`'s internal `arch`
+  cache-key component stays — it names the constant, not the config key.
+- Decision 5: delete `cmd_image`, `Miniroot::list`, `_release_root`, the `image`
+  entries in `%COMMANDS` and `fuguvm(1)`, and their subtests in
+  `t/fuguvm/miniroot.t:82,101` and `t/fuguvm/cli.t`.
 - Delete the unreachable `backing_format` default (every call site passes
-  `qcow2`), the pre-checks that `Fugu::File` failure reporting already covers
-  (`cmd_init`), the double diagnostic after `State->new`, and the three-stage
+  `qcow2`), the `cmd_init` pre-checks that `Fugu::File` failure reporting
+  already covers, the double diagnostic after `State->new`, and the three-stage
   timeout validation (one anchored regex).
 - `Guest.pm`: replace the self-doubting pidfile wait with one
-  `Fugu::Timeout::wait_until`; drop the fallback that contradicts its own
-  `check_alive => 0` premise. `_is_running` asks the kernel only; the QMP
-  handshake leaves the hot path. `_wait_console_ready` runs for the installer
-  only, not on every start.
+  `Fugu::Timeout::wait_until`; the fallback branch goes with decision 17.
+  `_is_running` asks the kernel only; the QMP handshake leaves the hot path.
+  `_wait_console_ready` runs for the installer only.
 
 ### 5.4 FuguWeb extraction leftovers
 
-- Delete `cmd_page`, `cmd_index`, their `%COMMANDS` entries, and the two `use`
-  lines (decision 6). `Page::document` folds into `Page::write`;
-  `Index::DEFAULT_TITLE` goes with its only reachable use. Update the pipeline
-  example in `fuguweb(1)`.
+- Decision 6: delete `cmd_page`, `cmd_index`, their `%COMMANDS` entries, the two
+  `use` lines, and their subtests in `t/fuguweb/cli.t:111-148`. `Page::document`
+  folds into `Page::write`; `Index::DEFAULT_TITLE` goes with its only reachable
+  use. Update the pipeline example in `fuguweb(1)`.
 - Delete `Check::_check_xrefs`; `_check_references` reports the same class of
-  failure for the same inputs (verified by execution). Update the one regex in
-  `t/fuguweb/check.t`.
+  failure for the same inputs. Update the one regex in `t/fuguweb/check.t`.
 - Delete the `@TITLE@` machinery: `TITLE_PLACEHOLDER`, `@LITERAL`,
-  `_without_literals`, the check, and its subtests. No code path can emit the
-  token since the sed chrome retired.
+  `_without_literals`, the check, and its subtests in `t/fuguweb/check.t`.
 - Delete the dead accessors: `Site::out`, `Site::render`, `Check::config`,
   `Check::out`, `Page::config`, `Index::config`, `Config::Group::dir`,
   `Config::Group::module_root`, `Manual::group`. Delete the dead `out` defaults
@@ -91,21 +106,27 @@ Every deletion re-verifies with a grep across
 
 ### 5.5 FuguWeb dedup and knobs
 
-- One `_names($dir)` helper in `App::FuguWeb` replaces the six
-  opendir/filter/closedir blocks; one `inventory` method on `Config` replaces
-  the two inventory computations; one `STYLESHEET` constant in `App::FuguWeb`
-  replaces the three definitions of `'style.css'`.
+- One directory-listing helper beside `escape_html` in `App::FuguWeb` replaces
+  the six opendir/filter/closedir blocks; one `inventory` method on `Config`
+  replaces the two inventory computations; one stylesheet constant in
+  `App::FuguWeb` replaces the three definitions of `'style.css'`. The shared
+  helpers are documented in `FuguWeb.pod`, not `_`-prefixed — a cross-package
+  private name is what phase 6's floor exists to keep out.
 - One prefix-test helper replaces `Config::_below` and `Site::_holds` (whose two
   unreachable early returns go); `Site::clean` and `_prune_output` share one
   classification step; one `_copy` helper replaces the three read-then-write
-  paths and makes their diagnostics agree.
+  paths.
 - `Page::_head` becomes a heredoc over pre-escaped values and `_nav` becomes a
-  `join`; `t/fuguweb/page.t` pins the output byte for byte, so the rewrite
-  proves itself.
-- Delete the knobs only their round-trip test sets: `banner`, `pod_center`,
-  `pod_release`, and the `extra.css` hook (decision 10). `lang` stays. Delete
-  `Config::anonymous`'s parser construction — its one caller needs `root` only.
-  Trim `$STARTER` to a minimal buildable description.
+  `join`; `t/fuguweb/page.t` pins the output byte for byte.
+- Decision 10: delete the `banner`, `pod_center`, and `pod_release` config keys
+  and the `extra.css` hook; `lang` stays. `Page` renders `$config->site` where
+  `banner` stood (its default, so the built site is unchanged). The `--center`
+  and `--release` values move into `Render` as constants — they pin `pod2man`
+  output so the site does not vary with the build host. Test fallout, verified:
+  `t/fuguweb/config.t:48,56-57,66-87`, `t/fuguweb/page.t:71,150,174-177`,
+  `t/fuguweb/site.t:83,180,239`.
+- Delete `Config::anonymous`'s parser construction — its one caller needs `root`
+  only. Trim `$STARTER` to a minimal buildable description.
 - The probe for missing tools lives in `Site::build`; `cmd_build` maps the
   result to `EXIT_TOOL_MISSING` without probing again. `POD_SECTION` defines
   once.
@@ -117,26 +138,32 @@ Every deletion re-verifies with a grep across
 
 ## Deliverables
 
-- `lib/App/FuguVM/QGA.pm`, `QGA.pod`, `t/fuguvm/qga.t`,
-  `share/fuguvm/expect/firstboot.exp`, and `share/fuguvm/cache-generation`
-  deleted.
-- Smaller `lib/App/FuguVM/*.pm` and `lib/App/FuguWeb/*.pm` with updated
-  sidecars.
+- Deleted: `lib/App/FuguVM/QGA.pm`, `QGA.pod`, `t/fuguvm/qga.t`,
+  `share/fuguvm/expect/firstboot.exp`.
+- `share/fuguvm/cache-generation` reads `2`.
+- Smaller `lib/App/FuguVM/*.pm` and `lib/App/FuguWeb/*.pm` with updated sidecars
+  (including `QMP.pod`).
 - Updated `man/fuguvm/fuguvm.1`, `man/fuguweb/fuguweb.1`, `.fuguvmrc`,
-  `.fuguwebrc`, and `share/` samples.
+  `.fuguwebrc`, and the three `share/fuguvm` samples.
+- Trimmed `t/fuguvm/{state,disk,qmp,miniroot,diskcache,guest,cli}.t` and
+  `t/fuguweb/{cli,check,config,page,site}.t`.
 
 ## Acceptance criteria
 
 - `make check` passes.
-- `grep -rn 'QGA\|qemu-ga\|guest-exec' lib bin t share scripts` finds nothing.
-- `grep -rn 'cmd_image\|cache-generation\|_check_xrefs\|@TITLE@' lib t share`
-  finds nothing.
-- `grep -n 'arch' .fuguvmrc share/fuguvm/*.sample man/fuguvm/fuguvm.1` finds
-  nothing but the fixed-architecture sentence.
-- `fuguvm up` and `fuguvm down` work in `make integration` in CI; the provision
-  path no longer waits on a guest agent.
+- `git grep -niE 'qga|qemu-ga|guest-exec' lib bin t share scripts` finds
+  nothing.
+- `git grep -n 'cmd_image\|_check_xrefs\|TITLE_PLACEHOLDER' lib t` finds
+  nothing.
+- `git grep -nE '^\s*arch\b' .fuguvmrc share/fuguvm` finds nothing, and
+  `git grep -n 'arch' man/fuguvm/fuguvm.1` finds only the fixed-architecture
+  sentence and the cache-filename format.
+- `fuguvm up` and `fuguvm down` work in `make integration` in CI, and the run
+  rebuilds its base image — the generation bump invalidated the cache built with
+  the old device model.
 - `make web WEBOUT=<tmp>` builds a tree that `diff -r` reports identical to the
-  pre-phase build, except pages the deleted knobs shaped;
-  `prove -l t/web/site.t` passes, including the double-build subtest.
-- A `.fuguwebrc` with a `banner` setting now fails config validation with a
-  named file and block, proving the knob is gone, not ignored.
+  pre-phase build (`banner` defaulted to `site` and `web/` has no `extra.css`,
+  so nothing changes); `prove -l t/web/site.t` passes, including the
+  double-build subtest.
+- `git grep -n 'banner\|pod_center\|pod_release\|extra\.css' lib/App/FuguWeb .fuguwebrc`
+  finds only the `Render` constants and their comment.

--- a/plans/010-simplify/plan-5.md
+++ b/plans/010-simplify/plan-5.md
@@ -1,0 +1,142 @@
+# Phase 5 — The App::FuguVM and App::FuguWeb sweeps
+
+This phase removes about 1,000 lines across the two development tools: the QGA
+subsystem, the CLI dedup, the cache-key speculation, and the extraction
+leftovers of plan 009. It executes design decisions 3–7 and 10. Phase 1 must
+land first. Phases 2, 3, and 4 are independent of it.
+
+Every deletion re-verifies with a grep across
+`lib/ bin/ t/ scripts/ share/ .fuguvmrc .fuguwebrc` first.
+
+## Tasks
+
+### 5.1 The QGA subsystem goes whole (decision 4)
+
+- Delete `lib/App/FuguVM/QGA.pm`, `QGA.pod`, and `t/fuguvm/qga.t`.
+- Delete from `Guest.pm`: the QGA fallback in `_graceful_shutdown`,
+  `_qga_socket_path`, `_qga_connect`, and the virtio-serial `-device`,
+  `-chardev`, and `virtserialport` arguments. `_graceful_shutdown` becomes: SSH
+  sync, ACPI powerdown, report.
+- Delete `share/fuguvm/expect/firstboot.exp`; installing an agent nothing talks
+  to was its only job. `login.exp` and `command.exp` stay — they are operator
+  tools for `fuguvm expect`.
+- Update `fuguvm(1)` and `Guest.pod` where they mention the agent.
+
+### 5.2 FuguVM dedup
+
+- `Guest.pm`: `down` becomes `_stop_proxy` plus `return $self->stop`; the
+  five-statement force-stop epilogue becomes one private helper; the install
+  tail of `up` becomes `return $self->_complete_ssh_setup`; `wait_ssh` and
+  `_wait_ssh_password` fold into one method with a `password` flag; the
+  hand-rolled remote mkdir uses one quoted command in one place.
+- `CLI.pm`: the five load-and-call commands dispatch through the `method` field
+  that `%COMMANDS` already carries; `_current_cache_key` folds its diagnostic
+  in, removing four copies; the snapshot-lookup diagnostic and the sorted
+  key-dump loop each keep one copy; `run` stops copying `%COMMANDS` field by
+  field.
+- `DiskCache.pm`: `_tree_size` calls `Fugu::Proxy::Cache::dir_size`; the four
+  hand-rolled unlink-on-failure paths in `snapshot_store` use the `Fugu::File`
+  atomics that `store` already uses.
+
+### 5.3 FuguVM dead code and redundant checks
+
+- Delete from `State.pm`: the seven proxy pid/port methods (production reaches
+  the pidfile and store directly), `is_ssh_key_installed`, and
+  `ssh_key_matches`. Resolve the near-dead `running` key: `mark_running` moves
+  to the main start path, so `was_unclean_shutdown` detects a crash again — or,
+  when that costs more than it returns, the key and its four no-op `delete`
+  calls go. Decide in review; record the choice in the commit.
+- Delete: `Disk::disk_exists` and `Disk::remove`, `QMP::socket_path` and
+  `QMP::is_available`, `Guest::pid`, `Config::project_root`, the three
+  never-returned exit codes in `CLI.pm` and one in `Guest.pm`,
+  `DiskCache::cache_dir`, the unreachable `return EXIT_ERROR` in `cmd_disk`,
+  `Miniroot::_ftp_script` (a test-only seam, per its own comment), and the
+  self-cancelling `timeout` round trip in `Console.pm`.
+- Wire in `default_vm` (decision 3): `_prepare` reads
+  `$cli->option('vm') // $config->default_vm // 'default'`.
+- Delete the `arch` key from `.fuguvmrc`, the samples, and `fuguvm(1)` (decision
+  7); the manual states the fixed architecture once.
+- Delete `cmd_image`, `Miniroot::list`, `_release_root`, and the `image` entries
+  in `%COMMANDS` and `fuguvm(1)` (decision 5).
+- Delete the `cache-generation` mechanism: the constant, the `share_path`
+  lookup, the file read, and `share/fuguvm/cache-generation` itself. The cache
+  key already hashes every real input, and the file never changed.
+- Delete the unreachable `backing_format` default (every call site passes
+  `qcow2`), the pre-checks that `Fugu::File` failure reporting already covers
+  (`cmd_init`), the double diagnostic after `State->new`, and the three-stage
+  timeout validation (one anchored regex).
+- `Guest.pm`: replace the self-doubting pidfile wait with one
+  `Fugu::Timeout::wait_until`; drop the fallback that contradicts its own
+  `check_alive => 0` premise. `_is_running` asks the kernel only; the QMP
+  handshake leaves the hot path. `_wait_console_ready` runs for the installer
+  only, not on every start.
+
+### 5.4 FuguWeb extraction leftovers
+
+- Delete `cmd_page`, `cmd_index`, their `%COMMANDS` entries, and the two `use`
+  lines (decision 6). `Page::document` folds into `Page::write`;
+  `Index::DEFAULT_TITLE` goes with its only reachable use. Update the pipeline
+  example in `fuguweb(1)`.
+- Delete `Check::_check_xrefs`; `_check_references` reports the same class of
+  failure for the same inputs (verified by execution). Update the one regex in
+  `t/fuguweb/check.t`.
+- Delete the `@TITLE@` machinery: `TITLE_PLACEHOLDER`, `@LITERAL`,
+  `_without_literals`, the check, and its subtests. No code path can emit the
+  token since the sed chrome retired.
+- Delete the dead accessors: `Site::out`, `Site::render`, `Check::config`,
+  `Check::out`, `Page::config`, `Index::config`, `Config::Group::dir`,
+  `Config::Group::module_root`, `Manual::group`. Delete the dead `out` defaults
+  in `Site::new` and `Check::new`; every caller passes `out`.
+- Delete `CLI::new`'s unused `%opts` and the write-only `quiet` field.
+
+### 5.5 FuguWeb dedup and knobs
+
+- One `_names($dir)` helper in `App::FuguWeb` replaces the six
+  opendir/filter/closedir blocks; one `inventory` method on `Config` replaces
+  the two inventory computations; one `STYLESHEET` constant in `App::FuguWeb`
+  replaces the three definitions of `'style.css'`.
+- One prefix-test helper replaces `Config::_below` and `Site::_holds` (whose two
+  unreachable early returns go); `Site::clean` and `_prune_output` share one
+  classification step; one `_copy` helper replaces the three read-then-write
+  paths and makes their diagnostics agree.
+- `Page::_head` becomes a heredoc over pre-escaped values and `_nav` becomes a
+  `join`; `t/fuguweb/page.t` pins the output byte for byte, so the rewrite
+  proves itself.
+- Delete the knobs only their round-trip test sets: `banner`, `pod_center`,
+  `pod_release`, and the `extra.css` hook (decision 10). `lang` stays. Delete
+  `Config::anonymous`'s parser construction — its one caller needs `root` only.
+  Trim `$STARTER` to a minimal buildable description.
+- The probe for missing tools lives in `Site::build`; `cmd_build` maps the
+  result to `EXIT_TOOL_MISSING` without probing again. `POD_SECTION` defines
+  once.
+
+### 5.6 Documentation
+
+- Update the sidecars of every touched module in both namespaces, the two
+  chapter-1 manuals, and the sample configs.
+
+## Deliverables
+
+- `lib/App/FuguVM/QGA.pm`, `QGA.pod`, `t/fuguvm/qga.t`,
+  `share/fuguvm/expect/firstboot.exp`, and `share/fuguvm/cache-generation`
+  deleted.
+- Smaller `lib/App/FuguVM/*.pm` and `lib/App/FuguWeb/*.pm` with updated
+  sidecars.
+- Updated `man/fuguvm/fuguvm.1`, `man/fuguweb/fuguweb.1`, `.fuguvmrc`,
+  `.fuguwebrc`, and `share/` samples.
+
+## Acceptance criteria
+
+- `make check` passes.
+- `grep -rn 'QGA\|qemu-ga\|guest-exec' lib bin t share scripts` finds nothing.
+- `grep -rn 'cmd_image\|cache-generation\|_check_xrefs\|@TITLE@' lib t share`
+  finds nothing.
+- `grep -n 'arch' .fuguvmrc share/fuguvm/*.sample man/fuguvm/fuguvm.1` finds
+  nothing but the fixed-architecture sentence.
+- `fuguvm up` and `fuguvm down` work in `make integration` in CI; the provision
+  path no longer waits on a guest agent.
+- `make web WEBOUT=<tmp>` builds a tree that `diff -r` reports identical to the
+  pre-phase build, except pages the deleted knobs shaped;
+  `prove -l t/web/site.t` passes, including the double-build subtest.
+- A `.fuguwebrc` with a `banner` setting now fails config validation with a
+  named file and block, proving the knob is gone, not ignored.

--- a/plans/010-simplify/plan-6.md
+++ b/plans/010-simplify/plan-6.md
@@ -1,58 +1,63 @@
 # Phase 6 — The lock
 
 This phase lands the strict gates that hold the tree at its new size:
-`t/scripts/symbols.t` and two Perl::Critic policies. It must land last — phases
-2 to 5 delete the code these gates would flag, so the gates cannot pass before
-the sweeps.
+`t/scripts/symbols.t` and the Perl::Critic enables. It must land last — phases 2
+to 5 delete the code these gates would flag, so the gates cannot pass before the
+sweeps.
 
 ## Tasks
 
 ### 6.1 t/scripts/symbols.t
 
 One new tooling test, in the house style of `namespaces.t`: `git ls-files`, text
-analysis, self-testing rules, and a sweep-size guard. Three subtest groups:
+analysis, self-testing rules, a sweep-size guard, and a negative control per
+group. Three subtest groups:
 
-- **The caller floor.** For every public sub defined in `lib/Fugu/` and
-  `lib/App/`, the sub's name appears in at least one other tracked file under
-  `lib/` or `bin/`. The match is textual (`\b<name>\b`), which accepts method
-  strings in `%COMMANDS` tables and dynamic dispatch; the floor catches API
-  nothing references, not API referenced weakly. Exemptions, each with a
-  one-line reason in the table:
+- **The caller floor.** For every sub defined in `lib/Fugu/` and `lib/App/` —
+  public and private alike — the sub's name appears at least once in `lib/` or
+  `bin/` outside its own definition line. Same-file references count: that is
+  what lets `%COMMANDS` method strings, template-method overrides named in the
+  base class, and self-calls pass without an allowlist row each. The floor
+  catches API nothing references at all. Its known blind spot is named in a
+  comment: a name duplicated across the CPAN boundary passes wrongly
+  (`Fugu::Random::random_bytes` matches `Protocol::HAP::Crypto`'s unrelated
+  sub), so the allowlist also records names to check by hand.
   - `Protocol::` is out of scope: a library's `.pod` contract is its caller.
-  - `App::OpenHAP::Test::` counts `t/openhap/integration/` as `bin/`: the
-    integration tier is what it exists for.
-  - A named allowlist for the rest. Seed it empty; every entry added while
-    making the gate pass must name its reason (a hook the design keeps, a
-    contract method, an OpenBSD-only path that CI cannot reference).
+  - `App::OpenHAP::Test::` counts `t/openhap/integration/` as its caller tree:
+    the integration tier is what it exists for.
+  - A named allowlist for the rest, one reason per row. Rows earn their place
+    while making the gate pass; a row with no reason fails the self-test.
 - **Documentation completeness, both directions.** Every `lib/Fugu/*.pm` has
   `man/fugu/<Module>.3p`, a `MAN3P` entry (parse the `Makefile` block as
   `t/web/site.t` parses `MAN`), and a `t/fugu/<module>.t`. Every other
   `lib/**/*.pm` has a `.pod` sidecar. Every `.pod` and every `man/fugu/*.3p` has
-  its `.pm`. No module has both a sidecar and a `.3p` page.
+  its `.pm`. No module has both a sidecar and a `.3p` page. An exemption table
+  with reasons, seeded with one row: `lib/Protocol/HAP/Store.pod` is the store
+  contract and has no `.pm` by design (`CLAUDE.md` names it; `namespaces.t`
+  already treats it as live).
 - **Declared dependencies.** Every `use` and `require` of a non-core module in
-  `lib/` and `bin/` names a module that appears in `cpanfile` and in each
-  `deps/*.txt` manifest that lists CPAN dependencies. Reuse the parse from
-  `t/protocol/boundary.t` (stop at `__END__`, `Module::CoreList` for the core
-  test).
-
-Follow the two habits of `coreperl.t` and `namespaces.t`: a negative control per
-group (a fabricated sub name must fail the floor; a fabricated import must fail
-the declaration check), and a sweep-size guard so an over-eager skip rule cannot
-pass an empty test.
+  `lib/` and `bin/` names a module that `cpanfile` requires. Reuse the parse
+  from `t/protocol/boundary.t` (stop at `__END__`, `Module::CoreList` for the
+  core test). The `deps/*.txt` manifests stay out of the gate: they name OS
+  packages (`p5-JSON-XS`, `p5-libwww`), not modules, and the mapping is not
+  mechanical — the existing human-kept rule in `CLAUDE.md` continues to own
+  them.
 
 ### 6.2 The Perl::Critic enables
 
 Add to `.perlcriticrc`, with the block syntax the file already uses:
 
-- `[Subroutines::ProhibitUnusedPrivateSubroutines]` with `severity = 4`. Run
-  `make lint`; for each finding, delete the sub, demote the caller relationship
-  it reveals, or add the policy's `allow` option with a comment naming the
-  reason. The sweeps removed the known cases; findings here are news.
-- `[Variables::ProhibitUnusedVariables]` with `severity = 4`.
+- `[Variables::ProhibitUnusedVariables]` with `severity = 4`. Measured clean on
+  today's tree; the enable locks it.
 - `[Miscellanea::ProhibitUnrestrictedNoCritic]` and
   `[Miscellanea::ProhibitUselessNoCritic]`, both `severity = 4`. The tree has
   zero `## no critic` annotations; these keep suppression from becoming the
   escape hatch.
+- Do **not** enable `Subroutines::ProhibitUnusedPrivateSubroutines`: it is
+  document-scoped, and measured on this tree it flags exactly the seven live
+  template-method overrides in `Tasmota/*.pm` and nothing real. The caller floor
+  in 6.1 covers private subs across files instead. Record this in a one-line
+  comment where the enables sit, so nobody "fixes" it back in.
 
 ### 6.3 The residue pass
 
@@ -63,29 +68,30 @@ here.
 
 ### 6.4 Documentation
 
-- Add the gate to `t/CLAUDE.md`'s tooling-test list, one line, next to
-  `namespaces.t`.
+- Add one sentence for `symbols.t` to the tooling-test paragraph of
+  `t/CLAUDE.md`, beside the phase-1 sentence for `namespaces.t`.
 
 ## Deliverables
 
 - New `t/scripts/symbols.t`.
 - Extended `.perlcriticrc`.
 - Whatever residue 6.3 removes, with its tests and documentation.
-- One line in `t/CLAUDE.md`.
+- One sentence in `t/CLAUDE.md`.
 
 ## Acceptance criteria
 
-- `make check` passes.
-- Plant a public sub `sub zz_unused_probe` in a `lib/Fugu/` module: `symbols.t`
-  fails naming the module and the sub, and `make lint` stays quiet (the floor,
-  not the policy, owns public subs). Remove the plant.
-- Plant a private `sub _zz_unused_probe` in the same module: `make lint` fails
-  via `ProhibitUnusedPrivateSubroutines`. Remove the plant.
-- Plant `use JSON::XS` in a `lib/App/` module without touching `cpanfile`: the
-  declaration group fails. Remove the plant.
-- Delete a `.pod` sidecar in a scratch commit: the completeness group fails in
-  both directions (missing sidecar, and — restoring it while deleting the `.pm`
-  — orphaned sidecar). Restore.
-- `git grep -c 'no critic' -- lib bin scripts` reports zero.
-- The allowlist in `symbols.t` has a reason on every row, and
-  `prove -l t/scripts/symbols.t` passes on the clean tree.
+- `make check` passes, and `prove -l t/scripts/symbols.t` passes on the clean
+  tree with every allowlist and exemption row carrying a reason.
+- Plant a sub `sub zz_unused_probe` in a `lib/Fugu/` module and `git add` it:
+  the caller floor fails naming the module and the sub. Remove the plant.
+- Plant `use JSON::PP::Boolean::Missing` (any module absent from `cpanfile`) in
+  a `lib/App/` module: the declaration group fails. A plant of `use JSON::XS`
+  must NOT fail — `cpanfile` already requires it, which is why the negative
+  control uses an absent module. Remove the plant.
+- Delete a `.pod` sidecar in a scratch commit: the completeness group fails;
+  restore it and delete the `.pm` instead: it fails in the other direction
+  (orphaned sidecar). Restore both.
+- `git grep -c 'no critic' -- lib bin scripts` exits non-zero with no output (no
+  annotations exist; note `grep -c` exits 1 on zero matches, so the scripted
+  form is `! git grep -q 'no critic' -- lib bin scripts`).
+- `make lint` stays green with the three enabled policies.

--- a/plans/010-simplify/plan-6.md
+++ b/plans/010-simplify/plan-6.md
@@ -1,0 +1,91 @@
+# Phase 6 — The lock
+
+This phase lands the strict gates that hold the tree at its new size:
+`t/scripts/symbols.t` and two Perl::Critic policies. It must land last — phases
+2 to 5 delete the code these gates would flag, so the gates cannot pass before
+the sweeps.
+
+## Tasks
+
+### 6.1 t/scripts/symbols.t
+
+One new tooling test, in the house style of `namespaces.t`: `git ls-files`, text
+analysis, self-testing rules, and a sweep-size guard. Three subtest groups:
+
+- **The caller floor.** For every public sub defined in `lib/Fugu/` and
+  `lib/App/`, the sub's name appears in at least one other tracked file under
+  `lib/` or `bin/`. The match is textual (`\b<name>\b`), which accepts method
+  strings in `%COMMANDS` tables and dynamic dispatch; the floor catches API
+  nothing references, not API referenced weakly. Exemptions, each with a
+  one-line reason in the table:
+  - `Protocol::` is out of scope: a library's `.pod` contract is its caller.
+  - `App::OpenHAP::Test::` counts `t/openhap/integration/` as `bin/`: the
+    integration tier is what it exists for.
+  - A named allowlist for the rest. Seed it empty; every entry added while
+    making the gate pass must name its reason (a hook the design keeps, a
+    contract method, an OpenBSD-only path that CI cannot reference).
+- **Documentation completeness, both directions.** Every `lib/Fugu/*.pm` has
+  `man/fugu/<Module>.3p`, a `MAN3P` entry (parse the `Makefile` block as
+  `t/web/site.t` parses `MAN`), and a `t/fugu/<module>.t`. Every other
+  `lib/**/*.pm` has a `.pod` sidecar. Every `.pod` and every `man/fugu/*.3p` has
+  its `.pm`. No module has both a sidecar and a `.3p` page.
+- **Declared dependencies.** Every `use` and `require` of a non-core module in
+  `lib/` and `bin/` names a module that appears in `cpanfile` and in each
+  `deps/*.txt` manifest that lists CPAN dependencies. Reuse the parse from
+  `t/protocol/boundary.t` (stop at `__END__`, `Module::CoreList` for the core
+  test).
+
+Follow the two habits of `coreperl.t` and `namespaces.t`: a negative control per
+group (a fabricated sub name must fail the floor; a fabricated import must fail
+the declaration check), and a sweep-size guard so an over-eager skip rule cannot
+pass an empty test.
+
+### 6.2 The Perl::Critic enables
+
+Add to `.perlcriticrc`, with the block syntax the file already uses:
+
+- `[Subroutines::ProhibitUnusedPrivateSubroutines]` with `severity = 4`. Run
+  `make lint`; for each finding, delete the sub, demote the caller relationship
+  it reveals, or add the policy's `allow` option with a comment naming the
+  reason. The sweeps removed the known cases; findings here are news.
+- `[Variables::ProhibitUnusedVariables]` with `severity = 4`.
+- `[Miscellanea::ProhibitUnrestrictedNoCritic]` and
+  `[Miscellanea::ProhibitUselessNoCritic]`, both `severity = 4`. The tree has
+  zero `## no critic` annotations; these keep suppression from becoming the
+  escape hatch.
+
+### 6.3 The residue pass
+
+Run the new gates over the whole tree and burn down what they find beyond the
+sweeps — the audit sampled; the gates are exhaustive. Small findings land in
+this phase; anything structural is recorded for a future effort, not rushed
+here.
+
+### 6.4 Documentation
+
+- Add the gate to `t/CLAUDE.md`'s tooling-test list, one line, next to
+  `namespaces.t`.
+
+## Deliverables
+
+- New `t/scripts/symbols.t`.
+- Extended `.perlcriticrc`.
+- Whatever residue 6.3 removes, with its tests and documentation.
+- One line in `t/CLAUDE.md`.
+
+## Acceptance criteria
+
+- `make check` passes.
+- Plant a public sub `sub zz_unused_probe` in a `lib/Fugu/` module: `symbols.t`
+  fails naming the module and the sub, and `make lint` stays quiet (the floor,
+  not the policy, owns public subs). Remove the plant.
+- Plant a private `sub _zz_unused_probe` in the same module: `make lint` fails
+  via `ProhibitUnusedPrivateSubroutines`. Remove the plant.
+- Plant `use JSON::XS` in a `lib/App/` module without touching `cpanfile`: the
+  declaration group fails. Remove the plant.
+- Delete a `.pod` sidecar in a scratch commit: the completeness group fails in
+  both directions (missing sidecar, and — restoring it while deleting the `.pm`
+  — orphaned sidecar). Restore.
+- `git grep -c 'no critic' -- lib bin scripts` reports zero.
+- The allowlist in `symbols.t` has a reason on every row, and
+  `prove -l t/scripts/symbols.t` passes on the clean tree.


### PR DESCRIPTION
This adds `plans/010-simplify/`: a design and six phase plans that shrink the tree by about 2,400 lib/bin lines without a change to module boundaries.

The design names six shapes of creep, nineteen delete-or-wire-up decisions, six bugs the sweeps fix in passing, and the gates that keep the tree small: a banned-vocabulary sweep in `t/scripts/namespaces.t`, a new `t/scripts/symbols.t`, three Perl::Critic enables, and a `shrink` skill.

Five refuting sub-agents reviewed the draft on different angles, and two independent agents confirmed 37 of 40 consolidated findings against the source. The second commit applies that review: it orders the phases, moves a dozen refuted deletions to a verified-keeps list, and repairs every non-falsifiable acceptance criterion.

The plans are documents only; no code changes ship here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYjyqbNtVvZtXCeuqzarcW

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYjyqbNtVvZtXCeuqzarcW)_